### PR TITLE
Do not allow `cp -n` to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ requirements.txt: env/bin/pip-compile requirements.in
 	env/bin/pip-compile --no-index requirements.in -o requirements.txt
 
 .env: .env.example
-	cp -n .env.example .env
+	cp -n .env.example .env | true
 	touch .env
 
 .PHONY: upgrade


### PR DESCRIPTION
`cp -n` returns `1` when file we copy to already exists, thus crashing
`make`.

```
bash-5.0$ cp -n .env.example .env
bash-5.0$ echo $?
1
bash-5.0$ touch .env.example
bash-5.0$ make
cp -n .env.example .env
make: *** [.env] Error 1
```

`| true` allows for `cp -n` command not to crash the `make`