### PR TITLE
Add base templates to the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     version='0.0.1',
     license='MIT',
     packages=find_packages(),
-    package_data={'spinta': ['manifest/*.yml']},
+    package_data={'spinta': ['manifest/*.yml', 'templates/*.html']},
     install_requires=read_requirements('requirements.in'),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
```
> env/bin/python setup.py bdist_wheel | rg "templates"
creating build/lib/spinta/templates
copying spinta/templates/base.html -> build/lib/spinta/templates
creating build/bdist.macosx-10.13-x86_64/wheel/spinta/templates
copying build/lib/spinta/templates/base.html -> build/bdist.macosx-10.13-x86_64/wheel/spinta/templates
adding 'spinta/templates/base.html'
```