### PR TITLE
544 client files are not migrated on spinta start

### DIFF
--- a/spinta/auth.py
+++ b/spinta/auth.py
@@ -769,10 +769,8 @@ def create_client_file_name_id_mapping(path: pathlib.Path):
     yml.dump(keymap, keymap_path)
 
 
-def handle_auth_client_files(context: Context):
-    config = context.get('config')
+def handle_auth_client_files(config: Config):
     path = get_clients_path(config)
-
     if path.exists():
         if not (path / 'id').exists():
             items = os.listdir(path)

--- a/spinta/cli/helpers/store.py
+++ b/spinta/cli/helpers/store.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from spinta import commands
-from spinta.auth import auth_server_keys_exists, handle_auth_client_files, client_name_exists, get_clients_path
+from spinta.auth import auth_server_keys_exists, client_name_exists, get_clients_path
 from spinta.auth import create_client_file
 from spinta.auth import gen_auth_server_keys
 from spinta.components import Config
@@ -62,7 +62,6 @@ def load_config(
 ) -> Config:
     config = context.get('config')
     commands.load(context, config)
-    handle_auth_client_files(context)
     if ensure_config_dir:
         _ensure_config_dir(
             config,

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -4,7 +4,7 @@ from typing import Type
 
 from ruamel.yaml import YAML
 
-from spinta.auth import client_name_exists, get_clients_path
+from spinta.auth import client_name_exists, get_clients_path, handle_auth_client_files
 from spinta.formats.components import Format
 from spinta.core.config import DEFAULT_CONFIG_PATH
 from spinta.core.config import DEFAULT_DATA_PATH
@@ -96,6 +96,8 @@ def load(context: Context, config: Config) -> Config:
             "Configuration option `mode` must be added to a manifest, now it "
             "is added to the config root."
         )
+    # Ensure that client filed were migrated
+    handle_auth_client_files(config)
 
     return config
 


### PR DESCRIPTION
Moved migration to commands.load[Context, Config].

Also as a reminder, in case migrations were corrupted, you can delete id folder and it will migrate again. Currently the check to see if migrations are needed, is to check if id folder exists.