### PR TITLE
979: fix no predefined key when collecting multi ref params

### DIFF
--- a/spinta/manifests/internal_sql/helpers.py
+++ b/spinta/manifests/internal_sql/helpers.py
@@ -872,7 +872,7 @@ def _params_to_sql(
                     'mpath': new_mpath,
                     'dim': 'param',
                     'name': param.name,
-                    'type': 'param',
+                    'type': param.type,
                     'ref': param.name,
                     'source': source,
                     'title': param.title,
@@ -1390,7 +1390,7 @@ def _convert_param(row: InternalManifestRow, param_data: InternalManifestRow, fi
         new["title"] = ''
         new["description"] = ''
     else:
-        new["type"] = 'param'
+        new["type"] = _value_or_empty(param_data["type"])
         new["ref"] = _value_or_empty(param_data["ref"])
         new["title"] = _value_or_empty(param_data["title"])
         new["description"] = _value_or_empty(param_data["description"])

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1432,9 +1432,10 @@ class ParamReader(TabularReader):
             self._check_param_name(node, self.name)
             self._ensure_params_list(node, self.name)
         params  = node.data['params']
-        if not self.name in params:
+        if self.name not in params:
             params[self.name] = self._get_data(self.name, row)
-        # self._get_and_append_data(params[self.name], row)
+        else:
+            self._get_and_append_data(params[self.name], row)
 
     def release(self, reader: TabularReader = None) -> bool:
         return not isinstance(reader, (AppendReader, LangReader))

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1434,7 +1434,7 @@ class ParamReader(TabularReader):
         params  = node.data['params']
         if not self.name in params:
             params[self.name] = self._get_data(self.name, row)
-        self._get_and_append_data(params[self.name], row)
+        # self._get_and_append_data(params[self.name], row)
 
     def release(self, reader: TabularReader = None) -> bool:
         return not isinstance(reader, (AppendReader, LangReader))

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1388,6 +1388,7 @@ class ParamReader(TabularReader):
     def _get_data(self, name: str, row: ManifestRow):
         return {
             'name': name,
+            'type': row['type'],
             'source': [row[SOURCE]],
             'prepare': [_parse_spyna(self, row[PREPARE])],
             'title': row[TITLE],
@@ -2286,7 +2287,7 @@ def _params_to_tabular(params: List[Param]) -> Iterator[ManifestRow]:
                 prepare = spyna.unparse(prepare)
             if i == 0:
                 yield torow(DATASET, {
-                    'type': 'param',
+                    'type': param.type,
                     'ref': param.name,
                     'source': source,
                     'prepare': prepare,

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1431,8 +1431,10 @@ class ParamReader(TabularReader):
             self.name = row[REF]
             self._check_param_name(node, self.name)
             self._ensure_params_list(node, self.name)
-
-        self._get_and_append_data(node.data['params'][self.name], row)
+        params  = node.data['params']
+        if not self.name in params:
+            params[self.name] = self._get_data(self.name, row)
+        self._get_and_append_data(params[self.name], row)
 
     def release(self, reader: TabularReader = None) -> bool:
         return not isinstance(reader, (AppendReader, LangReader))

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -806,6 +806,22 @@ def test_resource_param_multiple(manifest_type, tmp_path, rc):
     ''', manifest_type)
 
 
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_resource_param_multiple_prepare_body(manifest_type, tmp_path, rc):
+    check(tmp_path, rc,'''
+    d | r | b | m | property  | type    | ref    | source      | prepare
+    test_dataset              |         |        |             |
+      | resource1             | xml     |        |             |
+                              | param   | param1 | param1      | body()
+                              | param   | param2 | param2      | body()
+                              | param   | param3 | param3      | body()
+                              |         |        |             |
+      |   |   | Continent     |         |        |             |
+      |   |   |   | name      | string  |        | name/text() |
+      |   |   |   | id        | integer |        | name/text() |
+    ''', manifest_type)
+
+
 def test_multiline_prepare(tmp_path, rc):
     check(tmp_path, rc, '''
     d | r | b | m | property   | type    | ref     | source   | prepare

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -807,14 +807,14 @@ def test_resource_param_multiple(manifest_type, tmp_path, rc):
 
 
 @pytest.mark.manifests('internal_sql', 'csv')
-def test_resource_param_multiple_prepare_body(manifest_type, tmp_path, rc):
+def test_resource_param_multiple_prepare_type_is_empty(manifest_type, tmp_path, rc):
     check(tmp_path, rc,'''
     d | r | b | m | property  | type    | ref    | source      | prepare
     test_dataset              |         |        |             |
       | resource1             | xml     |        |             |
                               | param   | param1 | param1      | body()
-                              | param   | param2 | param2      | body()
-                              | param   | param3 | param3      | body()
+                              |         | param2 | param2      | body()
+                              |         | param3 | param3      | body()
                               |         |        |             |
       |   |   | Continent     |         |        |             |
       |   |   |   | name      | string  |        | name/text() |


### PR DESCRIPTION
This Pull Request fixes a couple of bugs that were raised for the following DSA:

```
d | r | b | m | property  | type    | ref    | source      | prepare
test_dataset              |         |        |             |
  | resource1             | xml     |        |             |
                          | param   | param1 | param1      | body()
                          |         | param2 | param2      | body()
                          |         | param3 | param3      | body()
                          |         |        |             |
  |   |   | Continent     |         |        |             |
  |   |   |   | name      | string  |        | name/text() |
  |   |   |   | id        | integer |        | name/text() |
```

1. Issue with ```_get_and_append_data()``` in ```ParamReader```:
The flow was being broken due to a ```KeyError: 'param2'```. This error occurred because the method was trying to access a key (```params['param2']```) that wasn't present in the dictionary.

**Fix:**

- An ```if``` condition was added to check if the key exists in the ```params``` dictionary.
- If the key does not exist, it is now added with the appropriate data.
2. Static ```param``` type added to DSA:
When running the command ```spinta show/copy``` with the provided DSA, it was incorrectly adding a param type to the parameters, which was not originally written in the DSA:

```
d | r | b | m | property  | type    | ref    | source      | prepare
test_dataset              |         |        |             |
  | resource1             | xml     |        |             |
                          | param   | param1 | param1      | body()
                          | param   | param2 | param2      | body()
                          | param   | param3 | param3      | body()
                          |         |        |             |
  |   |   | Continent     |         |        |             |
  |   |   |   | name      | string  |        | name/text() |
  |   |   |   | id        | integer |        | name/text() |
```
**Fix**:
- The ```type``` key is now dynamically set based on the row in the ```_get_data()``` method.
- This type is then correctly retrieved in the ```torow()``` method.
- Additionally, the issue is resolved in the```internal_sql``` manifests by ensuring that the type is returned in the ```_convert_param()``` method from the ```param_data``` dictionary.