### PR TITLE
978: fix enum None values under source column ignored during null-check handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ manifest.*
 /keymaps.db
 /.vscode/
 /reports/
+/config.yml
+/manifest.csv

--- a/spinta/datasets/backends/dataframe/commands/read.py
+++ b/spinta/datasets/backends/dataframe/commands/read.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from spinta import commands
 from spinta.components import Context, Property, Model
-from spinta.core.ufuncs import Expr
+from spinta.core.ufuncs import Expr, Env
 from spinta.datasets.backends.dataframe.components import DaskBackend
 from spinta.datasets.backends.dataframe.backends.json.components import Json
 from spinta.datasets.backends.dataframe.backends.csv.components import Csv
@@ -94,11 +94,17 @@ def _get_row_value(context: Context, row: Any, sel: Any) -> Any:
                     external=sel.prop.external.name,
                 )
 
-        if enum := get_prop_enum(sel.prop):
+        if enum_options := get_prop_enum(sel.prop):
+            env = Env(context)(this=sel.prop)
+            for enum_option in enum_options.values():
+                if isinstance(enum_option.prepare, Expr):
+                    val = env.call(enum_option.prepare.name, str(val), *enum_option.prepare.args)
+                    if val:
+                        break
             if val is None:
                 pass
-            elif str(val) in enum:
-                item = enum[str(val)]
+            elif str(val) in enum_options:
+                item = enum_options[str(val)]
                 if item.prepare is not NA:
                     val = item.prepare
             else:

--- a/spinta/dimensions/enum/commands.py
+++ b/spinta/dimensions/enum/commands.py
@@ -3,6 +3,7 @@ from typing import overload
 
 from spinta import commands
 from spinta.components import Context
+from spinta.core.ufuncs import Expr
 from spinta.types.datatype import DataType
 from spinta.types.datatype import Integer
 from spinta.types.datatype import String
@@ -25,6 +26,16 @@ def check(
         f"property type, which is {dtype.name!r}."
     ))
 
+
+@overload
+@commands.check.register(Context, EnumItem, DataType, Expr)
+def check(
+    context: Context,
+    item: EnumItem,
+    dtype: DataType,
+    value: Expr,
+):
+    pass
 
 @overload
 @commands.check.register(Context, EnumItem, DataType, type(None))

--- a/spinta/dimensions/enum/ufuncs.py
+++ b/spinta/dimensions/enum/ufuncs.py
@@ -1,9 +1,27 @@
-from spinta.core.ufuncs import ufunc
+from typing import overload, Any
+
+from spinta.core.ufuncs import ufunc, Expr, Env
 from spinta.dimensions.enum.components import EnumFormula
 from spinta.exceptions import FormulaError
+from spinta.ufuncs.resultbuilder.components import EnumResultBuilder
 
 
 @ufunc.resolver(EnumFormula, str)
 def bind(env: EnumFormula, name: str) -> None:
-    raise FormulaError(env.node, formula=name, error="Binds are not supported.")
+    raise FormulaError(env.node, formula=name, error="Enum Binds (property names) are not supported.")
 
+@overload
+@ufunc.resolver(EnumResultBuilder, Expr)
+def swap(env: EnumResultBuilder, expr: Expr) -> Any:
+    """ Should be invoked on ResultBuild. When data goes through."""
+    args, kwargs = expr.resolve(env)
+    new_value =  env.call('swap', *args, **kwargs)
+    if env.this != new_value:
+        env.has_value_changed = True
+    return new_value
+
+@overload
+@ufunc.resolver(Env, Expr)
+def swap(env: Env, expr: Expr) -> Any:
+    args, kwargs = expr.resolve(env)
+    return Expr('swap', *args, **kwargs)

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1484,7 +1484,8 @@ class EnumReader(TabularReader):
             return
 
         # FIXME AST should be handled by Env
-        source = str(row[SOURCE])
+        source = row[SOURCE]
+        source = str(source) if source else None
         if not source:
             prepare = _parse_spyna(self, row[PREPARE])
             if isinstance(prepare, dict):

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1876,7 +1876,7 @@ def _read_xlsx_manifest(path: str) -> Iterator[Tuple[str, List[str]]]:
 
         empty_rows = _empty_rows_counter()
         for i, row in enumerate(rows, 2):
-            row = [row[c] if c is not None else None for c in cols]
+            row = [row[c] or "" if c is not None else None for c in cols]
             yield f'{sheet.title}:{i}', row
 
             if empty_rows(row) > 100:

--- a/spinta/ufuncs/common.py
+++ b/spinta/ufuncs/common.py
@@ -1,17 +1,12 @@
-from typing import Any
-from typing import Tuple
-from typing import overload
+from typing import Any, Tuple, overload
 
-from spinta.core.ufuncs import Env
-from spinta.core.ufuncs import Expr
-from spinta.core.ufuncs import ufunc
+from spinta.core.ufuncs import Env, Expr, ufunc
 
 
 @overload
 @ufunc.resolver(Env, object, object)
 def swap(env: Env, old: Any, new: Any) -> Any:
     return env.call('swap', env.this, old, new)
-
 
 @overload
 @ufunc.resolver(Env, object, object, object)

--- a/spinta/ufuncs/resultbuilder/components.py
+++ b/spinta/ufuncs/resultbuilder/components.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from spinta.components import Property
 from spinta.core.ufuncs import Env
+from spinta.dimensions.enum.components import EnumItem
 
 
 class ResultBuilder(Env):
@@ -14,4 +15,13 @@ class ResultBuilder(Env):
             this=this,
             prop=prop,
             data=data,
+        )
+
+class EnumResultBuilder(Env):
+    this: EnumItem
+    has_value_changed: bool = False
+
+    def init(self, this: EnumItem):
+        return self(
+            this=this
         )

--- a/spinta/ufuncs/resultbuilder/helpers.py
+++ b/spinta/ufuncs/resultbuilder/helpers.py
@@ -5,11 +5,11 @@ from multipledispatch import dispatch
 
 from spinta.backends import Backend
 from spinta.components import Context, Property
-from spinta.core.ufuncs import Expr
+from spinta.core.ufuncs import Expr, Env
 from spinta.dimensions.enum.helpers import get_prop_enum
 from spinta.exceptions import ValueNotInEnum
 from spinta.ufuncs.querybuilder.components import Selected
-from spinta.ufuncs.resultbuilder.components import ResultBuilder
+from spinta.ufuncs.resultbuilder.components import ResultBuilder, EnumResultBuilder
 from spinta.utils.schema import NA
 
 ResultBuilderGetter = abc.Callable[[], ResultBuilder]
@@ -138,7 +138,7 @@ def _get_row_value(
     row: Any,
     sel: Any,
     check_enums: bool,
-    result_builder_getter: Union[ResultBuilderGetter, ResultBuilder]
+    result_builder_getter: Union[ResultBuilderGetter, ResultBuilder],
 ):
     if isinstance(sel, Selected):
         if isinstance(sel.prep, Expr):
@@ -164,7 +164,16 @@ def _get_row_value(
                         val = item.prepare
                 else:
                     raise ValueNotInEnum(sel.prop, value=val)
-
+        elif enum_options := get_prop_enum(sel.prop):
+            for enum_option in enum_options.values():
+                if isinstance(enum_option.prepare, Expr):
+                    env = EnumResultBuilder(context).init(val)
+                    val = env.resolve(enum_option.prepare)
+                    if env.has_value_changed:
+                        break
+                elif enum_option.source and enum_option.prepare and enum_option.source == val:
+                    val = enum_option.prepare
+                    break
         return val
     if isinstance(sel, tuple):
         return tuple(_get_row_value(context, row, v, check_enums, result_builder_getter) for v in sel)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -173,3 +173,53 @@ def test_check_names_dataset(
         commands.check(context, manifest)
 
     assert e.value.message == "Invalid 'datasets/gov/Example' namespace code name."
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_values_under_source(manifest_type , tmp_path, rc):
+    context, manifest = load_manifest_and_context(rc, '''
+    d | r | b | m | property   | type    | ref | source     | prepare
+    test_dataset               |         |     |            |        
+      | resource1              | xml     |     |            |         
+      |   |   | Country        |         |     | Country    |        
+      |   |   |   | driving    | string  |     |            |        
+      |   |   |   |            | enum    |     | 'left'     |        
+      |   |   |   |            |         |     | 'right'    |        
+        ''', manifest_type=manifest_type, tmp_path=tmp_path)
+    commands.check(context, manifest)
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_values_under_prepare(manifest_type , tmp_path, rc):
+    context, manifest = load_manifest_and_context(rc, '''
+    d | r | b | m | property   | type    | ref | source     | prepare
+    test_dataset               |         |     |            |        
+      | resource1              | xml     |     |            |         
+      |   |   | Country        |         |     | Country    |        
+      |   |   |   | driving    | string  |     |            |        
+      |   |   |   |            | enum    |     |            | 'left'  
+      |   |   |   |            |         |     |            | 'right' 
+        ''', manifest_type=manifest_type, tmp_path=tmp_path)
+    commands.check(context, manifest)
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_values_under_source_transforms_into_prepare_value(manifest_type , tmp_path, rc):
+    context, manifest = load_manifest_and_context(rc, '''
+    d | r | b | m | property   | type    | ref | source     | prepare
+    test_dataset               |         |     |            |        
+      | resource1              | xml     |     |            |         
+      |   |   | Country        |         |     | Country    |        
+      |   |   |   | driving    | string  |     |            |        
+      |   |   |   |            | enum    |     | "1"        | "2"    
+        ''', manifest_type=manifest_type, tmp_path=tmp_path)
+    commands.check(context, manifest)
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_null_under_prepare(manifest_type , tmp_path, rc):
+    context, manifest = load_manifest_and_context(rc, '''
+    d | r | b | m | property   | type    | ref | source     | prepare
+    test_dataset               |         |     |            |        
+      | resource1              | xml     |     |            |         
+      |   |   | Country        |         |     | Country    |        
+      |   |   |   | driving    | string  |     |            |           
+      |   |   |   |            | enum    |     |            | null
+        ''', manifest_type=manifest_type, tmp_path=tmp_path)
+    commands.check(context, manifest)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,13 +1,11 @@
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 from spinta import commands
 from spinta.core.config import RawConfig
-from spinta.testing.manifest import load_manifest_and_context, load_manifest
-from spinta.testing.manifest import load_manifest_get_context
-from spinta.exceptions import InvalidValue
-from spinta.exceptions import InvalidName
+from spinta.exceptions import InvalidName, InvalidValue
+from spinta.testing.manifest import load_manifest_and_context, load_manifest, load_manifest_get_context
 from spinta.testing.tabular import create_tabular_manifest
 
 
@@ -223,3 +221,31 @@ def test_check_enum_null_under_prepare(manifest_type , tmp_path, rc):
       |   |   |   |            | enum    |     |            | null
         ''', manifest_type=manifest_type, tmp_path=tmp_path)
     commands.check(context, manifest)
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_swap_null_under_prepare(manifest_type , tmp_path, rc):
+    context, manifest = load_manifest_and_context(rc, '''
+    d | r | b | m | property   | type    | ref | source     | prepare
+    test_dataset               |         |     |            |        
+      | resource1              | xml     |     |            |         
+      |   |   | Country        |         |     | Country    |        
+      |   |   |   | driving    | string  |     |            |             
+      |   |   |   |            | enum    |     |            | swap(null, '-')
+        ''', manifest_type=manifest_type, tmp_path=tmp_path)
+    commands.check(context, manifest)
+
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_check_enum_swap_param_validation_under_prepare(manifest_type , tmp_path, rc):
+    with pytest.raises(InvalidValue) as e:
+        context, manifest = load_manifest_and_context(rc, '''
+        d | r | b | m | property   | type    | ref | source     | prepare
+        test_dataset               |         |     |            |        
+          | resource1              | xml     |     |            |         
+          |   |   | Country        |         |     | Country    |        
+          |   |   |   | driving    | integer |     |            |             
+          |   |   |   |            | enum    |     |            | swap(null, '-')
+          |   |   |   |            |         |     |            | '-'
+            ''', manifest_type=manifest_type, tmp_path=tmp_path)
+        commands.check(context, manifest)
+        assert e.value.message == "Invalid value."
+


### PR DESCRIPTION
Tested according to https://github.com/ivpk/dsa/issues/46 except for `noop()` and `empty()` parts as those will be implemented under another tickets.
In short what was fixed under this PR:

Under check/copy process:
- enum values under prepare for ASCII DSA
- enum values under prepare for CSV DSA
- enum values under prepare for XLSX DSA
- swap ufunc under the prepare column and validation of the parameters for ASCII DSA
- swap ufunc under the prepare column and validation of the parameters for CSV DSA
- swap ufunc under the prepare column and validation of the parameters for XLSX DSA


Under data ingestion process (**read action only**):
 - covered in tests replacement logic from source to prepare for ASCII, CSV:
```
type  | source | prepare
enum  | 1      | 2

```
- swap ufunc unde prepare for ASCII, CSV:
```
type  | source | prepare
enum  |        | swap(null, '-')
```
- null under prepare for ASCII, CSV:
```
type  | source | prepare
enum  |        | null

```

**XLSX not implemented as backend is not yet supported.**


Updating git ignore as well to exclude configuration files used in the local environment under default names (config.yml, manifest.csv)

## Related

- https://github.com/atviriduomenys/spinta/issues/978
- https://github.com/ivpk/dsa/issues/46