### PR TITLE
Allow to override context

### DIFF
--- a/spinta/asgi.py
+++ b/spinta/asgi.py
@@ -2,11 +2,12 @@ import logging
 
 from spinta.api import app, set_context
 from spinta.commands import load, wait, prepare, check
-from spinta.components import Context, Store
+from spinta.components import Store
 from spinta.utils.commands import load_commands
 from spinta import components
 from spinta.config import Config
 from spinta.auth import AuthorizationServer, ResourceProtector, BearerTokenValidator
+from spinta.utils.imports import importstr
 
 logging.basicConfig(
     level=logging.INFO,
@@ -19,6 +20,7 @@ c.read()
 
 load_commands(c.get('commands', 'modules', cast=list))
 
+Context = c.get('components', 'core', 'context', cast=importstr)
 context = Context()
 config = context.set('config', components.Config())
 store = context.set('store', Store())

--- a/spinta/cli/__init__.py
+++ b/spinta/cli/__init__.py
@@ -7,9 +7,10 @@ import click
 
 from spinta.config import Config
 from spinta.utils.commands import load_commands
-from spinta.components import Context, Store
+from spinta.components import Store
 from spinta import commands
 from spinta import components
+from spinta.utils.imports import importstr
 
 
 @click.group()
@@ -21,6 +22,7 @@ def main(ctx, option):
 
     load_commands(c.get('commands', 'modules', cast=list))
 
+    Context = c.get('components', 'core', 'context', cast=importstr)
     context = Context()
     config = context.set('config', components.Config())
     store = context.set('store', Store())

--- a/spinta/config/__init__.py
+++ b/spinta/config/__init__.py
@@ -26,6 +26,9 @@ CONFIG = {
         },
     },
     'components': {
+        'core': {
+            'context': 'spinta.components:Context',
+        },
         'backends': {
             'postgresql': 'spinta.backends.postgresql:PostgreSQL',
             'mongo': 'spinta.backends.mongo:Mongo',

--- a/spinta/testing/context.py
+++ b/spinta/testing/context.py
@@ -2,10 +2,10 @@ import contextlib
 import typing
 
 from spinta import commands
-from spinta.components import Context, Node
+from spinta.components import Node
 
 
-class ContextForTests(Context):
+class ContextForTests:
 
     def _get_model(self, model: typing.Union[str, Node], dataset: str):
         if isinstance(model, str):

--- a/spinta/testing/pytest.py
+++ b/spinta/testing/pytest.py
@@ -17,6 +17,7 @@ from spinta.testing.client import TestClient
 from spinta import components
 from spinta.config import Config
 from spinta.auth import AuthorizationServer, ResourceProtector, BearerTokenValidator, AdminToken
+from spinta.utils.imports import importstr
 
 
 @pytest.fixture(scope='session')
@@ -54,7 +55,9 @@ def context(mocker, config, postgresql, mongo):
         'AUTHLIB_INSECURE_TRANSPORT': '1',
     })
 
-    context = ContextForTests()
+    Context = config.get('components', 'core', 'context', cast=importstr)
+    Context = type('ContextForTests', (ContextForTests, Context), {})
+    context = Context()
 
     context.set('config', components.Config())
     store = context.set('store', Store())


### PR DESCRIPTION
Context plays main role for overriding things, because each app should
have its own context and with this more specific context any command can
be overrident easilly in the app.