### PR TITLE
Changelog fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,16 @@ Changes
 0.1.40 (unreleased)
 ===================
 
+Bug fixes:
+
+- Changes loads indefinitely (`#307`__). Cleaned empty patches, fixed
+  `:/changes/<offset>` API call, now it actually works. Also empty patches now
+  are not saved into the changelog.
+
+  __ https://github.com/atviriduomenys/spinta/issues/291
+
+- `wipe` action, now also resets changelog change id.
+
 
 0.1.39 (2022-10-12)
 ===================

--- a/spinta/backends/mongo/commands/changes.py
+++ b/spinta/backends/mongo/commands/changes.py
@@ -21,6 +21,11 @@ async def create_changelog_entry(
     else:
         table = backend.db[model.model.model_type() + '__changelog']
     async for data in dstream:
+
+        if not data.patch:
+            yield data
+            continue
+
         table.insert_one({
             '__id': data.saved['_id'] if data.saved else data.patch['_id'],
             '_revision': data.patch['_revision'] if data.patch else data.saved['_revision'],

--- a/spinta/backends/postgresql/commands/wipe.py
+++ b/spinta/backends/postgresql/commands/wipe.py
@@ -1,14 +1,18 @@
 import logging
+from typing import overload
 
 from spinta import commands
 from spinta.components import Context, Model
 from spinta.types.datatype import DataType
 from spinta.backends.constants import TableType
+from spinta.backends.helpers import get_table_name
 from spinta.backends.postgresql.components import PostgreSQL
+from spinta.backends.postgresql.helpers import get_pg_sequence_name
 
 log = logging.getLogger(__name__)
 
 
+@overload
 @commands.wipe.register(Context, Model, PostgreSQL)
 def wipe(context: Context, model: Model, backend: PostgreSQL):
     table = backend.get_table(model, fail=False)
@@ -22,20 +26,28 @@ def wipe(context: Context, model: Model, backend: PostgreSQL):
         return
 
     for prop in model.properties.values():
-        wipe(context, prop.dtype, backend)
+        commands.wipe(context, prop.dtype, backend)
 
     connection = context.get('transaction').connection
 
+    # Detele changelog table
     table = backend.get_table(model, TableType.CHANGELOG)
     connection.execute(table.delete())
 
+    # Reset changelog table sequence
+    table_name = get_table_name(model, TableType.CHANGELOG)
+    seqname = get_pg_sequence_name(table_name)
+    connection.execute(f'ALTER SEQUENCE "{seqname}" RESTART')
+
+    # Delete data table
     table = backend.get_table(model)
     connection.execute(table.delete())
 
 
+@overload
 @commands.wipe.register(Context, DataType, PostgreSQL)
 def wipe(context: Context, dtype: DataType, backend: PostgreSQL):
     same_backend = backend.name == dtype.backend.name
 
     if not same_backend:
-        wipe(context, dtype, dtype.backend)
+        commands.wipe(context, dtype, dtype.backend)

--- a/spinta/backends/postgresql/helpers/__init__.py
+++ b/spinta/backends/postgresql/helpers/__init__.py
@@ -22,3 +22,13 @@ def get_pg_name(name: str) -> str:
         j = NAMEDATALEN - i - hs - 2
         name = name[:i] + '_' + h + '_' + name[-j:]
     return name
+
+
+def get_pg_sequence_name(name: str) -> str:
+    suffix = '__id_seq'
+    slen = len(suffix)
+    nlen = len(name)
+    if nlen + slen > NAMEDATALEN:
+        trim = (nlen + slen) - NAMEDATALEN
+        name = name[:-trim]
+    return name + suffix

--- a/spinta/commands/read.py
+++ b/spinta/commands/read.py
@@ -356,7 +356,7 @@ async def changes(
             model.backend,
             id_=params.pk,
             limit=params.limit,
-            offset=params.offset,
+            offset=params.changes_offset,
         )
 
     select_tree = get_select_tree(context, action, params.select)

--- a/spinta/formats/html/helpers.py
+++ b/spinta/formats/html/helpers.py
@@ -73,7 +73,7 @@ def get_current_location(
         if changes:
             loc += [('Changes', None)]
         else:
-            loc += [('Changes', get_model_link(model, pk=pk, changes=[]))]
+            loc += [('Changes', get_model_link(model, pk=pk, changes=[-10]))]
 
     return loc
 
@@ -245,12 +245,29 @@ def get_template_context(context: Context, model, params: UrlParams):
     }
 
 
+def _get_output_format_link(fmt: str, params: UrlParams) -> str:
+    query = ''
+    change = {'format': [fmt]}
+
+    if params.changes:
+        params.changes_offset = -10
+        query = 'limit(100)'
+
+    params = params.changed_parsetree(change)
+    link = '/' + build_url_path(params)
+    if query:
+        link = link + '?' + query
+    return link
+
+
 def get_output_formats(params: UrlParams):
+    links = [
+        ('CSV', 'csv'),
+        ('JSON', 'json'),
+        ('JSONL', 'jsonl'),
+        ('ASCII', 'ascii'),
+    ]
     return [
-        # XXX I don't like that, there should be a better way to build links
-        #     from UrlParams instance.
-        ('CSV', '/' + build_url_path(params.changed_parsetree({'format': ['csv']}))),
-        ('JSON', '/' + build_url_path(params.changed_parsetree({'format': ['json']}))),
-        ('JSONL', '/' + build_url_path(params.changed_parsetree({'format': ['jsonl']}))),
-        ('ASCII', '/' + build_url_path(params.changed_parsetree({'format': ['ascii']}))),
+        (label, _get_output_format_link(fmt, params))
+        for label, fmt in links
     ]

--- a/spinta/testing/data.py
+++ b/spinta/testing/data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 from textwrap import indent
 from typing import Any
@@ -6,7 +8,10 @@ from typing import Dict
 from typing import List
 from typing import Union
 from typing import cast
+from typing import NamedTuple
+from typing import Optional
 
+import httpx
 import requests
 from pprintpp import pformat
 
@@ -142,3 +147,94 @@ def pushdata(app: TestClient, *args) -> Union[dict, list]:
         return sorted(data['_data'], key=lambda x: x['_id'])
     else:
         return data
+
+
+class Data(NamedTuple):
+    id: str
+    rev: str
+    data: Dict[str, Any]
+
+    @property
+    def sid(self):
+        if self.id:
+            return self.id[:8]
+
+    def update(self, data: Dict[str, Any]) -> Data:
+        return Data(id=self.id, rev=self.rev, data={**self.data, **data})
+
+
+def _obj_from_dict(data: Dict[str, Any]) -> Data:
+    return Data(
+        id=data.pop('_id', None),
+        rev=data.pop('_revision', None),
+        data=data,
+    )
+
+
+def send(
+    app: TestClient,
+    model: str,
+    action: str,
+    obj: Optional[Union[Data, Dict[str, Any]]] = None,
+    data: Optional[Dict[str, Any]] = None,
+    *,
+    select: Optional[List[str]] = None,
+    sort: Optional[Union[bool, str]] = None,
+    full: Optional[bool] = None,  # returns dicts instead of tuples
+) -> Union[Data, List[Data]]:
+    if obj is not None and isinstance(obj, dict):
+        obj = _obj_from_dict(obj)
+
+    if data is not None:
+        obj = obj.update(data)
+
+    if action == 'insert':
+        resp = app.post(model, json=obj.data)
+    elif action in 'patch':
+        resp = app.patch(f'{model}/{obj.id}', json={
+            **obj.data,
+            '_revision': obj.rev,
+        })
+    elif action in 'delete':
+        resp = app.delete(f'{model}/{obj.id}')
+    elif action == 'changes':
+        if obj:
+            resp = app.get(f'{model}/{obj.id}/:changes')
+        else:
+            resp = app.get(f'{model}/:changes')
+    elif action == 'getall':
+        resp = app.get(model)
+    elif action == 'getone':
+        resp = app.get(f'{model}/{obj.id}')
+    else:
+        resp = app.get(f'{model}/{action}')
+
+    if select is not None or sort is not None or full is not None:
+        if select is None:
+            select = []
+        if sort is None:
+            sort = False
+        if full is None:
+            full = True
+        return listdata(resp, *select, sort=sort, full=full)
+
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        dump = indent(pformat(obj.data), '  ').strip()
+        raise Exception(
+            f"send error:\n"
+            f"  model={model},\n"
+            f"  action={action},\n"
+            f"  error={e},\n  "
+            f"data: {dump}"
+        )
+
+    result = resp.json()
+
+    if '_data' in result:
+        return [_obj_from_dict(data) for data in result['_data']]
+
+    else:
+        return _obj_from_dict(result)
+

--- a/spinta/urlparams.py
+++ b/spinta/urlparams.py
@@ -160,7 +160,7 @@ def _prepare_urlparams_from_path(params: UrlParams):
             params.count = True
         elif name == 'changes':
             params.changes = True
-            params.changes_offset = args[0] if args else None
+            params.changes_offset = int(args[0]) if args else None
         elif name == 'format':
             if isinstance(args[0], dict) and args[0]['name'] == 'bind':
                 params.format = _read_format_params(args[0])

--- a/tests/backends/test_postgresql.py
+++ b/tests/backends/test_postgresql.py
@@ -1,8 +1,11 @@
+import pytest
+
 from spinta.components import Model, Property
 from spinta.backends.constants import TableType
 from spinta.backends.helpers import get_table_name
 from spinta.backends.postgresql.constants import NAMEDATALEN
 from spinta.backends.postgresql.helpers import get_pg_name
+from spinta.backends.postgresql.helpers import get_pg_sequence_name
 from spinta.testing.utils import get_error_codes, get_error_context
 
 
@@ -37,6 +40,16 @@ def test_get_table_name():
 def test_get_table_name_lists():
     assert _get_table_name('org', 'names', TableType.LIST) == 'org/:list/names'
     assert _get_table_name('org', 'names.note', TableType.LIST) == 'org/:list/names.note'
+
+
+@pytest.mark.parametrize('name,result', [
+    ('datasets/gov/example/City/:changelog',
+     'datasets/gov/example/City/:changelog__id_seq'),
+    ('datasets/gov/example_with_long_name/VeryLong_name/:changelog',
+     'datasets/gov/example_with_long_name/VeryLong_name/:chan__id_seq'),
+])
+def test_get_pg_sequence_name(name: str, result: str):
+    assert get_pg_sequence_name(name) == result
 
 
 def test_changes(app):

--- a/tests/formats/test_csv.py
+++ b/tests/formats/test_csv.py
@@ -76,9 +76,9 @@ def test_export_csv(app):
         for x in lines
     ]
     assert lines == [
-        ('patch', '', 'Latvia'),
-        ('insert', 'lv', 'LATVIA'),
         ('insert', 'lt', 'Lithuania'),
+        ('insert', 'lv', 'LATVIA'),
+        ('patch', '', 'Latvia'),
     ]
 
 

--- a/tests/formats/test_html.py
+++ b/tests/formats/test_html.py
@@ -167,7 +167,7 @@ def context_current_location(rc: RawConfig) -> Context:
         ('vpt', '/datasets/gov/vpt'),
         ('New data', '/datasets/gov/vpt/new'),
         ('Cities', None),
-        ('Changes', '/datasets/gov/vpt/new/City/:changes'),
+        ('Changes', '/datasets/gov/vpt/new/City/:changes/-10'),
     ]),
     ('/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08', [
         ('🏠', '/'),
@@ -177,7 +177,7 @@ def context_current_location(rc: RawConfig) -> Context:
         ('New data', '/datasets/gov/vpt/new'),
         ('Cities', '/datasets/gov/vpt/new/City'),
         ('0edc2281', None),
-        ('Changes', '/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08/:changes'),
+        ('Changes', '/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08/:changes/-10'),
     ]),
 ])
 def test_current_location(
@@ -230,14 +230,14 @@ def context_current_location_with_root(rc: RawConfig):
         ('🏠', '/'),
         ('New data', '/datasets/gov/vpt/new'),
         ('Cities', None),
-        ('Changes', '/datasets/gov/vpt/new/City/:changes'),
+        ('Changes', '/datasets/gov/vpt/new/City/:changes/-10'),
     ]),
     ('/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08', [
         ('🏠', '/'),
         ('New data', '/datasets/gov/vpt/new'),
         ('Cities', '/datasets/gov/vpt/new/City'),
         ('0edc2281', None),
-        ('Changes', '/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08/:changes'),
+        ('Changes', '/datasets/gov/vpt/new/City/0edc2281-f372-44a7-b0f8-e8d06ad0ce08/:changes/-10'),
     ]),
 ])
 def test_current_location_with_root(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from spinta.testing.manifest import prepare_manifest
 from spinta.utils.nestedstruct import flatten
 from spinta.testing.client import create_test_client
 from spinta.backends.memory.components import Memory
+from spinta.testing.data import send
 
 
 def _cleaned_context(
@@ -172,7 +173,7 @@ def test_model(model, context, app):
             ('backends', '/backends'),
             (backend, f'/backends/{backend}'),
             ('Report', None),
-            ('Changes', f"/{model}/:changes"),
+            ('Changes', f"/{model}/:changes/-10"),
         ],
         'empty': False,
         'header': [
@@ -245,7 +246,7 @@ def test_model_get(model, app):
             (backend, f'/backends/{backend}'),
             ('Report', f'/{model}'),
             (_id[:8], None),
-            ('Changes', f'/{model}/%s/:changes' % _id),
+            ('Changes', f'/{model}/%s/:changes/-10' % _id),
         ],
         'header': [
             '_type',
@@ -313,7 +314,7 @@ def test_dataset(app):
             ('datasets', '/datasets'),
             ('json', '/datasets/json'),
             ('rinkimai', None),
-            ('Changes', '/datasets/json/rinkimai/:changes'),
+            ('Changes', '/datasets/json/rinkimai/:changes/-10'),
         ],
         'header': ['_id', 'id', 'pavadinimas'],
         'empty': False,
@@ -396,7 +397,7 @@ def test_nested_dataset(app):
             ('dataset', '/datasets/nested/dataset'),
             ('name', '/datasets/nested/dataset/name'),
             ('model', None),
-            ('Changes', '/datasets/nested/dataset/name/model/:changes'),
+            ('Changes', '/datasets/nested/dataset/name/model/:changes/-10'),
         ],
         'header': ['_id', 'name'],
         'empty': False,
@@ -437,7 +438,7 @@ def test_dataset_key(app):
             ('json', '/datasets/json'),
             ('rinkimai', '/datasets/json/rinkimai'),
             (short_id(pk), None),
-            ('Changes', f'/datasets/json/rinkimai/{pk}/:changes'),
+            ('Changes', f'/datasets/json/rinkimai/{pk}/:changes/-10'),
         ],
         'formats': [
             ('CSV', f'/datasets/json/rinkimai/{pk}/:format/csv'),
@@ -464,35 +465,20 @@ def test_dataset_key(app):
 
 
 def test_changes_single_object(app: TestClient, mocker):
-    app.authmodel('datasets/json/rinkimai', ['upsert', 'changes'])
-    resp = app.post('/datasets/json/rinkimai', json={
-        '_op': 'upsert',
-        '_where': f'id="1"',
+    app.authmodel('datasets/json/rinkimai', ['insert', 'patch', 'changes'])
+
+    model = 'datasets/json/rinkimai'
+
+    obj = send(app, model, 'insert', {
         'id': '1',
         'pavadinimas': 'Rinkimai 1',
     })
-    data = resp.json()
-    assert resp.status_code == 201, data
-    pk = data['_id']
-    rev1 = data['_revision']
-    resp = app.post('/datasets/json/rinkimai', json={
-        '_op': 'upsert',
-        '_where': f'id="1"',
+    obj1 = send(app, model, 'patch', obj, {
         'id': '1',
         'pavadinimas': 'Rinkimai 2',
     })
-    assert resp.status_code == 200, resp.json()
-    data = resp.json()
-    rev2 = data['_revision']
-    assert rev1 != rev2
-    assert data == {
-        '_id': pk,
-        '_revision': rev2,
-        '_type': 'datasets/json/rinkimai',
-        'pavadinimas': 'Rinkimai 2',
-    }
 
-    resp = app.get(f'/datasets/json/rinkimai/{pk}/:changes', headers={
+    resp = app.get(f'/datasets/json/rinkimai/{obj.id}/:changes/-10', headers={
         'accept': 'text/html',
     })
     assert resp.status_code == 200
@@ -504,14 +490,14 @@ def test_changes_single_object(app: TestClient, mocker):
             ('datasets', '/datasets'),
             ('json', '/datasets/json'),
             ('rinkimai', '/datasets/json/rinkimai'),
-            (short_id(pk), f'/datasets/json/rinkimai/{pk}'),
+            (obj1.sid, f'/datasets/json/rinkimai/{obj.id}'),
             ('Changes', None),
         ],
         'formats': [
-            ('CSV', f'/datasets/json/rinkimai/{pk}/:changes/:format/csv'),
-            ('JSON', f'/datasets/json/rinkimai/{pk}/:changes/:format/json'),
-            ('JSONL', f'/datasets/json/rinkimai/{pk}/:changes/:format/jsonl'),
-            ('ASCII', f'/datasets/json/rinkimai/{pk}/:changes/:format/ascii'),
+            ('CSV', f'/{model}/{obj.id}/:changes/-10/:format/csv?limit(100)'),
+            ('JSON', f'/{model}/{obj.id}/:changes/-10/:format/json?limit(100)'),
+            ('JSONL', f'/{model}/{obj.id}/:changes/-10/:format/jsonl?limit(100)'),
+            ('ASCII', f'/{model}/{obj.id}/:changes/-10/:format/ascii?limit(100)'),
         ],
         'header': [
             '_cid',
@@ -526,54 +512,44 @@ def test_changes_single_object(app: TestClient, mocker):
         'empty': False,
         'data': [
             [
-                {'value': change[0]['_cid']},
+                {'value': 1},
                 {'value': change[0]['_created']},
-                {'value': 'upsert'},
-                {'value': short_id(pk), 'link': f'/datasets/json/rinkimai/{pk}'},
+                {'value': 'insert'},
+                {'value': obj.sid, 'link': f'/{model}/{obj.id}'},
                 {'value': change[0]['_txn']},
-                {'value': rev2},
-                {'value': '', 'color': '#f5f5f5'},
-                {'value': 'Rinkimai 2'},
-            ],
-            [
-                {'value': change[1]['_cid']},
-                {'value': change[1]['_created']},
-                {'value': 'upsert'},
-                {'value': short_id(pk), 'link': f'/datasets/json/rinkimai/{pk}'},
-                {'value': change[1]['_txn']},
-                {'value': rev1},
+                {'value': obj.rev},
                 {'value': '1'},
                 {'value': 'Rinkimai 1'},
+            ],
+            [
+                {'value': 2},
+                {'value': change[1]['_created']},
+                {'value': 'patch'},
+                {'value': obj.sid, 'link': f'/datasets/json/rinkimai/{obj.id}'},
+                {'value': change[1]['_txn']},
+                {'value': obj1.rev},
+                {'value': '', 'color': '#f5f5f5'},
+                {'value': 'Rinkimai 2'},
             ],
         ],
     }
 
 
 def test_changes_object_list(app, mocker):
-    app.authmodel('datasets/json/rinkimai', ['upsert', 'changes'])
+    app.authmodel('datasets/json/rinkimai', ['insert', 'patch', 'changes'])
 
-    resp = app.post('/datasets/json/rinkimai', json={
-        '_op': 'upsert',
-        '_where': f'id="1"',
+    model = 'datasets/json/rinkimai'
+
+    obj = send(app, model, 'insert', {
         'id': '1',
         'pavadinimas': 'Rinkimai 1',
     })
-    data = resp.json()
-    assert resp.status_code == 201, data
-    pk = data['_id']
-    rev1 = data['_revision']
-    resp = app.post('/datasets/json/rinkimai', json={
-        '_op': 'upsert',
-        '_where': f'id="1"',
+    obj1 = send(app, model, 'patch', obj, {
         'id': '1',
         'pavadinimas': 'Rinkimai 2',
     })
-    data = resp.json()
-    assert resp.status_code == 200, data
-    rev2 = data['_revision']
-    assert rev1 != rev2
 
-    resp = app.get('/datasets/json/rinkimai/:changes', headers={'accept': 'text/html'})
+    resp = app.get('/datasets/json/rinkimai/:changes/-10', headers={'accept': 'text/html'})
     assert resp.status_code == 200
 
     change = _cleaned_context(resp)['data']
@@ -582,14 +558,14 @@ def test_changes_object_list(app, mocker):
             ('🏠', '/'),
             ('datasets', '/datasets'),
             ('json', '/datasets/json'),
-            ('rinkimai', '/datasets/json/rinkimai'),
+            ('rinkimai', f'/{model}'),
             ('Changes', None),
         ],
         'formats': [
-            ('CSV', '/datasets/json/rinkimai/:changes/:format/csv'),
-            ('JSON', '/datasets/json/rinkimai/:changes/:format/json'),
-            ('JSONL', '/datasets/json/rinkimai/:changes/:format/jsonl'),
-            ('ASCII', '/datasets/json/rinkimai/:changes/:format/ascii'),
+            ('CSV', f'/{model}/:changes/-10/:format/csv?limit(100)'),
+            ('JSON', f'/{model}/:changes/-10/:format/json?limit(100)'),
+            ('JSONL', f'/{model}/:changes/-10/:format/jsonl?limit(100)'),
+            ('ASCII', f'/{model}/:changes/-10/:format/ascii?limit(100)'),
         ],
         'header': [
             '_cid',
@@ -604,24 +580,24 @@ def test_changes_object_list(app, mocker):
         'empty': False,
         'data': [
             [
-                {'value': change[0]['_cid']},
+                {'value': 1},
                 {'value': change[0]['_created']},
-                {'value': 'upsert'},
-                {'link': f'/datasets/json/rinkimai/{pk}', 'value': pk[:8]},
+                {'value': 'insert'},
+                {'link': f'/{model}/{obj.id}', 'value': obj.sid},
                 {'value': change[0]['_txn']},
-                {'value': rev2},
-                {'value': '', 'color': '#f5f5f5'},
-                {'value': 'Rinkimai 2'},
-            ],
-            [
-                {'value': change[1]['_cid']},
-                {'value': change[1]['_created']},
-                {'value': 'upsert'},
-                {'link': f'/datasets/json/rinkimai/{pk}', 'value': pk[:8]},
-                {'value': change[1]['_txn']},
-                {'value': rev1},
+                {'value': obj.rev},
                 {'value': '1'},
                 {'value': 'Rinkimai 1'},
+            ],
+            [
+                {'value': 2},
+                {'value': change[1]['_created']},
+                {'value': 'patch'},
+                {'link': f'/{model}/{obj.id}', 'value': obj.sid},
+                {'value': change[1]['_txn']},
+                {'value': obj1.rev},
+                {'value': '', 'color': '#f5f5f5'},
+                {'value': 'Rinkimai 2'},
             ],
         ],
     }

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,0 +1,87 @@
+import pytest
+
+from spinta.testing.data import send
+
+
+@pytest.mark.models(
+    'backends/postgres/report',
+    # 'backends/mongo/report',
+)
+def test_changes(model, context, app):
+    app.authmodel(model, ['insert', 'patch', 'changes'])
+    obj = send(app, model, 'insert', {'status': '1'})
+    obj = send(app, model, 'patch', obj, {'status': '2'})
+    obj = send(app, model, 'patch', obj, {'status': '3'})
+    obj = send(app, model, 'patch', obj, {'status': '4'})
+
+    assert send(app, model, 'changes', select=['_cid', '_op', 'status']) == [
+        {'_cid': 1, '_op': 'insert', 'status': '1'},
+        {'_cid': 2, '_op': 'patch', 'status': '2'},
+        {'_cid': 3, '_op': 'patch', 'status': '3'},
+        {'_cid': 4, '_op': 'patch', 'status': '4'},
+    ]
+
+    assert send(app, model, ':changes?limit(1)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 1, '_op': 'insert', 'status': '1'},
+    ]
+
+    assert send(app, model, ':changes/2?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 2, '_op': 'patch', 'status': '2'},
+        {'_cid': 3, '_op': 'patch', 'status': '3'},
+    ]
+
+    assert send(app, model, ':changes/3?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 3, '_op': 'patch', 'status': '3'},
+        {'_cid': 4, '_op': 'patch', 'status': '4'},
+    ]
+
+
+@pytest.mark.models(
+    'backends/postgres/report',
+    # 'backends/mongo/report',
+)
+def test_changes_negative_offset(model, context, app):
+    app.authmodel(model, ['insert', 'patch', 'changes'])
+    obj = send(app, model, 'insert', {'status': '1'})
+    obj = send(app, model, 'patch', obj, {'status': '2'})
+    obj = send(app, model, 'patch', obj, {'status': '3'})
+    obj = send(app, model, 'patch', obj, {'status': '4'})
+
+    assert send(app, model, ':changes/-1?limit(1)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 4, '_op': 'patch', 'status': '4'},
+    ]
+
+    assert send(app, model, ':changes/-2?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 3, '_op': 'patch', 'status': '3'},
+        {'_cid': 4, '_op': 'patch', 'status': '4'},
+    ]
+
+    assert send(app, model, ':changes/-3?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 2, '_op': 'patch', 'status': '2'},
+        {'_cid': 3, '_op': 'patch', 'status': '3'},
+    ]
+
+    assert send(app, model, ':changes/-4?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 1, '_op': 'insert', 'status': '1'},
+        {'_cid': 2, '_op': 'patch', 'status': '2'},
+    ]
+
+    assert send(app, model, ':changes/-5?limit(2)', select=['_cid', '_op', 'status']) == [
+        {'_cid': 1, '_op': 'insert', 'status': '1'},
+        {'_cid': 2, '_op': 'patch', 'status': '2'},
+    ]
+
+
+@pytest.mark.models(
+    'backends/postgres/report',
+    # 'backends/mongo/report',
+)
+def test_changes_empty_patch(model, context, app):
+    app.authmodel(model, ['insert', 'patch', 'changes'])
+    obj = send(app, model, 'insert', {'status': '1'})
+    obj = send(app, model, 'patch', obj, {'status': '1'})
+    obj = send(app, model, 'patch', obj, {'status': '1'})
+
+    assert send(app, model, ':changes', select=['_cid', '_op', 'status']) == [
+        {'_cid': 1, '_op': 'insert', 'status': '1'},
+    ]


### PR DESCRIPTION
- Do not save empty changes.

- Fix `:changes/<offset>`, previously offset was read from `?offset(<offset>)`.

- Changes changelog order, now changes starts from oldest to newest as it should be.

- `wipe` action now also restarts changelog sequence.