### PR TITLE
More explicit error message for unknown column type in SQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,6 @@ Changes
 0.1.63 (unreleased)
 ===================
 
-New features:
-
-- More explicit error message for unknown column type in SQL
 
 0.1.62 (2024-02-29)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 0.1.63 (unreleased)
 ===================
 
+New features:
+
+- More explicit error message for unknown column type in SQL
 
 0.1.62 (2024-02-29)
 ===================

--- a/spinta/manifests/sql/helpers.py
+++ b/spinta/manifests/sql/helpers.py
@@ -196,7 +196,7 @@ def _read_props(
             }
 
         else:
-            dtype = get_column_type(col, table)
+            dtype = _get_column_type(col, table)
 
         yield prop, {
             'type': dtype,

--- a/spinta/manifests/sql/helpers.py
+++ b/spinta/manifests/sql/helpers.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import Any
+from typing import Any, TypedDict
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -239,7 +239,11 @@ TYPES = [
 ]
 
 
-def _get_column_type(column: dict, table: str = None) -> str:
+class _Column(TypedDict):
+    type: TypeEngine
+
+
+def _get_column_type(column: _Column, table: str = None) -> str:
     column_type: TypeEngine = column["type"]
     for cls, name in TYPES:
         if isinstance(column_type, cls):

--- a/spinta/manifests/sql/helpers.py
+++ b/spinta/manifests/sql/helpers.py
@@ -196,7 +196,7 @@ def _read_props(
             }
 
         else:
-            dtype = _get_type(col['type'])
+            dtype = get_column_type(col, table)
 
         yield prop, {
             'type': dtype,
@@ -239,11 +239,12 @@ TYPES = [
 ]
 
 
-def _get_type(sql_type: TypeEngine) -> str:
+def _get_column_type(column: dict, table: str = None) -> str:
+    column_type: TypeEngine = column["type"]
     for cls, name in TYPES:
-        if isinstance(sql_type, cls):
+        if isinstance(column_type, cls):
             return name
-    raise TypeError(f"Unknown type {sql_type!r}.")
+    raise TypeError(f"Unknown type {column_type!r} of column {column!r} in table {table!r}.")
 
 
 class _Ref(NamedTuple):

--- a/tests/datasets/sql/test_inspect.py
+++ b/tests/datasets/sql/test_inspect.py
@@ -4,4 +4,10 @@ from spinta.manifests.sql.helpers import _get_column_type
 
 
 def test_char_type():
-    assert _get_column_type(mysql.CHAR()) == 'string'
+    column = {
+        "name": "test",
+        "type": mysql.CHAR()
+    }
+    table = "test"
+
+    assert _get_column_type(column, table) == 'string'

--- a/tests/datasets/sql/test_inspect.py
+++ b/tests/datasets/sql/test_inspect.py
@@ -1,7 +1,7 @@
 from sqlalchemy.dialects import mysql
 
-from spinta.manifests.sql.helpers import get_column_type
+from spinta.manifests.sql.helpers import _get_column_type
 
 
 def test_char_type():
-    assert get_column_type(mysql.CHAR()) == 'string'
+    assert _get_column_type(mysql.CHAR()) == 'string'

--- a/tests/datasets/sql/test_inspect.py
+++ b/tests/datasets/sql/test_inspect.py
@@ -1,7 +1,7 @@
 from sqlalchemy.dialects import mysql
 
-from spinta.manifests.sql.helpers import _get_type
+from spinta.manifests.sql.helpers import get_column_type
 
 
 def test_char_type():
-    assert _get_type(mysql.CHAR()) == 'string'
+    assert get_column_type(mysql.CHAR()) == 'string'


### PR DESCRIPTION
another option would be to catch the error in the `read_props` and reraise with the traceback (I found a way: https://stackoverflow.com/a/72300659/2114935)
