### PR TITLE
Configuration refactoring

### DIFF
--- a/spinta/asgi.py
+++ b/spinta/asgi.py
@@ -1,20 +1,25 @@
+import os
+
 from spinta.api import app, set_context
 from spinta.commands import load, prepare, check
-from spinta.components import Context, Config, Store
-from spinta.config import get_config
+from spinta.components import Context, Store
 from spinta.utils.commands import load_commands
+from spinta import components
+from spinta.config import Config
 
 
-CONFIG = get_config()
+c = Config()
+c.set_env(os.environ)
+c.add_env_file('.env')
 
-load_commands(CONFIG['commands']['modules'])
+load_commands(c.get('commands', 'modules', cast=list))
 
 context = Context()
-config = context.set('config', Config())
+config = context.set('config', components.Config())
 store = context.set('store', Store())
 
-load(context, config, CONFIG)
-load(context, store, config)
+load(context, config, c)
+load(context, store, c)
 check(context, store)
 
 prepare(context, store.internal)
@@ -22,4 +27,4 @@ prepare(context, store)
 
 set_context(context)
 
-app.debug = store.config.debug
+app.debug = config.debug

--- a/spinta/backends/postgresql/__init__.py
+++ b/spinta/backends/postgresql/__init__.py
@@ -12,9 +12,10 @@ from sqlalchemy.sql.expression import FunctionElement
 
 from spinta.types import NA
 from spinta.commands import load, prepare, migrate, check, push, get, getall, wipe, error
-from spinta.components import Context, BackendConfig, Manifest, Model, Property
+from spinta.components import Context, Manifest, Model, Property
 from spinta.backends import Backend
 from spinta.types.type import Type
+from spinta.config import Config
 
 # Maximum length for PostgreSQL identifiers (e.g. table names, column names,
 # function names).
@@ -103,9 +104,9 @@ class WriteTransaction(ReadTransaction):
 
 
 @load.register()
-def load(context: Context, backend: PostgreSQL, config: BackendConfig):
-    backend.name = config.name
-    backend.engine = sa.create_engine(config.dsn, echo=False)
+def load(context: Context, backend: PostgreSQL, config: Config):
+    backend.dsn = config.get('backends', backend.name, 'dsn', required=True)
+    backend.engine = sa.create_engine(backend.dsn, echo=False)
     backend.schema = sa.MetaData(backend.engine)
     backend.tables = {}
 

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -67,14 +67,6 @@ class Config:
         self.debug = False
 
 
-class BackendConfig:
-
-    def __init__(self):
-        self.Backend = None
-        self.name = None
-        self.dsn = None
-
-
 class Store:
 
     def __init__(self):

--- a/spinta/testing/__init__.py
+++ b/spinta/testing/__init__.py
@@ -1,0 +1,4 @@
+CONFIG = {
+    'ignore': [],
+    'debug': True,
+}

--- a/spinta/testing/context.py
+++ b/spinta/testing/context.py
@@ -1,0 +1,67 @@
+import contextlib
+import typing
+
+from spinta import commands
+from spinta.components import Context, Node
+
+
+class ContextForTests(Context):
+
+    def _get_model(self, model: typing.Union[str, Node], dataset: str):
+        if isinstance(model, str):
+            store = self.get('store')
+            if dataset:
+                return store.manifests['default'].objects['dataset'][dataset].objects[model]
+            else:
+                return store.manifests['default'].objects['model'][model]
+        else:
+            return model
+
+    @contextlib.contextmanager
+    def transaction(self, *, write=False):
+        store = self.get('store')
+        if self.has('transaction'):
+            yield self.get('transaction')
+        else:
+            with self.enter():
+                self.bind('transaction', store.backends['default'].transaction, write=write)
+                yield self.get('transaction')
+
+    def pull(self, dataset: str, *, models: list = None, push: bool = True):
+        store = self.get('store')
+        dataset = store.manifests['default'].objects['dataset'][dataset]
+        models = models or []
+        try:
+            with self.transaction(write=push):
+                data = commands.pull(self, dataset, models=models)
+                if push:
+                    yield from commands.push(self, store, data)
+                else:
+                    yield from data
+        except Exception:
+            raise Exception(f"Error while processing '{dataset.path}'.")
+
+    def push(self, data):
+        store = self.get('store')
+        with self.transaction(write=True):
+            yield from commands.push(self, store, data)
+
+    def getone(self, model: str, id, *, dataset: str = None):
+        model = self._get_model(model, dataset)
+        with self.transaction():
+            return commands.get(self, model, model.backend, id)
+
+    def getall(self, model: str, *, dataset: str = None, **kwargs):
+        model = self._get_model(model, dataset)
+        with self.transaction():
+            return list(commands.getall(self, model, model.backend, **kwargs))
+
+    def changes(self, model: str, *, dataset: str = None, **kwargs):
+        model = self._get_model(model, dataset)
+        with self.transaction():
+            return list(commands.changes(self, model, model.backend, **kwargs))
+
+    def wipe(self, model: str, *, dataset: str = None):
+        model = self._get_model(model, dataset)
+        with self.transaction():
+            commands.wipe(self, model, model.backend)

--- a/spinta/testing/pytest.py
+++ b/spinta/testing/pytest.py
@@ -1,0 +1,81 @@
+import collections
+import os
+
+import pytest
+import sqlalchemy_utils as su
+from responses import RequestsMock
+from toposort import toposort
+from starlette.testclient import TestClient
+
+from spinta import api
+from spinta.components import Config, Store
+from spinta.commands import load, check, prepare, migrate
+from spinta.utils.commands import load_commands
+from spinta.testing.context import ContextForTests
+
+
+@pytest.fixture
+def context(config, postgresql):
+    context = ContextForTests()
+
+    context.set('config', Config())
+    store = context.set('store', Store())
+
+    load_commands(config.get('commands', 'modules', cast=list))
+    load(context, context.get('config'), config)
+    load(context, store, config)
+    check(context, store)
+    prepare(context, store.internal)
+    migrate(context, store)
+    prepare(context, store)
+    migrate(context, store)
+
+    yield context
+
+    # Remove all data after each test run.
+    graph = collections.defaultdict(set)
+    for model in store.manifests['default'].objects['model'].values():
+        if model.name not in graph:
+            graph[model.name] = set()
+        for prop in model.properties.values():
+            if prop.type.name == 'ref':
+                graph[prop.type.object].add(model.name)
+
+    for models in toposort(graph):
+        for name in models:
+            context.wipe(name)
+
+    # Datasets does not have foreign kei constraints, so there is no need to
+    # topologically sort them. At least for now.
+    for dataset in store.manifests['default'].objects['dataset'].values():
+        for model in dataset.objects.values():
+            context.wipe(model)
+
+    context.wipe(store.internal.objects['model']['transaction'])
+
+
+@pytest.fixture(scope='session')
+def postgresql():
+    if 'SPINTA_TEST_DATABASE' in os.environ:
+        yield os.environ['SPINTA_TEST_DATABASE']
+    else:
+        if 'SPINTA_TEST_DATABASE_DSN' in os.environ:
+            dsn = os.environ['SPINTA_TEST_DATABASE_DSN']
+        else:
+            dsn = 'postgresql:///spinta_tests'
+        assert not su.database_exists(dsn), 'Test database already exists. Aborting tests.'
+        su.create_database(dsn)
+        yield dsn
+        su.drop_database(dsn)
+
+
+@pytest.fixture
+def responses():
+    with RequestsMock() as mock:
+        yield mock
+
+
+@pytest.fixture
+def app(context, mocker):
+    mocker.patch('spinta.api.context', context)
+    return TestClient(api.app)

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -1,42 +1,38 @@
 from spinta.utils.imports import importstr
 from spinta.commands import load
-from spinta.components import Context, Config, BackendConfig
+from spinta.components import Context
+from spinta.config import Config
+from spinta import components
 
 
 @load.register()
-def load(context: Context, config: Config, data: dict) -> Config:
+def load(context: Context, config: components.Config, c: Config) -> Config:
 
     # Load commands.
     config.commands = {}
-    for scope, commands in data.get('commands', {}).items():
+    for scope in c.keys('commands'):
         if scope == 'modules':
             continue
         config.commands[scope] = {}
-        for name, command in commands.items():
-            config.commands[scope][name] = importstr(command)
+        for name in c.keys('commands', scope):
+            command = c.get('commands', scope, name, cast=importstr)
+            config.commands[scope][name] = command
 
     # Load components.
     config.components = {}
-    for group, components in data['components'].items():
+    for group in c.keys('components'):
         config.components[group] = {}
-        for name, component in components.items():
-            config.components[group][name] = importstr(component)
+        for name in c.keys('components', group):
+            component = c.get('components', group, name, cast=importstr)
+            config.components[group][name] = component
 
     # Load exporters.
     config.exporters = {}
-    for name, exporter in data['exporters'].items():
-        config.exporters[name] = importstr(exporter)()
+    for name in c.keys('exporters'):
+        exporter = c.get('exporters', name, cast=importstr)
+        config.exporters[name] = exporter()
 
-    # Load backends.
-    config.backends = {}
-    for name, backend in data['backends'].items():
-        bconf = config.backends[name] = BackendConfig()
-        bconf.Backend = importstr(backend['backend'])
-        bconf.name = name
-        bconf.dsn = backend['dsn']
-
-    config.manifests = data['manifests']
-    config.ignore = data.get('ignore', [])
-    config.debug = data.get('debug', False)
+    # Load everything else.
+    config.debug = c.get('debug', default=False)
 
     return config

--- a/spinta/types/manifest.py
+++ b/spinta/types/manifest.py
@@ -5,25 +5,18 @@ from ruamel.yaml.scanner import ScannerError
 from spinta.utils.path import is_ignored
 from spinta.commands import load, prepare, check
 from spinta.components import Context, Manifest
+from spinta.config import Config
 
 yaml = YAML(typ='safe')
 
 
-class Path:
-    metadata = {
-        'name': 'path',
-    }
-
-
 @load.register()
-def load(context: Context, manifest: Manifest, manifest_conf: dict):
-    store = context.get('store')
+def load(context: Context, manifest: Manifest, c: Config):
     config = context.get('config')
-    manifest.name = manifest_conf['name']
-    manifest.path = manifest_conf['path']
-    manifest.backend = store.backends[manifest_conf['backend']]
+    ignore = c.get('ignore', default=[], cast=list)
+
     for file in manifest.path.glob('**/*.yml'):
-        if is_ignored(config.ignore, manifest_conf['path'], file):
+        if is_ignored(ignore, manifest.path, file):
             continue
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,101 +1,24 @@
-import collections
-import contextlib
-import os
 import pathlib
-import typing
 
 import pytest
-import sqlalchemy_utils as su
-from responses import RequestsMock
-from toposort import toposort
-from starlette.testclient import TestClient
 
-from spinta import api
-from spinta.components import Context, Config, Store, Node
-from spinta.commands import load, check, prepare, migrate, wipe
-from spinta.utils.commands import load_commands
-from spinta.config import CONFIG
-from spinta import commands
+from spinta.config import Config
+from spinta.testing import CONFIG
+
+pytest_plugins = [
+    'spinta.testing.pytest',
+]
 
 
-class ContextForTests(Context):
-
-    def _get_model(self, model: typing.Union[str, Node], dataset: str):
-        if isinstance(model, str):
-            store = self.get('store')
-            if dataset:
-                return store.manifests['default'].objects['dataset'][dataset].objects[model]
-            else:
-                return store.manifests['default'].objects['model'][model]
-        else:
-            return model
-
-    @contextlib.contextmanager
-    def transaction(self, *, write=False):
-        store = self.get('store')
-        if self.has('transaction'):
-            yield self.get('transaction')
-        else:
-            with self.enter():
-                self.bind('transaction', store.backends['default'].transaction, write=write)
-                yield self.get('transaction')
-
-    def pull(self, dataset: str, *, models: list = None, push: bool = True):
-        store = self.get('store')
-        dataset = store.manifests['default'].objects['dataset'][dataset]
-        models = models or []
-        try:
-            with self.transaction(write=push):
-                data = commands.pull(self, dataset, models=models)
-                if push:
-                    yield from commands.push(self, store, data)
-                else:
-                    yield from data
-        except Exception:
-            raise Exception(f"Error while processing '{dataset.path}'.")
-
-    def push(self, data):
-        store = self.get('store')
-        with self.transaction(write=True):
-            yield from commands.push(self, store, data)
-
-    def getone(self, model: str, id, *, dataset: str = None):
-        model = self._get_model(model, dataset)
-        with self.transaction():
-            return commands.get(self, model, model.backend, id)
-
-    def getall(self, model: str, *, dataset: str = None, **kwargs):
-        model = self._get_model(model, dataset)
-        with self.transaction():
-            return list(commands.getall(self, model, model.backend, **kwargs))
-
-    def changes(self, model: str, *, dataset: str = None, **kwargs):
-        model = self._get_model(model, dataset)
-        with self.transaction():
-            return list(commands.changes(self, model, model.backend, **kwargs))
-
-    def wipe(self, model: str, *, dataset: str = None):
-        model = self._get_model(model, dataset)
-        with self.transaction():
-            wipe(self, model, model.backend)
-
-
-@pytest.fixture
-def context(postgresql):
-    context = ContextForTests()
+@pytest.fixture(scope='session')
+def config(postgresql):
     config = Config()
-    store = Store()
 
-    context.set('config', config)
-    context.set('store', store)
+    # Add default configuration for tests.
+    config.add(CONFIG)
 
-    load_commands([
-        'spinta.types',
-        'spinta.backends',
-    ])
-
-    load(context, config, {
-        **CONFIG,
+    # Add test configuration for this project.
+    config.add({
         'backends': {
             'default': {
                 'backend': 'spinta.backends.postgresql:PostgreSQL',
@@ -104,66 +27,9 @@ def context(postgresql):
         },
         'manifests': {
             'default': {
-                'backend': 'default',
                 'path': pathlib.Path(__file__).parent / 'manifest',
             },
         },
-        'ignore': [],
     })
 
-    load(context, store, config)
-    check(context, store)
-    prepare(context, store.internal)
-    migrate(context, store)
-    prepare(context, store)
-    migrate(context, store)
-
-    yield context
-
-    # Remove all data after each test run.
-    graph = collections.defaultdict(set)
-    for model in store.manifests['default'].objects['model'].values():
-        if model.name not in graph:
-            graph[model.name] = set()
-        for prop in model.properties.values():
-            if prop.type.name == 'ref':
-                graph[prop.type.object].add(model.name)
-
-    for models in toposort(graph):
-        for name in models:
-            context.wipe(name)
-
-    # Datasets does not have foreign kei constraints, so there is no need to
-    # topologically sort them. At least for now.
-    for dataset in store.manifests['default'].objects['dataset'].values():
-        for model in dataset.objects.values():
-            context.wipe(model)
-
-    context.wipe(store.internal.objects['model']['transaction'])
-
-
-@pytest.fixture(scope='session')
-def postgresql():
-    if 'SPINTA_TEST_DATABASE' in os.environ:
-        yield os.environ['SPINTA_TEST_DATABASE']
-    else:
-        if 'SPINTA_TEST_DATABASE_DSN' in os.environ:
-            dsn = os.environ['SPINTA_TEST_DATABASE_DSN']
-        else:
-            dsn = 'postgresql:///spinta_tests'
-        assert not su.database_exists(dsn), 'Test database already exists. Aborting tests.'
-        su.create_database(dsn)
-        yield dsn
-        su.drop_database(dsn)
-
-
-@pytest.fixture
-def responses():
-    with RequestsMock() as mock:
-        yield mock
-
-
-@pytest.fixture
-def app(context, mocker):
-    mocker.patch('spinta.api.context', context)
-    return TestClient(api.app)
+    return config


### PR DESCRIPTION
Changed how configuration is loaded and how store, manifests and
backends are loaded from configuration.

Now store, backends and manifests all are loaded from raw configuration
component, each backend can have it's own configuration parameters.

Configuration can be easily overriden in tests and other places.

Consistent bahaviour for setting configuration parameters from env, cli
or directly from python.