### PR TITLE
Prepare data with user defiend functions

### DIFF
--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -7,3 +7,4 @@ Manual
 
    manifest/index
    functions
+   rql

--- a/docs/manual/manifest/functions.rst
+++ b/docs/manual/manifest/functions.rst
@@ -14,3 +14,13 @@ Using functions in Manifest
 ===========================
 
 
+.. code-block:: yaml
+
+    type: model
+      properties:
+        gov_org_id:
+          type: string
+          description: Government issues organization identifier
+          prepare:
+            - .check(.len() == 9, "Invalid company registration number.")
+            - .check(.re("\d+"))

--- a/docs/manual/rql.rst
+++ b/docs/manual/rql.rst
@@ -1,0 +1,24 @@
+.. default-role:: literal
+
+RQL
+###
+
+Spinta uses an RQL-like query language, which also can be used to transform,
+validate and define data.
+
+Examples:
+
+.. code-block:: python
+
+    # Data definition
+    create_table(
+      report,
+      column(status, string, choices=[ok, warn]),
+    )
+
+    # Query
+    groupby(org)&status.lower()=ok|status.lower()=warn&sort(+name)
+
+    # Data transformation and validation
+    check(lower().in(ok, warn), "Unknown status {given}.", given:.).
+    check(len() < 10, "Status name is too long.")

--- a/spinta/auth.py
+++ b/spinta/auth.py
@@ -165,6 +165,8 @@ def get_auth_token(context: Context) -> Token:
         request.headers = request.headers.mutablecopy()
         request.headers['authorization'] = f'Bearer {token}'
 
+    print('----')
+    context.dump()
     resource_protector = context.get('auth.resource_protector')
     try:
         token = resource_protector.validate_request(scope, request)

--- a/spinta/backends/__init__.py
+++ b/spinta/backends/__init__.py
@@ -602,3 +602,8 @@ async def _prepare_property_for_delete(
                 prop.name: None,
             }
         yield data
+
+
+@commands.prepare_given_ufunc.register()
+def prepare_given_ufunc(context: Context, model: Model, givena: dict, *, action: Action):
+    pass

--- a/spinta/backends/__init__.py
+++ b/spinta/backends/__init__.py
@@ -613,12 +613,14 @@ def ufunc_prepare_given(
 ):
     prepared = {}
     for name, prop in model.properties.items():
-        prepared[name] = commands.ufunc_prepare_given(
+        value = commands.ufunc_prepare_given(
             context,
             prop.dtype,
             given.get(name, NA),
             this=(prepared,),
         )
+        if value is not NA:
+            prepared[name] = value
     for ufunc in (model.prepare or []):
         prepared = execute(ufunc, context, model, (prepared,))
     return prepared
@@ -634,12 +636,14 @@ def ufunc_prepare_given(  # noqa
 ):
     prepared = {}
     for name, prop in dtype.properties.items():
-        prepared[name] = commands.ufunc_prepare_given(
+        value = commands.ufunc_prepare_given(
             context,
             prop.dtype,
             given.get(name, NA),
             this=this + (given,),
         )
+        if value is not NA:
+            prepared[name] = value
     for ufunc in (dtype.prop.prepare or []):
         prepared = execute(ufunc, context, dtype, this + (prepared,))
     return prepared

--- a/spinta/commands/__init__.py
+++ b/spinta/commands/__init__.py
@@ -395,7 +395,7 @@ def get_model_scopes():
 
 
 @command()
-def prepare_given_ufunc():
+def ufunc_prepare_given():
     """Prepare given user data using ufuncs defined in manifest YAML files.
 
     This data prepareation happens afeter initial data loading and type
@@ -410,9 +410,9 @@ def prepare_given_ufunc():
         type: string
         prepare: >-
           check(
-            this, len(this) = 2,
-            Country code must be 2 letters long, given: {given}.,
-            given: len(this)
+            len(this) = 2,
+            "Country code must be 2 letters long, given: {given}.",
+            given: len(this),
           )
 
     """

--- a/spinta/commands/__init__.py
+++ b/spinta/commands/__init__.py
@@ -392,3 +392,27 @@ def rename_metadata():
 def get_model_scopes():
     """Returns list of model scopes by given list of actions.
     """
+
+
+@command()
+def prepare_given_ufunc():
+    """Prepare given user data using ufuncs defined in manifest YAML files.
+
+    This data prepareation happens afeter initial data loading and type
+    validation.
+
+    Example manifest YAML file:
+
+    type: model
+    name: country
+    properties:
+      code:
+        type: string
+        prepare: >-
+          check(
+            this, len(this) = 2,
+            Country code must be 2 letters long, given: {given}.,
+            given: len(this)
+          )
+
+    """

--- a/spinta/commands/ufuncs.py
+++ b/spinta/commands/ufuncs.py
@@ -1,0 +1,15 @@
+from spinta.components import Context
+from spinta.types.datatype import DataType
+from spinta.ufuncs import ufunc
+
+
+@ufunc(Context, DataType)
+def check(context, dtype, this, value, message, **kwargs):
+    if bool(value) is False:
+        raise Exception(message.format(**kwargs))
+    return this[-1]
+
+
+@ufunc(Context, DataType)
+def len(context, dtype, this, value):
+    return len(value)

--- a/spinta/commands/ufuncs.py
+++ b/spinta/commands/ufuncs.py
@@ -1,15 +1,34 @@
-from spinta.components import Context
+from spinta.components import Context, Model
 from spinta.types.datatype import DataType
+from spinta.types import dataset
 from spinta.ufuncs import ufunc
+from spinta import exceptions
 
 
-@ufunc(Context, DataType)
-def check(context, dtype, this, value, message, **kwargs):
-    if bool(value) is False:
-        raise Exception(message.format(**kwargs))
+@ufunc(Context, DataType, tuple)
+def bind(context, dtype, this):
     return this[-1]
 
 
-@ufunc(Context, DataType)
-def len(context, dtype, this, value):
+@ufunc(Context, (Model, dataset.Model, DataType), tuple, str)
+def bind(context, dtype, this, name):  # noqa
+    return this[-1][name]
+
+
+@ufunc(Context, (dataset.Model, DataType), tuple, object)
+@ufunc(Context, (dataset.Model, DataType), tuple, object, str)
+def check(context, dtype, this, value, message=None, **kwargs):
+    if bool(value) is False:
+        message = message or "Data check error."
+        raise exceptions.InvalidValue(dtype, error=message.format(**kwargs))
+    return this[-1]
+
+
+@ufunc(Context, DataType, tuple, object)
+def len_(context, dtype, this, value):
     return len(value)
+
+
+@ufunc(Context, (dataset.Model, DataType), tuple, object, object)
+def eq(context, dtype, this, left, right):
+    return left == right

--- a/spinta/commands/write.py
+++ b/spinta/commands/write.py
@@ -343,6 +343,7 @@ async def prepare_data(
                 data.given = commands.load(context, data.model, data.payload)
                 data.given = commands.prepare(context, data.model, data.given, action=data.action)
                 commands.simple_data_check(context, data, data.model, data.model.backend)
+                data.given = commands.prepare_given_ufunc(context, data.model, data.given, action=data.action)
         except (exceptions.UserError, InsufficientScopeError) as error:
             report_error(error, stop_on_error)
         yield data

--- a/spinta/commands/write.py
+++ b/spinta/commands/write.py
@@ -343,7 +343,7 @@ async def prepare_data(
                 data.given = commands.load(context, data.model, data.payload)
                 data.given = commands.prepare(context, data.model, data.given, action=data.action)
                 commands.simple_data_check(context, data, data.model, data.model.backend)
-                data.given = commands.prepare_given_ufunc(context, data.model, data.given, action=data.action)
+                data.given = commands.ufunc_prepare_given(context, data.model, data.given)
         except (exceptions.UserError, InsufficientScopeError) as error:
             report_error(error, stop_on_error)
         yield data

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -404,6 +404,7 @@ class Model(Node):
         'flatprops': {},
         'leafprops': {},
         'endpoint': {},
+        'prepare': {'type': 'ufunc'},
     }
 
     def __init__(self):
@@ -440,6 +441,7 @@ class Property(Node):
         'hidden': {'type': 'boolean', 'default': False},
         'model': {'required': True},
         'place': {'required': True},
+        'prepare': {'type': 'ufunc'},
     }
 
     def __init__(self):

--- a/spinta/config/__init__.py
+++ b/spinta/config/__init__.py
@@ -34,6 +34,11 @@ CONFIG = {
             'range': 'spinta.commands.helpers:range_',
         },
     },
+    'ufuncs': {
+        'default': [
+            'spinta.commands.ufuncs',
+        ],
+    },
     'components': {
         'core': {
             'context': 'spinta.components:Context',

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -41,6 +41,12 @@ def load(context: Context, config: components.Config, raw: RawConfig) -> compone
         exporter = raw.get('exporters', name, cast=importstr)
         config.exporters[name] = exporter()
 
+    # Load ufuncs
+    config.ufuncs = init_ufuncs({
+        name: raw.get('ufuncs', name)
+        for name in raw.keys('ufuncs')
+    })
+
     # Load everything else.
     config.debug = raw.get('debug', default=False)
     config.config_path = raw.get('config_path', cast=pathlib.Path, exists=True)

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -7,6 +7,7 @@ from spinta.commands import load, check
 from spinta.components import Context
 from spinta.config import RawConfig
 from spinta import components
+from spinta.ufuncs import init_ufuncs
 
 yaml = YAML(typ='safe')
 

--- a/spinta/types/dataset.py
+++ b/spinta/types/dataset.py
@@ -143,6 +143,7 @@ class Property(Node):
         'place': {'required': True},
         'flags': {'type': 'array'},
         'default': {},
+        'prepare': {},
     }
 
     def __init__(self):

--- a/spinta/types/dataset.py
+++ b/spinta/types/dataset.py
@@ -89,6 +89,7 @@ class Model(Node):
         'canonical': {'type': 'boolean', 'default': False},
         'endpoint': {},
         'flags': {'type': 'array'},
+        'prepare': {'type': 'ufunc'},
     }
 
     property_type = 'dataset.property'
@@ -143,7 +144,7 @@ class Property(Node):
         'place': {'required': True},
         'flags': {'type': 'array'},
         'default': {},
-        'prepare': {},
+        'prepare': {'type': 'ufunc'},
     }
 
     def __init__(self):

--- a/spinta/ufuncs.py
+++ b/spinta/ufuncs.py
@@ -2,8 +2,7 @@ from typing import Union
 
 import importlib
 
-from multipledispatch.dispatcher import Dispatcher
-
+from spinta.dispatcher import Command
 from spinta.components import Context, Model
 from spinta.types.datatype import DataType
 
@@ -14,34 +13,39 @@ def execute(
     dtype: Union[Model, DataType],
     this: tuple,
 ):
-    config.context.get('config')
-    return this[-1]
+    if isinstance(ufunc, dict):
+        config = context.get('config')
+        func = config.ufuncs[ufunc['name']]
+        args = [execute(arg, context, dtype, this) for arg in ufunc['args']]
+        return func(context, dtype, this, *args)
+    else:
+        return ufunc
+
+
+_found_ufuncs = []
 
 
 def ufunc(*types):
     def _(func):
-        # Just save given types and load it later with `load_ufuncs`.
-        func._ufunc = types
+        # Just save given types and load it later with `init_ufuncs`.
+        _found_ufuncs.append((func, types))
         return func
     return _
 
 
-def load_ufuncs(ufuncs):
-    registry = {}
+def init_ufuncs(ufuncs):
+    # Collect all ufuncs to _found_ufuncs.
     for ns, modules in ufuncs.items():
         for module in modules:
             module = importlib.import_module(module)
-            for name in dir(module):
-                func = getattr(module, name)
-                if hasattr(func._ufunc):
-                    name = func.__name__.rstrip('_')
-                    if ns != 'default':
-                        name = f'{ns}.{name}'
-                    if name not in registry:
-                        registry[name] = Dispatcher(name)
-                    dispatcher = registry[name]
-                    dispatcher.add(func._ufunc, func)
-                    return dispatcher
+    # Create commands from _found_ufuncs
+    registry = {}
+    for func, types in _found_ufuncs:
+        name = func.__name__.rstrip('_')
+        if ns != 'default':
+            name = f'{ns}.{name}'
+        if name not in registry:
+            registry[name] = Command(name)
+        dispatcher = registry[name]
+        dispatcher.add(types, func)
     return registry
-
-

--- a/spinta/ufuncs.py
+++ b/spinta/ufuncs.py
@@ -1,0 +1,47 @@
+from typing import Union
+
+import importlib
+
+from multipledispatch.dispatcher import Dispatcher
+
+from spinta.components import Context, Model
+from spinta.types.datatype import DataType
+
+
+def execute(
+    ufunc: dict,
+    context: Context,
+    dtype: Union[Model, DataType],
+    this: tuple,
+):
+    config.context.get('config')
+    return this[-1]
+
+
+def ufunc(*types):
+    def _(func):
+        # Just save given types and load it later with `load_ufuncs`.
+        func._ufunc = types
+        return func
+    return _
+
+
+def load_ufuncs(ufuncs):
+    registry = {}
+    for ns, modules in ufuncs.items():
+        for module in modules:
+            module = importlib.import_module(module)
+            for name in dir(module):
+                func = getattr(module, name)
+                if hasattr(func._ufunc):
+                    name = func.__name__.rstrip('_')
+                    if ns != 'default':
+                        name = f'{ns}.{name}'
+                    if name not in registry:
+                        registry[name] = Dispatcher(name)
+                    dispatcher = registry[name]
+                    dispatcher.add(func._ufunc, func)
+                    return dispatcher
+    return registry
+
+

--- a/tests/manifest/datasets/csv.yml
+++ b/tests/manifest/datasets/csv.yml
@@ -1,6 +1,6 @@
 ---
-name: csv
 type: dataset
+name: csv
 version:
   number: 1
   date: 2019-02-15
@@ -18,6 +18,7 @@ resources:
               source: kodas
             code:
               type: string
+              prepare: check(this, eq(len(this), 2))
               source: kodas
             title:
               type: string

--- a/tests/manifest/datasets/csv.yml
+++ b/tests/manifest/datasets/csv.yml
@@ -18,7 +18,7 @@ resources:
               source: kodas
             code:
               type: string
-              prepare: check(this, eq(len(this), 2))
+              prepare: check(eq(len(this), 2))
               source: kodas
             title:
               type: string

--- a/tests/manifest/datasets/csv.yml
+++ b/tests/manifest/datasets/csv.yml
@@ -18,7 +18,7 @@ resources:
               source: kodas
             code:
               type: string
-              prepare: check(eq(len(this), 2))
+              prepare: check(eq(bind(),2))
               source: kodas
             title:
               type: string

--- a/tests/manifest/datasets/denorm.yml
+++ b/tests/manifest/datasets/denorm.yml
@@ -25,6 +25,7 @@ resources:
               source: kodas
         country:
           source: orgs.csv
+          prepare: check(eq(bind(code),2))
           properties:
             _id:
               type: pk

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 import uuid
 
 import pytest

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,0 +1,11 @@
+from responses import GET
+
+
+def test_prepare(app, context, responses):
+    responses.add(
+        GET, 'http://example.com/countries.csv',
+        status=200, stream=True, content_type='text/plain; charset=utf-8',
+        body='kodas,šalis\nfoo,Lithuania\n',
+    )
+
+    context.pull('csv')

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,11 +1,50 @@
+import pytest
+
 from responses import GET
 
+from spinta import exceptions
 
-def test_prepare(app, context, responses):
+
+def test_prepare_model(app, context, responses):
+    responses.add(
+        GET, 'http://example.com/orgs.csv',
+        status=200, content_type='text/plain; charset=utf-8',
+        body=(
+            'govid,org,kodas,šalis\n'
+            '1,Org1,foo,Lietuva\n'
+        ),
+    )
+    with pytest.raises(exceptions.InvalidValue) as e:
+        context.pull('denorm')
+    assert e.value.context == {
+        'schema': 'tests/manifest/datasets/denorm.yml',
+        'manifest': 'default',
+        'backend': 'default',
+        'dataset': 'denorm',
+        'model': 'country',
+        'resource': 'orgs',
+        'origin': '',
+        'error': 'Data check error.',
+    }
+
+
+def test_prepare_prop(app, context, responses):
     responses.add(
         GET, 'http://example.com/countries.csv',
         status=200, stream=True, content_type='text/plain; charset=utf-8',
         body='kodas,šalis\nfoo,Lithuania\n',
     )
-
-    context.pull('csv')
+    with pytest.raises(exceptions.InvalidValue) as e:
+        context.pull('csv')
+    assert e.value.context == {
+        'schema': 'tests/manifest/datasets/csv.yml',
+        'manifest': 'default',
+        'backend': 'default',
+        'dataset': 'csv',
+        'model': 'country',
+        'resource': 'countries',
+        'origin': '',
+        'property': 'code',
+        'type': 'string',
+        'error': 'Data check error.',
+    }


### PR DESCRIPTION
In GitLab by @sirex on Jan 13, 2020, 18:08

The idea, that users should be able to define custom functions and these
functions can be used in YAML files, for example:

    type: model
    name: country
    properties:
      code:
        type: string
        prepare: >-
          check(
            len(this) = 2,
            "Country code must be 2 characters long!, got {given}.",
            given: len(this),
          )

After `code` property data is loaded, prepared and simple validation is
done, then user defined functions will be executed. In this case
`check` and `len` built-in user defined functions were used.

These functions are defined in `spinta.ufuncs` and look like this:

    @ufunc(Context, DataType)
    def check(context, dtype, this, value, message, **kwargs):
        if bool(value) is False:
            raise ValidationError(message.format(**kwargs))
        return this[-1]

    @ufunc(Context, DataType)
    def len(context, dtype, this, value):
        return len(value)

When preparing values, each ufunc must return same or modified value
and it will be passed as `this` to the next ufunc.

Argument `this` is a list of all vales in the structure, `this[0]` always points to a model data and `this[-1]` always points to current value.

Ufuncs are multiple dispatch functions, so it is possible to define
multiple ufuncs of the same name for different types.

Two arguments must always be passed to ufuncs, these are `context` and
`model` or `dtype`. These two argumens are not visible from manifest,
but all other arguments are the same as passed in yaml file.

https://gitlab.com/atviriduomenys/spinta/issues/8