### PR TITLE
Allow to use existing backend with -r option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Changes
 0.1.35 (unreleased)
 ===================
 
+New features:
+
+- Allow to use existing backend with -r option (`#231`__).
+
+  __ https://github.com/atviriduomenys/spinta/issues/231
+
 Bug fixes:
 
 - Allow NULL values for properties with enum constraints (`#230`__).

--- a/spinta/cli/inspect.py
+++ b/spinta/cli/inspect.py
@@ -10,13 +10,13 @@ from spinta import commands
 from spinta.cli.helpers.auth import require_auth
 from spinta.cli.helpers.store import prepare_manifest
 from spinta.components import Mode
-from spinta.core.config import ResourceTuple
 from spinta.core.context import configure_context
 from spinta.manifests.components import Manifest
 from spinta.manifests.helpers import init_manifest
 from spinta.manifests.helpers import load_manifest_nodes
 from spinta.manifests.tabular.helpers import render_tabular_manifest
 from spinta.manifests.tabular.helpers import write_tabular_manifest
+from spinta.core.config import parse_resource_args
 
 
 def inspect(
@@ -39,20 +39,13 @@ def inspect(
     )),
 ):
     """Update manifest schema from an external data source"""
-    resource = ResourceTuple(*resource, formula)
-    if (
-        resource.type is None and
-        resource.external is None and
-        not resource.prepare
-    ):
-        resource = None
-
+    resources = parse_resource_args(*resource, formula)
     context = configure_context(
         ctx.obj,
         [manifest] if manifest else None,
         mode=Mode.external,
         backend=backend,
-        resources=[resource] if resource else None,
+        resources=resources,
     )
     store = prepare_manifest(context, ensure_config_dir=True)
 

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -57,9 +57,30 @@ def test_configure_with_resource(rc: RawConfig):
     ])
     store = prepare_manifest(context, verbose=False)
     assert store.manifest == '''
-    d | r | b | m | property       | type   | source
-    datasets/gov/example/resources |        |
-      | resource1                  | sql    | sqlite://
+    d | r | b | m | property | type | ref  | source     | prepare
+    datasets/gov/example     |      |      |            |
+      | resource1            | sql  |      | sqlite://  |
+    '''
+
+
+def test_configure_with_resource_backend(rc: RawConfig):
+    rc = rc.fork({
+        'backends': {
+            'mydb': {
+                'type': 'sql',
+                'dsn': 'sqlite://',
+            }
+        }
+    })
+    context: Context = create_test_context(rc)
+    context = configure_context(context, resources=[
+        ResourceTuple('sql', 'mydb'),
+    ])
+    store = prepare_manifest(context, verbose=False)
+    assert store.manifest == '''
+    d | r | b | m | property | type | ref  | source     | prepare
+    datasets/gov/example     |      |      |            |
+      | resource1            | sql  | mydb |            |
     '''
 
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -43,18 +43,18 @@ def test_inspect(
     manifest = load_manifest(rc, tmpdir / 'result.csv')
     manifest.datasets['dataset'].resources['rs'].external = 'sqlite'
     assert manifest == '''
-    id | d | r | b | m | property   | type    | ref     | source     | prepare | level | access | uri | title | description
-       | dataset                    |         |         |            |         |       |        |     |       |
-       |   | rs                     | sql     |         | sqlite     |         |       |        |     |       |
-       |                            |         |         |            |         |       |        |     |       |
-       |   |   |   | Country        |         | id      | COUNTRY    |         |       |        |     |       |
-       |   |   |   |   | id         | integer |         | ID         |         |       |        |     |       |
-       |   |   |   |   | code       | string  |         | CODE       |         |       |        |     |       |
-       |   |   |   |   | name       | string  |         | NAME       |         |       |        |     |       |
-       |                            |         |         |            |         |       |        |     |       |
-       |   |   |   | City           |         |         | CITY       |         |       |        |     |       |
-       |   |   |   |   | name       | string  |         | NAME       |         |       |        |     |       |
-       |   |   |   |   | country_id | ref     | Country | COUNTRY_ID |         |       |        |     |       |
+    d | r | b | m | property   | type    | ref     | source     | prepare
+    dataset                    |         |         |            |
+      | rs                     | sql     |         | sqlite     |
+                               |         |         |            |
+      |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | id         | integer |         | ID         |
+      |   |   |   | code       | string  |         | CODE       |
+      |   |   |   | name       | string  |         | NAME       |
+                               |         |         |            |
+      |   |   | City           |         |         | CITY       |
+      |   |   |   | name       | string  |         | NAME       |
+      |   |   |   | country_id | ref     | Country | COUNTRY_ID |
     '''
 
 
@@ -87,13 +87,13 @@ def test_inspect_from_manifest_table(
     manifest = load_manifest(rc, tmpdir / 'result.csv')
     manifest.datasets['dataset'].resources['rs'].external = 'sqlite'
     assert manifest == '''
-    id | d | r | b | m | property | type    | ref | source  | prepare | level | access | uri | title | description
-       | dataset                  |         |     |         |         |       |        |     |       |
-       |   | rs                   | sql     |     | sqlite  |         |       |        |     |       |
-       |                          |         |     |         |         |       |        |     |       |
-       |   |   |   | Country      |         | id  | COUNTRY |         |       |        |     |       |
-       |   |   |   |   | id       | integer |     | ID      |         |       |        |     |       |
-       |   |   |   |   | name     | string  |     | NAME    |         |       |        |     |       |
+    d | r | b | m | property | type    | ref | source  | prepare
+    dataset                  |         |     |         |
+      | rs                   | sql     |     | sqlite  |
+                             |         |     |         |
+      |   |   | Country      |         | id  | COUNTRY |
+      |   |   |   | id       | integer |     | ID      |
+      |   |   |   | name     | string  |     | NAME    |
     '''
 
 
@@ -124,21 +124,21 @@ def test_inspect_format(
 
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'manifest.csv')
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite'
     assert manifest == '''
-    id | d | r | b | m | property       | type    | ref     | source     | prepare | level | access | uri | title | description
-       | datasets/gov/example/resources |         |         |            |         |       |        |     |       |
-       |   | resource1                  | sql     |         | sqlite     |         |       |        |     |       |
-       |                                |         |         |            |         |       |        |     |       |
-       |   |   |   | Country            |         | id      | COUNTRY    |         |       |        |     |       |
-       |   |   |   |   | id             | integer |         | ID         |         |       |        |     |       |
-       |   |   |   |   | code           | string  |         | CODE       |         |       |        |     |       |
-       |   |   |   |   | name           | string  |         | NAME       |         |       |        |     |       |
-       |                                |         |         |            |         |       |        |     |       |
-       |   |   |   | City               |         |         | CITY       |         |       |        |     |       |
-       |   |   |   |   | name           | string  |         | NAME       |         |       |        |     |       |
-       |   |   |   |   | country_id     | ref     | Country | COUNTRY_ID |         |       |        |     |       |
+    d | r | b | m | property   | type    | ref     | source     | prepare
+    datasets/gov/example       |         |         |            |
+      | resource1              | sql     |         | sqlite     |
+                               |         |         |            |
+      |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | id         | integer |         | ID         |
+      |   |   |   | code       | string  |         | CODE       |
+      |   |   |   | name       | string  |         | NAME       |
+                               |         |         |            |
+      |   |   | City           |         |         | CITY       |
+      |   |   |   | name       | string  |         | NAME       |
+      |   |   |   | country_id | ref     | Country | COUNTRY_ID |
     '''
 
 
@@ -170,22 +170,22 @@ def test_inspect_cyclic_refs(
 
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'manifest.csv')
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite'
     assert manifest == '''
-    id | d | r | b | m | property       | type    | ref     | source     | prepare | level | access | uri | title | description
-       | datasets/gov/example/resources |         |         |            |         |       |        |     |       |
-       |   | resource1                  | sql     |         | sqlite     |         |       |        |     |       |
-       |                                |         |         |            |         |       |        |     |       |
-       |   |   |   | City               |         | id      | CITY       |         |       |        |     |       |
-       |   |   |   |   | id             | integer |         | ID         |         |       |        |     |       |
-       |   |   |   |   | name           | string  |         | NAME       |         |       |        |     |       |
-       |   |   |   |   | country_id     | ref     | Country | COUNTRY_ID |         |       |        |     |       |
-       |                                |         |         |            |         |       |        |     |       |
-       |   |   |   | Country            |         | id      | COUNTRY    |         |       |        |     |       |
-       |   |   |   |   | id             | integer |         | ID         |         |       |        |     |       |
-       |   |   |   |   | capital        | ref     | City    | CAPITAL    |         |       |        |     |       |
-       |   |   |   |   | name           | string  |         | NAME       |         |       |        |     |       |
+    d | r | b | m | property   | type    | ref     | source     | prepare
+    datasets/gov/example       |         |         |            |
+      | resource1              | sql     |         | sqlite     |
+                               |         |         |            |
+      |   |   | City           |         | id      | CITY       |
+      |   |   |   | id         | integer |         | ID         |
+      |   |   |   | name       | string  |         | NAME       |
+      |   |   |   | country_id | ref     | Country | COUNTRY_ID |
+                               |         |         |            |
+      |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | id         | integer |         | ID         |
+      |   |   |   | capital    | ref     | City    | CAPITAL    |
+      |   |   |   | name       | string  |         | NAME       |
     '''
 
 
@@ -212,17 +212,17 @@ def test_inspect_self_refs(
 
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'manifest.csv')
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite'
     assert manifest == '''
-    id | d | r | b | m | property       | type    | ref      | source    | prepare | level | access | uri | title | description
-       | datasets/gov/example/resources |         |          |           |         |       |        |     |       |
-       |   | resource1                  | sql     |          | sqlite    |         |       |        |     |       |
-       |                                |         |          |           |         |       |        |     |       |
-       |   |   |   | Category           |         | id       | CATEGORY  |         |       |        |     |       |
-       |   |   |   |   | id             | integer |          | ID        |         |       |        |     |       |
-       |   |   |   |   | name           | string  |          | NAME      |         |       |        |     |       |
-       |   |   |   |   | parent_id      | ref     | Category | PARENT_ID |         |       |        |     |       |
+    d | r | b | m | property  | type    | ref      | source    | prepare
+    datasets/gov/example      |         |          |           |
+      | resource1             | sql     |          | sqlite    |
+                              |         |          |           |
+      |   |   | Category      |         | id       | CATEGORY  |
+      |   |   |   | id        | integer |          | ID        |
+      |   |   |   | name      | string  |          | NAME      |
+      |   |   |   | parent_id | ref     | Category | PARENT_ID |
     '''
 
 
@@ -275,13 +275,13 @@ def test_inspect_oracle_sqldump_stdin(
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'manifest.csv')
     assert manifest == '''
-    id | d | r | b | m | property       | type    | ref | source  | prepare | level | access | uri | title | description
-       | datasets/gov/example/resources |         |     |         |         |       |        |     |       |
-       |   | resource1                  | sqldump |     | -       |         |       |        |     |       |
-       |                                |         |     |         |         |       |        |     |       |
-       |   |   |   | Country            |         |     | COUNTRY |         |       |        |     |       |
-       |                                |         |     |         |         |       |        |     |       |
-       |   |   |   | City               |         |     | CITY    |         |       |        |     |       |
+    id | d | r | b | m | property | type    | ref | source  | prepare | level | access | uri | title | description
+       | datasets/gov/example     |         |     |         |         |       |        |     |       |
+       |   | resource1            | sqldump |     | -       |         |       |        |     |       |
+       |                          |         |     |         |         |       |        |     |       |
+       |   |   |   | Country      |         |     | COUNTRY |         |       |        |     |       |
+       |                          |         |     |         |         |       |        |     |       |
+       |   |   |   | City         |         |     | CITY    |         |       |        |     |       |
     '''
 
 
@@ -306,14 +306,14 @@ def test_inspect_oracle_sqldump_file_with_formula(
 
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'manifest.csv')
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'dump.sql'
     assert manifest == '''
-    id | d | r | b | m | property       | type    | ref | source   | prepare                            | level | access    | uri | title | description
-       | datasets/gov/example/resources |         |     |          |                                    |       |           |     |       |
-       |   | resource1                  | sqldump |     | dump.sql | file(self, encoding: 'iso-8859-4') |       |           |     |       |
-       |                                |         |     |          |                                    |       |           |     |       |
-       |   |   |   | Country            |         |     | COUNTRY  |                                    |       |           |     |       |
+    d | r | b | m | property | type    | ref | source   | prepare
+    datasets/gov/example     |         |     |          |
+      | resource1            | sqldump |     | dump.sql | file(self, encoding: 'iso-8859-4')
+                             |         |     |          |
+      |   |   | Country      |         |     | COUNTRY  |
     '''
 
 
@@ -498,16 +498,16 @@ def test_inspect_with_empty_config_dir(
 
     # Check what was detected.
     manifest = load_manifest(rc, tmpdir / 'result.csv')
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite://'
     assert manifest == '''
-    d | r | b | m | property       | type    | ref     | source
-    datasets/gov/example/resources |         |         |
-      | resource1                  | sql     |         | sqlite://
-                                   |         |         |
-      |   |   | Country            |         | id      | COUNTRY
-      |   |   |   | id             | integer |         | ID
-      |   |   |   | name           | string  |         | NAME
+    d | r | b | m | property | type    | ref | source
+    datasets/gov/example     |         |     |
+      | resource1            | sql     |     | sqlite://
+                             |         |     |
+      |   |   | Country      |         | id  | COUNTRY
+      |   |   |   | id       | integer |     | ID
+      |   |   |   | name     | string  |     | NAME
     '''
 
 
@@ -533,21 +533,21 @@ def test_inspect_duplicate_table_names(
 
     # Check what was detected.
     manifest = load_manifest(rc, result_file_path)
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite://'
     assert manifest == '''
-    d | r | b | m | property       | type    | ref     | source
-    datasets/gov/example/resources |         |         |
-      | resource1                  | sql     |         | sqlite://
-                                   |         |         |
-      |   |   | Country            |         |         | COUNTRY
-      |   |   |   | name           | string  |         | NAME
-                                   |         |         |
-      |   |   | Country1           |         |         | _COUNTRY
-      |   |   |   | name           | string  |         | NAME
-                                   |         |         |
-      |   |   | Country2           |         |         | __COUNTRY
-      |   |   |   | name           | string  |         | NAME
+    d | r | b | m | property | type    | ref | source
+    datasets/gov/example     |         |     |
+      | resource1            | sql     |     | sqlite://
+                             |         |     |
+      |   |   | Country      |         |     | COUNTRY
+      |   |   |   | name     | string  |     | NAME
+                             |         |     |
+      |   |   | Country1     |         |     | _COUNTRY
+      |   |   |   | name     | string  |     | NAME
+                             |         |     |
+      |   |   | Country2     |         |     | __COUNTRY
+      |   |   |   | name     | string  |     | NAME
     '''
 
 
@@ -575,15 +575,15 @@ def test_inspect_duplicate_column_names(
 
     # Check what was detected.
     manifest = load_manifest(rc, result_file_path)
-    dataset = manifest.datasets['datasets/gov/example/resources']
+    dataset = manifest.datasets['datasets/gov/example']
     dataset.resources['resource1'].external = 'sqlite://'
     assert manifest == '''
-    d | r | b | m | property       | type    | ref     | source
-    datasets/gov/example/resources |         |         |
-      | resource1                  | sql     |         | sqlite://
-                                   |         |         |
-      |   |   | Country            |         |         | COUNTRY
-      |   |   |   | name           | string  |         | __NAME
-      |   |   |   | name_1         | string  |         | _NAME
-      |   |   |   | name_2         | string  |         | NAME
+    d | r | b | m | property | type    | ref | source
+    datasets/gov/example     |         |     |
+      | resource1            | sql     |     | sqlite://
+                             |         |     |
+      |   |   | Country      |         |     | COUNTRY
+      |   |   |   | name     | string  |     | __NAME
+      |   |   |   | name_1   | string  |     | _NAME
+      |   |   |   | name_2   | string  |     | NAME
     '''


### PR DESCRIPTION
Now you can do:

    spitna -o config=config.yml inspect -r sql mydb

Where `mydb` is an exsiting database from a config file.