### PR TITLE
[#999] Fix language tag property as reference error

### DIFF
--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -303,7 +303,7 @@ class ModelReferenceNotFound(BaseError):
 
 
 class ModelReferenceKeyNotFound(BaseError):
-    template = "Model reference key {ref!r} not found in {model!r}."
+    template = "Model reference key {ref!r} not found in model that is being referenced {referenced_model!r}."
 
 
 class SourceNotSet(UserError):

--- a/spinta/types/array/link.py
+++ b/spinta/types/array/link.py
@@ -35,7 +35,7 @@ def link(context: Context, dtype: Array) -> None:
         raw_refprops: List[str] = dtype.refprops
         for rprop in raw_refprops:
             if rprop not in dtype.model.properties:
-                raise ModelReferenceKeyNotFound(dtype, ref=rprop, model=dtype.model)
+                raise ModelReferenceKeyNotFound(dtype, ref=rprop, referenced_model=dtype.model.name, model=dtype.prop.model.name)
             refprops.append(dtype.model.properties[rprop])
         dtype.refprops = refprops
         dtype.explicit = True

--- a/spinta/types/ref/link.py
+++ b/spinta/types/ref/link.py
@@ -29,9 +29,9 @@ def link(context: Context, dtype: Ref) -> None:
         # XXX: https://github.com/atviriduomenys/spinta/issues/44
         raw_refprops: List[str] = dtype.refprops
         for rprop in raw_refprops:
-            if rprop not in dtype.model.properties:
+            if not (prop := dtype.model.get_from_flatprops(rprop)):
                 raise ModelReferenceKeyNotFound(dtype, ref=rprop, model=dtype.model)
-            refprops.append(dtype.model.properties[rprop])
+            refprops.append(prop)
         dtype.refprops = refprops
         dtype.explicit = True
     elif dtype.model.external:

--- a/spinta/types/ref/link.py
+++ b/spinta/types/ref/link.py
@@ -29,8 +29,8 @@ def link(context: Context, dtype: Ref) -> None:
         # XXX: https://github.com/atviriduomenys/spinta/issues/44
         raw_refprops: List[str] = dtype.refprops
         for rprop in raw_refprops:
-            if not (prop := dtype.model.get_from_flatprops(rprop)):
-                raise ModelReferenceKeyNotFound(dtype, ref=rprop, model=dtype.model)
+            if not (prop := dtype.model.flatprops.get(rprop)):
+                raise ModelReferenceKeyNotFound(dtype, ref=rprop, referenced_model=dtype.model.name, model=dtype.prop.model.name)
             refprops.append(prop)
         dtype.refprops = refprops
         dtype.explicit = True

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1120,6 +1120,22 @@ def test_text_prop_as_reference(manifest_type, tmp_path, rc):
 
 
 @pytest.mark.manifests('internal_sql', 'csv')
+def test_not_primary_key_text_property_as_reference(manifest_type, tmp_path, rc):
+    check(tmp_path, rc, '''
+        d | r | b | m | property               | type    | ref              | access | title
+        example                                |         |                  |        |
+                                               |         |                  |        |
+          |   |   | Country                    |         | name@lt          |        |
+          |   |   |   | name@lt                | text    |                  | open   |
+          |   |   |   | name@en                | text    |                  | open   |
+                                               |         |                  |        |
+          |   |   | City                       |         | name@en          |        |
+          |   |   |   | name@en                | text    |                  | open   |
+          |   |   |   | country                | ref     | Country[name@en] | open   |
+        ''', manifest_type)
+
+
+@pytest.mark.manifests('internal_sql', 'csv')
 def test_prop_multi_nested_exposed_text(manifest_type, tmp_path, rc):
     check(tmp_path, rc, '''
         d | r | b | m | property               | type    | ref       | access | title


### PR DESCRIPTION
`Country[name@en]` was raising an error that the `name@en` property could not be found on the referenced model. Fixing it by searching for the name not in `model.properties`, but rather, in `get_from_flatprops()`.

spinta check returns OK as well as spinta copy returns the same as is given:

```python
(spinta-py3.9) ➜  spinta git:(ft/999-language-tag-property-as-ref) ✗ spinta copy test_files/999_5.xlsx
id | d | r | b | m | property | type   | ref              | source | prepare | level | access | uri | title | description
   | example                  |        |                  |        |         |       |        |     |       |
   |                          |        |                  |        |         |       |        |     |       |
   |   |   |   | Country      |        | name@lt          |        |         |       |        |     |       |
   |   |   |   |   | name@lt  | string |                  |        |         |       |        |     |       |
   |   |   |   |   | name@en  | string |                  |        |         |       |        |     |       |
   |                          |        |                  |        |         |       |        |     |       |
   |   |   |   | City         |        | name@en          |        |         |       |        |     |       |
   |   |   |   |   | name@en  | string |                  |        |         |       |        |     |       |
   |   |   |   |   | country  | ref    | Country[name@en] |        |         |       |        |     |       |

```