### PR TITLE
Use named volumes and use docker services in tests

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,46 +1,17 @@
 Development environment
 =======================
 
-You can develop either on local machine or using docker
+You can use docker-compose to run dependant services for spinta development::
 
-Docker
-------
+   docker-compose up -d
 
-You can use docker-compose to run dependant services for python app development::
-
-   docker-compose up
-
-If migrations are not applied, app will crash. To launch migrations::
+If migrations are not applied, spinta will crash. To launch migrations::
 
    env/bin/spinta migrate
-   # and restart the app
+
+You can run the app using::
+
    make run
-
-Local machine
--------------
-
-Create database::
-
-   createdb spinta
-
-Create configuration files::
-
-   SPINTA_BACKENDS_DEFAULT_DSN=postgresql:///spinta
-   SPINTA_MANIFESTS_DEFAULT_PATH=path/to/manifest
-
-Prepare environment::
-
-   make
-
-Run database migrations::
-
-   env/bin/spinta migrate
-
-
-Import some datasets::
-
-   env/bin/spinta pull gov/vrk/rinkejopuslapis.lt/kandidatai
-   env/bin/spinta pull gov/lrs/ad
 
 
 Diretory tree

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - POSTGRES_USER=admin
             - POSTGRES_PASSWORD=admin123
         volumes:
-            - "/var/lib/postgresql/data"
+            - postgres:/var/lib/postgresql/data
     mongo:
         image: mongo:4.0.9-xenial
         ports:
@@ -20,4 +20,8 @@ services:
             - MONGO_INITDB_ROOT_USERNAME=admin
             - MONGO_INITDB_ROOT_PASSWORD=admin123
         volumes:
-            - "/data/db"
+            - mongo:/data/db
+
+volumes:
+  postgres:
+  mongo:

--- a/spinta/config/__init__.py
+++ b/spinta/config/__init__.py
@@ -72,7 +72,7 @@ CONFIG = {
     'backends': {
         'default': {
             'backend': 'spinta.backends.postgresql:PostgreSQL',
-            'dsn': 'postgresql:///spinta',
+            'dsn': 'postgresql://admin:admin123@localhost:54321/spinta',
         },
     },
     'manifests': {
@@ -114,12 +114,12 @@ CONFIG = {
             'backends': {
                 'default': {
                     'backend': 'spinta.backends.postgresql:PostgreSQL',
-                    'dsn': 'postgresql:///spinta_tests',
+                    'dsn': 'postgresql://admin:admin123@localhost:54321/spinta_tests',
                 },
                 'mongo': {
                     'backend': 'spinta.backends.mongo:Mongo',
                     'dsn': 'mongodb://admin:admin123@localhost:27017/',
-                    'db': 'spinta_test',
+                    'db': 'spinta_tests',
                 },
             },
             'manifests': {


### PR DESCRIPTION
Changes anonymous docker volumes to named volumes. Also updated default
Spinta configuration to use database services from docker compose.