### PR TITLE
Add checks for valid `create` requests

### DIFF
--- a/spinta/backends/postgresql/__init__.py
+++ b/spinta/backends/postgresql/__init__.py
@@ -11,12 +11,13 @@ from sqlalchemy.dialects.postgresql import JSONB, BIGINT
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import FunctionElement
 
-from spinta.types import NA
+from spinta.backends import Backend
 from spinta.commands import wait, load, prepare, migrate, check, push, get, getall, wipe
 from spinta.components import Context, Manifest, Model, Property
-from spinta.backends import Backend
-from spinta.types.type import Type
 from spinta.config import Config
+from spinta.types import NA
+from spinta.types.type import Type
+from spinta.utils.exceptions import MultipleRowsException, NoResultsException
 
 # Maximum length for PostgreSQL identifiers (e.g. table names, column names,
 # function names).
@@ -82,12 +83,12 @@ class PostgreSQL(Backend):
 
         elif len(result) == 0:
             if default is NA:
-                raise Exception("No results where found.")
+                raise NoResultsException("No results where found.")
             else:
                 return default
 
         else:
-            raise Exception("Multiple rows were found.")
+            raise MultipleRowsException("Multiple rows were found.")
 
 
 class ReadTransaction:

--- a/spinta/utils/exceptions.py
+++ b/spinta/utils/exceptions.py
@@ -1,0 +1,6 @@
+class MultipleRowsException(Exception):
+    pass
+
+
+class NoResultsException(Exception):
+    pass

--- a/spinta/utils/response.py
+++ b/spinta/utils/response.py
@@ -1,6 +1,7 @@
 import cgi
 import collections
 import datetime
+import json
 import operator
 
 import pkg_resources as pres
@@ -14,6 +15,7 @@ from starlette.requests import Request
 from spinta import commands
 from spinta.types import Type
 from spinta.types.store import get_model_from_params
+from spinta.utils.exceptions import MultipleRowsException, NoResultsException
 from spinta.utils.tree import build_path_tree
 from spinta.utils.url import build_url_path
 from spinta.utils.url import parse_url_path
@@ -106,7 +108,58 @@ async def create_http_response(context, params, request):
 
         if request.method == 'POST':
             context.bind('transaction', manifest.backend.transaction, write=True)
-            data = await request.json()
+
+            # only `application/json` is supported
+            ct = request.headers.get('content-type')
+            if ct != 'application/json':
+                return JSONResponse(
+                    {"error": "only 'application/json' content-type is supported"},
+                    status_code=415
+                )
+
+            auth_header = request.headers.get('authorization')
+            if auth_header is None:
+                return JSONResponse({"error": "missing authorization header"},
+                                    status_code=401)
+
+            if not auth_header.startswith('Bearer '):
+                return JSONResponse({"error": "invalid authorization header"},
+                                    status_code=403)
+
+            jwt_token = auth_header.strip('Bearer ') if auth_header else None
+
+            # TODO: check for special scope which allows id creation
+            # scopes = jwt.decode(jwt_token)
+            #
+            # XXX: currently for dev purposes and testing use
+            # fake token `f00b4rb4z`
+            can_create_ids = bool(jwt_token == "f00b4rb4z")
+
+            # make sure json is valid
+            try:
+                data = await request.json()
+            except json.decoder.JSONDecodeError:
+                return JSONResponse({"error": "not a valid json"},
+                                    status_code=400)
+
+            object_is_being_created = ('id' in data.keys() and not params.id)
+            if object_is_being_created:
+                if not can_create_ids:
+                    return JSONResponse({"error": "cannot create 'id'"},
+                                        status_code=400)
+                else:
+                    try:
+                        id = commands.get(context, model, model.backend, data['id'])
+                    except (MultipleRowsException, NoResultsException):
+                        pass
+                    else:
+                        return JSONResponse({"error": "cannot create duplicate 'id'"},
+                                            status_code=400)
+
+            if 'revision' in data.keys():
+                return JSONResponse({"error": "cannot create 'revision'"},
+                                    status_code=400)
+
             id = commands.push(context, model, model.backend, data)
             data = {
                 'type': model.name,


### PR DESCRIPTION
_NOTE: as discussed this  is implemented within `spinta` and not in the client. It's implemented in straightforward, but ugly way until refactoring pattern will emerge._

As per ticket:
- [X] 201 (Created) - if the posted content has been stored
- [X] 400 (Content is not valid JSON) - if the content is not valid JSON
- [X] 400 (New item has id already set) - if the content contains id without appropriate scope
- [X] 400 (New item has revision already set) - if the content contains revision
- [X] 400 (New item has conflicting id) - if the caller has permission to set the id, but it exists already in the data storage:
- [X] 401 (Authorization header is missing) - if there is no Authorization header in the request
- [ ] 401 (Access token is invalid: <token error>) - if validation of the access token fails in any way (missing scope, wrong signature etc.)
- [X] 403 (Authorization header is in invalid format, should be "Bearer TOKEN") - if the header is in any other format
- [X] 415 (Unsupported media type) - if the content is not specified as JSON

One point (`401 (Access token is invalid: <token error>)`) is not implemented and parts related to scopes are mocked for
development and testing purposes, though should be implemented easily, when scopes and authorization is implemented.

Related: SPLAT-12