### PR TITLE
Fix PostgreSQL issue on spinta bootstrap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,22 @@ Changes
 0.1.57 (unreleased)
 ===================
 
+New features:
+
+- Add support for array type in tabular manifests (`#161`__).
+
+  __ https://github.com/atviriduomenys/spinta/issues/161
+
+Bug fixes:
+
+- Fixed pagination error with date types (`#516`__).
+
+  __ https://github.com/atviriduomenys/spinta/issues/516
+
+- Fix issue with old SQLite versions used for keymaps (`#518`__).
+
+  __ https://github.com/atviriduomenys/spinta/issues/518
+
 
 0.1.56 (2023-09-30)
 ===================

--- a/spinta/backends/postgresql/commands/bootstrap.py
+++ b/spinta/backends/postgresql/commands/bootstrap.py
@@ -10,4 +10,8 @@ def bootstrap(context: Context, backend: PostgreSQL):
     #      line.
     # TODO: update appropriate rows in _schema and save `applied` date
     #       of schema migration
-    backend.schema.create_all(checkfirst=True)
+    with (
+        backend.engine.connect().
+        execution_options(isolation_level='AUTOCOMMIT')
+    ) as conn:
+        backend.schema.create_all(conn, checkfirst=True)


### PR DESCRIPTION
When there are too many tables to create or drop, PostgreSQL runs out of memory. The fix is to run quries with autocommit.