### PR TITLE
Fix bug with empty scopes request

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 
 from spinta.utils.itertools import consume
-from spinta.commands import push
 
 
 def test_app(app):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,3 +64,22 @@ def test_client_add(cli, tmpdir):
         'client_secret_hash': client['client_secret_hash'],
         'scopes': [],
     }
+
+
+def test_empty_scope(context, app):
+    client_id = '3388ea36-4a4f-4821-900a-b574c8829d52'
+    client_secret = 'b5DVbOaEY1BGnfbfv82oA0-4XEBgLQuJ'
+
+    resp = app.post('/auth/token', auth=(client_id, client_secret), data={
+        'grant_type': 'client_credentials',
+        'scope': '',
+    })
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert 'scope' not in data
+
+    config = context.get('config')
+    key = jwk.loads(json.loads((config.config_path / 'keys/public.json').read_text()))
+    token = jwt.decode(data['access_token'], key)
+    assert token['scope'] == ''


### PR DESCRIPTION
When client requested empty scopes on /auth/token, then all client
scopes were granted.

The fix is to give no scopes if no scopes were requested.

Also there is a potential bug in auth lib described here:

https://github.com/lepture/authlib/issues/130