### PR TITLE
[#1015] Throw an error for array type primary keys

### DIFF
--- a/spinta/datasets/commands/load.py
+++ b/spinta/datasets/commands/load.py
@@ -130,7 +130,7 @@ def load(context: Context, entity: Entity, data: dict, manifest: Manifest):
     else:
         entity.unknown_primary_key = True
         entity.pkeys = sorted(
-            take(entity.model.flatprops).values(),
+            [pk for pk in take(entity.model.flatprops).values() if not pk.list],
             key=lambda p: p.place,
         )
 

--- a/spinta/datasets/commands/load.py
+++ b/spinta/datasets/commands/load.py
@@ -125,12 +125,12 @@ def load(context: Context, entity: Entity, data: dict, manifest: Manifest):
     # XXX: https://gitlab.com/atviriduomenys/spinta/-/issues/44
     pkeys: List[str] = entity.pkeys or []
     if pkeys:
-        _check_unknown_keys(entity.model, pkeys, entity.model.properties)
-        entity.pkeys = [entity.model.properties[k] for k in pkeys]
+        _check_unknown_keys(entity.model, pkeys, entity.model.flatprops)
+        entity.pkeys = [entity.model.flatprops[k] for k in pkeys]
     else:
         entity.unknown_primary_key = True
         entity.pkeys = sorted(
-            take(entity.model.properties).values(),
+            take(entity.model.flatprops).values(),
             key=lambda p: p.place,
         )
 

--- a/spinta/datasets/components.py
+++ b/spinta/datasets/components.py
@@ -197,7 +197,7 @@ class Entity(External):
     resource: Optional[Resource]    # resource
     model: Model                    # model
     pkeys: List[Property]           # model.ref
-    # This is set to True if primary key is not given. Anf if primary key is not
+    # This is set to True if primary key is not given. And if primary key is not
     # given, then `pkeys` will be set to all properties.
     unknown_primary_key: bool = False
     name: str                       # model.source

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -766,7 +766,7 @@ class NoReferencesFound(UserError):
 
 
 class PrimaryKeyArrayTypeError(UserError):
-    template = "Array type object can not be used as a model primary key."
+    template = "Array type property can not be used as a model primary key."
 
 
 class MultipleBackRefReferencesFound(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -765,6 +765,10 @@ class NoReferencesFound(UserError):
     template = "Property {prop_name!r} of type 'Ref' was not found."
 
 
+class PrimaryKeyArrayTypeError(UserError):
+    template = "Array type object can not be used as a model primary key."
+
+
 class MultipleBackRefReferencesFound(UserError):
     template = "Model {model!r} contains multiple references to backref, please specify which one to use."
 

--- a/spinta/types/datatype.py
+++ b/spinta/types/datatype.py
@@ -477,30 +477,21 @@ def load(context: Context, dtype: Array, data: dict, manifest: Manifest) -> Data
 
 @load.register(Context, ArrayBackRef, dict, Manifest)
 def load(context: Context, dtype: ArrayBackRef, data: dict, manifest: Manifest) -> DataType:
-    if dtype.items:
-        assert isinstance(dtype.items, dict), type(dtype.items)
-        prop: Property = dtype.prop.__class__()
-        prop.name = dtype.prop.name
-        prop.place = dtype.prop.place
-        prop.parent = dtype.prop
-        prop.model = dtype.prop.model
-        commands.load(context, prop, dtype.items, manifest)
-        dtype.items = prop
-    else:
-        dtype.items = None
-    return dtype
+    return _load_array(context, dtype, manifest)
 
 
 def _load_array(context: Context, dtype: Array | ArrayBackRef, manifest: Manifest) -> DataType:
     if dtype.items:
         assert isinstance(dtype.items, dict), type(dtype.items)
+        place = f'{dtype.prop.place}[]'
         prop: Property = dtype.prop.__class__()
-        prop.list = dtype.prop
         prop.name = dtype.prop.name
-        prop.place = dtype.prop.place
+        prop.place = place
         prop.parent = dtype.prop
         prop.model = dtype.prop.model
+        prop.list = dtype.prop
         commands.load(context, prop, dtype.items, manifest)
+        dtype.prop.model.flatprops[place] = prop
         dtype.items = prop
     else:
         dtype.items = None

--- a/spinta/types/datatype.py
+++ b/spinta/types/datatype.py
@@ -477,10 +477,6 @@ def load(context: Context, dtype: Array, data: dict, manifest: Manifest) -> Data
 
 @load.register(Context, ArrayBackRef, dict, Manifest)
 def load(context: Context, dtype: ArrayBackRef, data: dict, manifest: Manifest) -> DataType:
-    return _load_array(context, dtype, manifest)
-
-
-def _load_array(context: Context, dtype: Array | ArrayBackRef, manifest: Manifest) -> DataType:
     if dtype.items:
         assert isinstance(dtype.items, dict), type(dtype.items)
         place = f'{dtype.prop.place}[]'
@@ -492,6 +488,22 @@ def _load_array(context: Context, dtype: Array | ArrayBackRef, manifest: Manifes
         prop.list = dtype.prop
         commands.load(context, prop, dtype.items, manifest)
         dtype.prop.model.flatprops[place] = prop
+        dtype.items = prop
+    else:
+        dtype.items = None
+    return dtype
+
+
+def _load_array(context: Context, dtype: Array | ArrayBackRef, manifest: Manifest) -> DataType:
+    if dtype.items:
+        assert isinstance(dtype.items, dict), type(dtype.items)
+        prop: Property = dtype.prop.__class__()
+        prop.list = dtype.prop
+        prop.name = dtype.prop.name
+        prop.place = dtype.prop.place
+        prop.parent = dtype.prop
+        prop.model = dtype.prop.model
+        commands.load(context, prop, dtype.items, manifest)
         dtype.items = prop
     else:
         dtype.items = None

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -9,7 +9,7 @@ from spinta.components import Config
 from spinta.components import Context
 from spinta.components import Model
 from spinta.components import Property
-from spinta.exceptions import BackendNotFound
+from spinta.exceptions import BackendNotFound, PrimaryKeyArrayTypeError
 from spinta.exceptions import InvalidName
 
 if TYPE_CHECKING:
@@ -77,3 +77,12 @@ def check_property_name(context: Context, prop: Property):
             snake_case.match(name) is None
         ):
             raise InvalidName(prop, name=name, type='property')
+
+
+def check_model_primary_keys(model: Model) -> None:
+    if not model.external:
+        return
+
+    for primary_key in model.external.pkeys:
+        if primary_key.list:
+            raise PrimaryKeyArrayTypeError(model, name=primary_key.given_name)

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -45,7 +45,7 @@ from spinta.manifests.tabular.components import PropertyRow
 from spinta.nodes import get_node
 from spinta.nodes import load_model_properties
 from spinta.nodes import load_node
-from spinta.types.helpers import check_model_name
+from spinta.types.helpers import check_model_name, check_model_primary_keys
 from spinta.types.helpers import check_property_name
 from spinta.types.namespace import load_namespace_from_name
 from spinta.ufuncs.loadbuilder.components import LoadBuilder
@@ -120,9 +120,9 @@ def load(
             for prop_name in unique_set:
                 if "." in prop_name:
                     prop_name = prop_name.split(".")[0]
-                if prop_name not in model.properties:
+                if not (model_property := model.get_from_flatprops(prop_name)):
                     raise PropertyNotFound(model, property=prop_name)
-                prop_set.append(model.properties[prop_name])
+                prop_set.append(model_property)
             if prop_set:
                 unique_properties.append(prop_set)
         model.unique = unique_properties
@@ -476,6 +476,8 @@ def check(context: Context, model: Model):
     check_model_name(context, model)
     if '_id' not in model.properties:
         raise exceptions.MissingRequiredProperty(model, prop='_id')
+
+    check_model_primary_keys(model)
 
     for prop in model.properties.values():
         commands.check(context, prop)

--- a/spinta/ufuncs/loadbuilder/components.py
+++ b/spinta/ufuncs/loadbuilder/components.py
@@ -64,8 +64,8 @@ class LoadBuilder(Env):
                     args.remove('_id')
             for arg in args:
                 key = arg
-                if arg in self.model.properties:
-                    prop = self.model.properties[arg]
+                if arg in self.model.flatprops:
+                    prop = self.model.flatprops[arg]
                     page.keys.update({
                         key: prop
                     })

--- a/tests/dtypes/test_backref.py
+++ b/tests/dtypes/test_backref.py
@@ -882,326 +882,326 @@ def test_backref_error_modify_backref_patch(
     }
 
 
-# @pytest.mark.manifests('internal_sql', 'csv')
-# def test_backref_multiple_same(
-#     manifest_type: str,
-#     tmp_path: pathlib.Path,
-#     rc: RawConfig,
-#     postgresql: str,
-#     request: FixtureRequest,
-# ):
-#     context = bootstrap_manifest(
-#         rc, '''
-#     d | r | b | m | property    | type    | ref      | access | level
-#     example/dtypes/backref/multiple/same |         |          |        |
-#                                         |         |                             |        |
-#       |   |   | Language                |         | id, name                    |        |
-#       |   |   |   | id                  | integer |                             | open   |
-#       |   |   |   | name                | string  |                             | open   |
-#       |   |   |   | country_primary[]   | backref | Country[language_primary]   | open   |
-#       |   |   |   | country_secondary[] | backref | Country[language_secondary] | open   |
-#                                         |         |                             |        |
-#       |   |   | Country                 |         | id                          |        |
-#       |   |   |   | id                  | integer |                             | open   |
-#       |   |   |   | name                | string  |                             | open   |
-#       |   |   |   | language_primary    | ref     | Language                    | open   |
-#       |   |   |   | language_secondary  | ref     | Language                    | open   |
-#     ''',
-#         backend=postgresql,
-#         tmp_path=tmp_path,
-#         manifest_type=manifest_type,
-#         request=request,
-#         full_load=True
-#     )
-#
-#     app = create_test_client(context)
-#     app.authorize(['spinta_set_meta_fields'])
-#     app.authmodel('example/dtypes/backref/multiple/same', ['insert', 'getone', 'getall'])
-#
-#     lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
-#     english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
-#     russian = "6e285646-f637-43a4-be34-79d616064f25"
-#     app.post('example/dtypes/backref/multiple/same/Language', json={
-#         '_id': lithuanian,
-#         'id': 0,
-#         'name': 'Lithuanian',
-#     })
-#     app.post('example/dtypes/backref/multiple/same/Language', json={
-#         '_id': english,
-#         'id': 1,
-#         'name': 'English',
-#     })
-#     app.post('example/dtypes/backref/multiple/same/Language', json={
-#         '_id': russian,
-#         'id': 2,
-#         'name': 'Russian',
-#     })
-#
-#     lithuania_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
-#     poland_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
-#     app.post('example/dtypes/backref/multiple/same/Country', json={
-#         '_id': lithuania_id,
-#         'id': 0,
-#         'name': 'Lithuania',
-#         'language_primary': {
-#             "_id": lithuanian
-#         },
-#         'language_secondary': {
-#             "_id": english
-#         }
-#     })
-#     app.post('example/dtypes/backref/multiple/same/Country', json={
-#         '_id': poland_id,
-#         'id': 1,
-#         'name': 'Poland',
-#         'language_primary': {
-#             "_id": english
-#         },
-#         'language_secondary': {
-#             "_id": russian
-#         }
-#     })
-#
-#     result = app.get('example/dtypes/backref/multiple/same/Language?expand()')
-#     assert result.status_code == 200
-#     result_json = result.json()['_data']
-#     assert are_lists_of_dicts_equal(result_json[0]['country_primary'], [
-#         {
-#             '_id': lithuania_id
-#         }
-#     ])
-#     assert result_json[0]['country_secondary'] == []
-#
-#     assert are_lists_of_dicts_equal(result_json[1]['country_primary'], [
-#         {
-#             '_id': poland_id
-#         }
-#     ])
-#     assert are_lists_of_dicts_equal(result_json[1]['country_secondary'], [
-#         {
-#             '_id': lithuania_id
-#         }
-#     ])
-#
-#     assert result_json[2]['country_primary'] == []
-#     assert are_lists_of_dicts_equal(result_json[2]['country_secondary'], [
-#         {
-#             '_id': poland_id
-#         }
-#     ])
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_backref_multiple_same(
+    manifest_type: str,
+    tmp_path: pathlib.Path,
+    rc: RawConfig,
+    postgresql: str,
+    request: FixtureRequest,
+):
+    context = bootstrap_manifest(
+        rc, '''
+    d | r | b | m | property    | type    | ref      | access | level
+    example/dtypes/backref/multiple/same |         |          |        |
+                                        |         |                             |        |
+      |   |   | Language                |         | id, name                    |        |
+      |   |   |   | id                  | integer |                             | open   |
+      |   |   |   | name                | string  |                             | open   |
+      |   |   |   | country_primary[]   | backref | Country[language_primary]   | open   |
+      |   |   |   | country_secondary[] | backref | Country[language_secondary] | open   |
+                                        |         |                             |        |
+      |   |   | Country                 |         | id                          |        |
+      |   |   |   | id                  | integer |                             | open   |
+      |   |   |   | name                | string  |                             | open   |
+      |   |   |   | language_primary    | ref     | Language                    | open   |
+      |   |   |   | language_secondary  | ref     | Language                    | open   |
+    ''',
+        backend=postgresql,
+        tmp_path=tmp_path,
+        manifest_type=manifest_type,
+        request=request,
+        full_load=True
+    )
+
+    app = create_test_client(context)
+    app.authorize(['spinta_set_meta_fields'])
+    app.authmodel('example/dtypes/backref/multiple/same', ['insert', 'getone', 'getall'])
+
+    lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
+    english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
+    russian = "6e285646-f637-43a4-be34-79d616064f25"
+    app.post('example/dtypes/backref/multiple/same/Language', json={
+        '_id': lithuanian,
+        'id': 0,
+        'name': 'Lithuanian',
+    })
+    app.post('example/dtypes/backref/multiple/same/Language', json={
+        '_id': english,
+        'id': 1,
+        'name': 'English',
+    })
+    app.post('example/dtypes/backref/multiple/same/Language', json={
+        '_id': russian,
+        'id': 2,
+        'name': 'Russian',
+    })
+
+    lithuania_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
+    poland_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
+    app.post('example/dtypes/backref/multiple/same/Country', json={
+        '_id': lithuania_id,
+        'id': 0,
+        'name': 'Lithuania',
+        'language_primary': {
+            "_id": lithuanian
+        },
+        'language_secondary': {
+            "_id": english
+        }
+    })
+    app.post('example/dtypes/backref/multiple/same/Country', json={
+        '_id': poland_id,
+        'id': 1,
+        'name': 'Poland',
+        'language_primary': {
+            "_id": english
+        },
+        'language_secondary': {
+            "_id": russian
+        }
+    })
+
+    result = app.get('example/dtypes/backref/multiple/same/Language?expand()')
+    assert result.status_code == 200
+    result_json = result.json()['_data']
+    assert are_lists_of_dicts_equal(result_json[0]['country_primary'], [
+        {
+            '_id': lithuania_id
+        }
+    ])
+    assert result_json[0]['country_secondary'] == []
+
+    assert are_lists_of_dicts_equal(result_json[1]['country_primary'], [
+        {
+            '_id': poland_id
+        }
+    ])
+    assert are_lists_of_dicts_equal(result_json[1]['country_secondary'], [
+        {
+            '_id': lithuania_id
+        }
+    ])
+
+    assert result_json[2]['country_primary'] == []
+    assert are_lists_of_dicts_equal(result_json[2]['country_secondary'], [
+        {
+            '_id': poland_id
+        }
+    ])
 
 
-# @pytest.mark.manifests('internal_sql', 'csv')
-# def test_backref_multiple_all_types(
-#     manifest_type: str,
-#     tmp_path: pathlib.Path,
-#     rc: RawConfig,
-#     postgresql: str,
-#     request: FixtureRequest,
-# ):
-#     context = bootstrap_manifest(
-#         rc, '''
-#     d | r | b | m | property    | type    | ref      | access | level
-#     example/dtypes/backref/multiple/all |         |          |        |
-#                                         |         |                             |        |
-#       |   |   | Language                |         | id, name                    |        |
-#       |   |   |   | id                  | integer |                             | open   |
-#       |   |   |   | name                | string  |                             | open   |
-#       |   |   |   | country_0           | backref | Country[language_0]         | open   |
-#       |   |   |   | country_1[]         | backref | Country[language_1]         | open   |
-#       |   |   |   | country_array[]     | backref | Country[language_array]     | open   |
-#                                         |         |                             |        |
-#       |   |   | Country                 |         | id                          |        |
-#       |   |   |   | id                  | integer |                             | open   |
-#       |   |   |   | name                | string  |                             | open   |
-#       |   |   |   | language_0          | ref     | Language                    | open   |
-#       |   |   |   | language_1          | ref     | Language                    | open   |
-#       |   |   |   | language_array[]    | ref     | Language                    | open   |
-#     ''',
-#         backend=postgresql,
-#         tmp_path=tmp_path,
-#         manifest_type=manifest_type,
-#         request=request,
-#         full_load=True
-#     )
-#
-#     app = create_test_client(context)
-#     app.authorize(['spinta_set_meta_fields'])
-#     app.authmodel('example/dtypes/backref/multiple/all', ['insert', 'getone', 'getall'])
-#
-#     lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
-#     english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
-#     russian = "6e285646-f637-43a4-be34-79d616064f25"
-#     empty_language = "090875d3-aaaa-422f-984a-733acc0a7c77"
-#     app.post('example/dtypes/backref/multiple/all/Language', json={
-#         '_id': lithuanian,
-#         'id': 0,
-#         'name': 'Lithuanian',
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Language', json={
-#         '_id': english,
-#         'id': 1,
-#         'name': 'English',
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Language', json={
-#         '_id': russian,
-#         'id': 2,
-#         'name': 'Russian',
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Language', json={
-#         '_id': empty_language,
-#         'id': 3,
-#         'name': 'Empty',
-#     })
-#
-#     lithuania_0_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
-#     lithuania_1_id = '84eb5386-ec69-4df8-a1d2-d3ce439b7054'
-#     poland_0_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
-#     poland_1_id = '04091c91-b789-44cf-8024-e3dce45421cc'
-#     app.post('example/dtypes/backref/multiple/all/Country', json={
-#         '_id': lithuania_0_id,
-#         'id': 0,
-#         'name': 'Lithuania',
-#         'language_0': {
-#             "_id": lithuanian
-#         },
-#         'language_1': {
-#             "_id": lithuanian
-#         },
-#         'language_array': [
-#             {
-#                 "_id": lithuanian
-#             },
-#             {
-#                 "_id": english
-#             },
-#         ],
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Country', json={
-#         '_id': lithuania_1_id,
-#         'id': 1,
-#         'name': 'Lithuania',
-#         'language_1': {
-#             "_id": lithuanian
-#         },
-#         'language_array': [
-#             {
-#                 "_id": lithuanian
-#             },
-#             {
-#                 "_id": english
-#             },
-#             {
-#                 '_id': russian
-#             }
-#         ],
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Country', json={
-#         '_id': poland_0_id,
-#         'id': 2,
-#         'name': 'Poland',
-#         'language_0': {
-#             "_id": english
-#         },
-#         'language_1': {
-#             "_id": english
-#         },
-#         'language_array': [
-#             {
-#                 "_id": english
-#             },
-#             {
-#                 "_id": russian
-#             },
-#         ],
-#     })
-#     app.post('example/dtypes/backref/multiple/all/Country', json={
-#         '_id': poland_1_id,
-#         'id': 3,
-#         'name': 'Poland',
-#         'language_0': {
-#             "_id": russian
-#         },
-#         'language_1': {
-#             "_id": english
-#         },
-#         'language_array': [
-#             {
-#                 "_id": english
-#             },
-#         ],
-#     })
-#
-#     result = app.get('example/dtypes/backref/multiple/all/Language?expand()')
-#     assert result.status_code == 200
-#     result_json = result.json()['_data']
-#
-#     # Lithuanian
-#     assert result_json[0]['country_0'] == {
-#         '_id': lithuania_0_id
-#     }
-#     assert are_lists_of_dicts_equal(result_json[0]['country_1'], [
-#         {
-#             '_id': lithuania_0_id
-#         },
-#         {
-#             '_id': lithuania_1_id
-#         }
-#     ])
-#     assert are_lists_of_dicts_equal(result_json[0]['country_array'], [
-#         {
-#             '_id': lithuania_0_id
-#         },
-#         {
-#             '_id': lithuania_1_id
-#         }
-#     ])
-#
-#     # English
-#     assert result_json[1]['country_0'] == {
-#         '_id': poland_0_id
-#     }
-#     assert are_lists_of_dicts_equal(result_json[1]['country_1'], [
-#         {
-#             '_id': poland_0_id
-#         },
-#         {
-#             '_id': poland_1_id
-#         }
-#     ])
-#     assert are_lists_of_dicts_equal(result_json[1]['country_array'], [
-#         {
-#             '_id': lithuania_0_id
-#         },
-#         {
-#             '_id': lithuania_1_id
-#         },
-#         {
-#             '_id': poland_0_id
-#         },
-#         {
-#             '_id': poland_1_id
-#         }
-#     ])
-#
-#     # Russian
-#     assert result_json[2]['country_0'] == {
-#         '_id': poland_1_id
-#     }
-#     assert result_json[2]['country_1'] == []
-#     assert are_lists_of_dicts_equal(result_json[2]['country_array'], [
-#         {
-#             '_id': lithuania_1_id
-#         },
-#         {
-#             '_id': poland_0_id
-#         }
-#     ])
-#
-#     # Empty
-#     assert result_json[3]['country_0'] is None
-#     assert result_json[3]['country_1'] == []
-#     assert result_json[3]['country_array'] == []
+@pytest.mark.manifests('internal_sql', 'csv')
+def test_backref_multiple_all_types(
+    manifest_type: str,
+    tmp_path: pathlib.Path,
+    rc: RawConfig,
+    postgresql: str,
+    request: FixtureRequest,
+):
+    context = bootstrap_manifest(
+        rc, '''
+    d | r | b | m | property    | type    | ref      | access | level
+    example/dtypes/backref/multiple/all |         |          |        |
+                                        |         |                             |        |
+      |   |   | Language                |         | id, name                    |        |
+      |   |   |   | id                  | integer |                             | open   |
+      |   |   |   | name                | string  |                             | open   |
+      |   |   |   | country_0           | backref | Country[language_0]         | open   |
+      |   |   |   | country_1[]         | backref | Country[language_1]         | open   |
+      |   |   |   | country_array[]     | backref | Country[language_array]     | open   |
+                                        |         |                             |        |
+      |   |   | Country                 |         | id                          |        |
+      |   |   |   | id                  | integer |                             | open   |
+      |   |   |   | name                | string  |                             | open   |
+      |   |   |   | language_0          | ref     | Language                    | open   |
+      |   |   |   | language_1          | ref     | Language                    | open   |
+      |   |   |   | language_array[]    | ref     | Language                    | open   |
+    ''',
+        backend=postgresql,
+        tmp_path=tmp_path,
+        manifest_type=manifest_type,
+        request=request,
+        full_load=True
+    )
+
+    app = create_test_client(context)
+    app.authorize(['spinta_set_meta_fields'])
+    app.authmodel('example/dtypes/backref/multiple/all', ['insert', 'getone', 'getall'])
+
+    lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
+    english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
+    russian = "6e285646-f637-43a4-be34-79d616064f25"
+    empty_language = "090875d3-aaaa-422f-984a-733acc0a7c77"
+    app.post('example/dtypes/backref/multiple/all/Language', json={
+        '_id': lithuanian,
+        'id': 0,
+        'name': 'Lithuanian',
+    })
+    app.post('example/dtypes/backref/multiple/all/Language', json={
+        '_id': english,
+        'id': 1,
+        'name': 'English',
+    })
+    app.post('example/dtypes/backref/multiple/all/Language', json={
+        '_id': russian,
+        'id': 2,
+        'name': 'Russian',
+    })
+    app.post('example/dtypes/backref/multiple/all/Language', json={
+        '_id': empty_language,
+        'id': 3,
+        'name': 'Empty',
+    })
+
+    lithuania_0_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
+    lithuania_1_id = '84eb5386-ec69-4df8-a1d2-d3ce439b7054'
+    poland_0_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
+    poland_1_id = '04091c91-b789-44cf-8024-e3dce45421cc'
+    app.post('example/dtypes/backref/multiple/all/Country', json={
+        '_id': lithuania_0_id,
+        'id': 0,
+        'name': 'Lithuania',
+        'language_0': {
+            "_id": lithuanian
+        },
+        'language_1': {
+            "_id": lithuanian
+        },
+        'language_array': [
+            {
+                "_id": lithuanian
+            },
+            {
+                "_id": english
+            },
+        ],
+    })
+    app.post('example/dtypes/backref/multiple/all/Country', json={
+        '_id': lithuania_1_id,
+        'id': 1,
+        'name': 'Lithuania',
+        'language_1': {
+            "_id": lithuanian
+        },
+        'language_array': [
+            {
+                "_id": lithuanian
+            },
+            {
+                "_id": english
+            },
+            {
+                '_id': russian
+            }
+        ],
+    })
+    app.post('example/dtypes/backref/multiple/all/Country', json={
+        '_id': poland_0_id,
+        'id': 2,
+        'name': 'Poland',
+        'language_0': {
+            "_id": english
+        },
+        'language_1': {
+            "_id": english
+        },
+        'language_array': [
+            {
+                "_id": english
+            },
+            {
+                "_id": russian
+            },
+        ],
+    })
+    app.post('example/dtypes/backref/multiple/all/Country', json={
+        '_id': poland_1_id,
+        'id': 3,
+        'name': 'Poland',
+        'language_0': {
+            "_id": russian
+        },
+        'language_1': {
+            "_id": english
+        },
+        'language_array': [
+            {
+                "_id": english
+            },
+        ],
+    })
+
+    result = app.get('example/dtypes/backref/multiple/all/Language?expand()')
+    assert result.status_code == 200
+    result_json = result.json()['_data']
+
+    # Lithuanian
+    assert result_json[0]['country_0'] == {
+        '_id': lithuania_0_id
+    }
+    assert are_lists_of_dicts_equal(result_json[0]['country_1'], [
+        {
+            '_id': lithuania_0_id
+        },
+        {
+            '_id': lithuania_1_id
+        }
+    ])
+    assert are_lists_of_dicts_equal(result_json[0]['country_array'], [
+        {
+            '_id': lithuania_0_id
+        },
+        {
+            '_id': lithuania_1_id
+        }
+    ])
+
+    # English
+    assert result_json[1]['country_0'] == {
+        '_id': poland_0_id
+    }
+    assert are_lists_of_dicts_equal(result_json[1]['country_1'], [
+        {
+            '_id': poland_0_id
+        },
+        {
+            '_id': poland_1_id
+        }
+    ])
+    assert are_lists_of_dicts_equal(result_json[1]['country_array'], [
+        {
+            '_id': lithuania_0_id
+        },
+        {
+            '_id': lithuania_1_id
+        },
+        {
+            '_id': poland_0_id
+        },
+        {
+            '_id': poland_1_id
+        }
+    ])
+
+    # Russian
+    assert result_json[2]['country_0'] == {
+        '_id': poland_1_id
+    }
+    assert result_json[2]['country_1'] == []
+    assert are_lists_of_dicts_equal(result_json[2]['country_array'], [
+        {
+            '_id': lithuania_1_id
+        },
+        {
+            '_id': poland_0_id
+        }
+    ])
+
+    # Empty
+    assert result_json[3]['country_0'] is None
+    assert result_json[3]['country_1'] == []
+    assert result_json[3]['country_array'] == []
 
 
 @pytest.mark.manifests('internal_sql', 'csv')

--- a/tests/dtypes/test_backref.py
+++ b/tests/dtypes/test_backref.py
@@ -882,326 +882,326 @@ def test_backref_error_modify_backref_patch(
     }
 
 
-@pytest.mark.manifests('internal_sql', 'csv')
-def test_backref_multiple_same(
-    manifest_type: str,
-    tmp_path: pathlib.Path,
-    rc: RawConfig,
-    postgresql: str,
-    request: FixtureRequest,
-):
-    context = bootstrap_manifest(
-        rc, '''
-    d | r | b | m | property    | type    | ref      | access | level
-    example/dtypes/backref/multiple/same |         |          |        |
-                                        |         |                             |        |
-      |   |   | Language                |         | id, name                    |        |
-      |   |   |   | id                  | integer |                             | open   |
-      |   |   |   | name                | string  |                             | open   |
-      |   |   |   | country_primary[]   | backref | Country[language_primary]   | open   |
-      |   |   |   | country_secondary[] | backref | Country[language_secondary] | open   |
-                                        |         |                             |        |
-      |   |   | Country                 |         | id                          |        |
-      |   |   |   | id                  | integer |                             | open   |
-      |   |   |   | name                | string  |                             | open   |
-      |   |   |   | language_primary    | ref     | Language                    | open   |
-      |   |   |   | language_secondary  | ref     | Language                    | open   |
-    ''',
-        backend=postgresql,
-        tmp_path=tmp_path,
-        manifest_type=manifest_type,
-        request=request,
-        full_load=True
-    )
+# @pytest.mark.manifests('internal_sql', 'csv')
+# def test_backref_multiple_same(
+#     manifest_type: str,
+#     tmp_path: pathlib.Path,
+#     rc: RawConfig,
+#     postgresql: str,
+#     request: FixtureRequest,
+# ):
+#     context = bootstrap_manifest(
+#         rc, '''
+#     d | r | b | m | property    | type    | ref      | access | level
+#     example/dtypes/backref/multiple/same |         |          |        |
+#                                         |         |                             |        |
+#       |   |   | Language                |         | id, name                    |        |
+#       |   |   |   | id                  | integer |                             | open   |
+#       |   |   |   | name                | string  |                             | open   |
+#       |   |   |   | country_primary[]   | backref | Country[language_primary]   | open   |
+#       |   |   |   | country_secondary[] | backref | Country[language_secondary] | open   |
+#                                         |         |                             |        |
+#       |   |   | Country                 |         | id                          |        |
+#       |   |   |   | id                  | integer |                             | open   |
+#       |   |   |   | name                | string  |                             | open   |
+#       |   |   |   | language_primary    | ref     | Language                    | open   |
+#       |   |   |   | language_secondary  | ref     | Language                    | open   |
+#     ''',
+#         backend=postgresql,
+#         tmp_path=tmp_path,
+#         manifest_type=manifest_type,
+#         request=request,
+#         full_load=True
+#     )
+#
+#     app = create_test_client(context)
+#     app.authorize(['spinta_set_meta_fields'])
+#     app.authmodel('example/dtypes/backref/multiple/same', ['insert', 'getone', 'getall'])
+#
+#     lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
+#     english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
+#     russian = "6e285646-f637-43a4-be34-79d616064f25"
+#     app.post('example/dtypes/backref/multiple/same/Language', json={
+#         '_id': lithuanian,
+#         'id': 0,
+#         'name': 'Lithuanian',
+#     })
+#     app.post('example/dtypes/backref/multiple/same/Language', json={
+#         '_id': english,
+#         'id': 1,
+#         'name': 'English',
+#     })
+#     app.post('example/dtypes/backref/multiple/same/Language', json={
+#         '_id': russian,
+#         'id': 2,
+#         'name': 'Russian',
+#     })
+#
+#     lithuania_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
+#     poland_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
+#     app.post('example/dtypes/backref/multiple/same/Country', json={
+#         '_id': lithuania_id,
+#         'id': 0,
+#         'name': 'Lithuania',
+#         'language_primary': {
+#             "_id": lithuanian
+#         },
+#         'language_secondary': {
+#             "_id": english
+#         }
+#     })
+#     app.post('example/dtypes/backref/multiple/same/Country', json={
+#         '_id': poland_id,
+#         'id': 1,
+#         'name': 'Poland',
+#         'language_primary': {
+#             "_id": english
+#         },
+#         'language_secondary': {
+#             "_id": russian
+#         }
+#     })
+#
+#     result = app.get('example/dtypes/backref/multiple/same/Language?expand()')
+#     assert result.status_code == 200
+#     result_json = result.json()['_data']
+#     assert are_lists_of_dicts_equal(result_json[0]['country_primary'], [
+#         {
+#             '_id': lithuania_id
+#         }
+#     ])
+#     assert result_json[0]['country_secondary'] == []
+#
+#     assert are_lists_of_dicts_equal(result_json[1]['country_primary'], [
+#         {
+#             '_id': poland_id
+#         }
+#     ])
+#     assert are_lists_of_dicts_equal(result_json[1]['country_secondary'], [
+#         {
+#             '_id': lithuania_id
+#         }
+#     ])
+#
+#     assert result_json[2]['country_primary'] == []
+#     assert are_lists_of_dicts_equal(result_json[2]['country_secondary'], [
+#         {
+#             '_id': poland_id
+#         }
+#     ])
 
-    app = create_test_client(context)
-    app.authorize(['spinta_set_meta_fields'])
-    app.authmodel('example/dtypes/backref/multiple/same', ['insert', 'getone', 'getall'])
 
-    lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
-    english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
-    russian = "6e285646-f637-43a4-be34-79d616064f25"
-    app.post('example/dtypes/backref/multiple/same/Language', json={
-        '_id': lithuanian,
-        'id': 0,
-        'name': 'Lithuanian',
-    })
-    app.post('example/dtypes/backref/multiple/same/Language', json={
-        '_id': english,
-        'id': 1,
-        'name': 'English',
-    })
-    app.post('example/dtypes/backref/multiple/same/Language', json={
-        '_id': russian,
-        'id': 2,
-        'name': 'Russian',
-    })
-
-    lithuania_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
-    poland_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
-    app.post('example/dtypes/backref/multiple/same/Country', json={
-        '_id': lithuania_id,
-        'id': 0,
-        'name': 'Lithuania',
-        'language_primary': {
-            "_id": lithuanian
-        },
-        'language_secondary': {
-            "_id": english
-        }
-    })
-    app.post('example/dtypes/backref/multiple/same/Country', json={
-        '_id': poland_id,
-        'id': 1,
-        'name': 'Poland',
-        'language_primary': {
-            "_id": english
-        },
-        'language_secondary': {
-            "_id": russian
-        }
-    })
-
-    result = app.get('example/dtypes/backref/multiple/same/Language?expand()')
-    assert result.status_code == 200
-    result_json = result.json()['_data']
-    assert are_lists_of_dicts_equal(result_json[0]['country_primary'], [
-        {
-            '_id': lithuania_id
-        }
-    ])
-    assert result_json[0]['country_secondary'] == []
-
-    assert are_lists_of_dicts_equal(result_json[1]['country_primary'], [
-        {
-            '_id': poland_id
-        }
-    ])
-    assert are_lists_of_dicts_equal(result_json[1]['country_secondary'], [
-        {
-            '_id': lithuania_id
-        }
-    ])
-
-    assert result_json[2]['country_primary'] == []
-    assert are_lists_of_dicts_equal(result_json[2]['country_secondary'], [
-        {
-            '_id': poland_id
-        }
-    ])
-
-
-@pytest.mark.manifests('internal_sql', 'csv')
-def test_backref_multiple_all_types(
-    manifest_type: str,
-    tmp_path: pathlib.Path,
-    rc: RawConfig,
-    postgresql: str,
-    request: FixtureRequest,
-):
-    context = bootstrap_manifest(
-        rc, '''
-    d | r | b | m | property    | type    | ref      | access | level
-    example/dtypes/backref/multiple/all |         |          |        |
-                                        |         |                             |        |
-      |   |   | Language                |         | id, name                    |        |
-      |   |   |   | id                  | integer |                             | open   |
-      |   |   |   | name                | string  |                             | open   |
-      |   |   |   | country_0           | backref | Country[language_0]         | open   |
-      |   |   |   | country_1[]         | backref | Country[language_1]         | open   |
-      |   |   |   | country_array[]     | backref | Country[language_array]     | open   |
-                                        |         |                             |        |
-      |   |   | Country                 |         | id                          |        |
-      |   |   |   | id                  | integer |                             | open   |
-      |   |   |   | name                | string  |                             | open   |
-      |   |   |   | language_0          | ref     | Language                    | open   |
-      |   |   |   | language_1          | ref     | Language                    | open   |
-      |   |   |   | language_array[]    | ref     | Language                    | open   |
-    ''',
-        backend=postgresql,
-        tmp_path=tmp_path,
-        manifest_type=manifest_type,
-        request=request,
-        full_load=True
-    )
-
-    app = create_test_client(context)
-    app.authorize(['spinta_set_meta_fields'])
-    app.authmodel('example/dtypes/backref/multiple/all', ['insert', 'getone', 'getall'])
-
-    lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
-    english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
-    russian = "6e285646-f637-43a4-be34-79d616064f25"
-    empty_language = "090875d3-aaaa-422f-984a-733acc0a7c77"
-    app.post('example/dtypes/backref/multiple/all/Language', json={
-        '_id': lithuanian,
-        'id': 0,
-        'name': 'Lithuanian',
-    })
-    app.post('example/dtypes/backref/multiple/all/Language', json={
-        '_id': english,
-        'id': 1,
-        'name': 'English',
-    })
-    app.post('example/dtypes/backref/multiple/all/Language', json={
-        '_id': russian,
-        'id': 2,
-        'name': 'Russian',
-    })
-    app.post('example/dtypes/backref/multiple/all/Language', json={
-        '_id': empty_language,
-        'id': 3,
-        'name': 'Empty',
-    })
-
-    lithuania_0_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
-    lithuania_1_id = '84eb5386-ec69-4df8-a1d2-d3ce439b7054'
-    poland_0_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
-    poland_1_id = '04091c91-b789-44cf-8024-e3dce45421cc'
-    app.post('example/dtypes/backref/multiple/all/Country', json={
-        '_id': lithuania_0_id,
-        'id': 0,
-        'name': 'Lithuania',
-        'language_0': {
-            "_id": lithuanian
-        },
-        'language_1': {
-            "_id": lithuanian
-        },
-        'language_array': [
-            {
-                "_id": lithuanian
-            },
-            {
-                "_id": english
-            },
-        ],
-    })
-    app.post('example/dtypes/backref/multiple/all/Country', json={
-        '_id': lithuania_1_id,
-        'id': 1,
-        'name': 'Lithuania',
-        'language_1': {
-            "_id": lithuanian
-        },
-        'language_array': [
-            {
-                "_id": lithuanian
-            },
-            {
-                "_id": english
-            },
-            {
-                '_id': russian
-            }
-        ],
-    })
-    app.post('example/dtypes/backref/multiple/all/Country', json={
-        '_id': poland_0_id,
-        'id': 2,
-        'name': 'Poland',
-        'language_0': {
-            "_id": english
-        },
-        'language_1': {
-            "_id": english
-        },
-        'language_array': [
-            {
-                "_id": english
-            },
-            {
-                "_id": russian
-            },
-        ],
-    })
-    app.post('example/dtypes/backref/multiple/all/Country', json={
-        '_id': poland_1_id,
-        'id': 3,
-        'name': 'Poland',
-        'language_0': {
-            "_id": russian
-        },
-        'language_1': {
-            "_id": english
-        },
-        'language_array': [
-            {
-                "_id": english
-            },
-        ],
-    })
-
-    result = app.get('example/dtypes/backref/multiple/all/Language?expand()')
-    assert result.status_code == 200
-    result_json = result.json()['_data']
-
-    # Lithuanian
-    assert result_json[0]['country_0'] == {
-        '_id': lithuania_0_id
-    }
-    assert are_lists_of_dicts_equal(result_json[0]['country_1'], [
-        {
-            '_id': lithuania_0_id
-        },
-        {
-            '_id': lithuania_1_id
-        }
-    ])
-    assert are_lists_of_dicts_equal(result_json[0]['country_array'], [
-        {
-            '_id': lithuania_0_id
-        },
-        {
-            '_id': lithuania_1_id
-        }
-    ])
-
-    # English
-    assert result_json[1]['country_0'] == {
-        '_id': poland_0_id
-    }
-    assert are_lists_of_dicts_equal(result_json[1]['country_1'], [
-        {
-            '_id': poland_0_id
-        },
-        {
-            '_id': poland_1_id
-        }
-    ])
-    assert are_lists_of_dicts_equal(result_json[1]['country_array'], [
-        {
-            '_id': lithuania_0_id
-        },
-        {
-            '_id': lithuania_1_id
-        },
-        {
-            '_id': poland_0_id
-        },
-        {
-            '_id': poland_1_id
-        }
-    ])
-
-    # Russian
-    assert result_json[2]['country_0'] == {
-        '_id': poland_1_id
-    }
-    assert result_json[2]['country_1'] == []
-    assert are_lists_of_dicts_equal(result_json[2]['country_array'], [
-        {
-            '_id': lithuania_1_id
-        },
-        {
-            '_id': poland_0_id
-        }
-    ])
-
-    # Empty
-    assert result_json[3]['country_0'] is None
-    assert result_json[3]['country_1'] == []
-    assert result_json[3]['country_array'] == []
+# @pytest.mark.manifests('internal_sql', 'csv')
+# def test_backref_multiple_all_types(
+#     manifest_type: str,
+#     tmp_path: pathlib.Path,
+#     rc: RawConfig,
+#     postgresql: str,
+#     request: FixtureRequest,
+# ):
+#     context = bootstrap_manifest(
+#         rc, '''
+#     d | r | b | m | property    | type    | ref      | access | level
+#     example/dtypes/backref/multiple/all |         |          |        |
+#                                         |         |                             |        |
+#       |   |   | Language                |         | id, name                    |        |
+#       |   |   |   | id                  | integer |                             | open   |
+#       |   |   |   | name                | string  |                             | open   |
+#       |   |   |   | country_0           | backref | Country[language_0]         | open   |
+#       |   |   |   | country_1[]         | backref | Country[language_1]         | open   |
+#       |   |   |   | country_array[]     | backref | Country[language_array]     | open   |
+#                                         |         |                             |        |
+#       |   |   | Country                 |         | id                          |        |
+#       |   |   |   | id                  | integer |                             | open   |
+#       |   |   |   | name                | string  |                             | open   |
+#       |   |   |   | language_0          | ref     | Language                    | open   |
+#       |   |   |   | language_1          | ref     | Language                    | open   |
+#       |   |   |   | language_array[]    | ref     | Language                    | open   |
+#     ''',
+#         backend=postgresql,
+#         tmp_path=tmp_path,
+#         manifest_type=manifest_type,
+#         request=request,
+#         full_load=True
+#     )
+#
+#     app = create_test_client(context)
+#     app.authorize(['spinta_set_meta_fields'])
+#     app.authmodel('example/dtypes/backref/multiple/all', ['insert', 'getone', 'getall'])
+#
+#     lithuanian = "c8e4cd60-0b15-4b23-a691-09cdf2ebd9c0"
+#     english = "1cccf6f6-9fe2-4055-b003-915a7c1abee8"
+#     russian = "6e285646-f637-43a4-be34-79d616064f25"
+#     empty_language = "090875d3-aaaa-422f-984a-733acc0a7c77"
+#     app.post('example/dtypes/backref/multiple/all/Language', json={
+#         '_id': lithuanian,
+#         'id': 0,
+#         'name': 'Lithuanian',
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Language', json={
+#         '_id': english,
+#         'id': 1,
+#         'name': 'English',
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Language', json={
+#         '_id': russian,
+#         'id': 2,
+#         'name': 'Russian',
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Language', json={
+#         '_id': empty_language,
+#         'id': 3,
+#         'name': 'Empty',
+#     })
+#
+#     lithuania_0_id = 'd73306fb-4ee5-483d-9bad-d86f98e1869c'
+#     lithuania_1_id = '84eb5386-ec69-4df8-a1d2-d3ce439b7054'
+#     poland_0_id = '25c3f7bf-67f5-47cc-8d40-297c499e8067'
+#     poland_1_id = '04091c91-b789-44cf-8024-e3dce45421cc'
+#     app.post('example/dtypes/backref/multiple/all/Country', json={
+#         '_id': lithuania_0_id,
+#         'id': 0,
+#         'name': 'Lithuania',
+#         'language_0': {
+#             "_id": lithuanian
+#         },
+#         'language_1': {
+#             "_id": lithuanian
+#         },
+#         'language_array': [
+#             {
+#                 "_id": lithuanian
+#             },
+#             {
+#                 "_id": english
+#             },
+#         ],
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Country', json={
+#         '_id': lithuania_1_id,
+#         'id': 1,
+#         'name': 'Lithuania',
+#         'language_1': {
+#             "_id": lithuanian
+#         },
+#         'language_array': [
+#             {
+#                 "_id": lithuanian
+#             },
+#             {
+#                 "_id": english
+#             },
+#             {
+#                 '_id': russian
+#             }
+#         ],
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Country', json={
+#         '_id': poland_0_id,
+#         'id': 2,
+#         'name': 'Poland',
+#         'language_0': {
+#             "_id": english
+#         },
+#         'language_1': {
+#             "_id": english
+#         },
+#         'language_array': [
+#             {
+#                 "_id": english
+#             },
+#             {
+#                 "_id": russian
+#             },
+#         ],
+#     })
+#     app.post('example/dtypes/backref/multiple/all/Country', json={
+#         '_id': poland_1_id,
+#         'id': 3,
+#         'name': 'Poland',
+#         'language_0': {
+#             "_id": russian
+#         },
+#         'language_1': {
+#             "_id": english
+#         },
+#         'language_array': [
+#             {
+#                 "_id": english
+#             },
+#         ],
+#     })
+#
+#     result = app.get('example/dtypes/backref/multiple/all/Language?expand()')
+#     assert result.status_code == 200
+#     result_json = result.json()['_data']
+#
+#     # Lithuanian
+#     assert result_json[0]['country_0'] == {
+#         '_id': lithuania_0_id
+#     }
+#     assert are_lists_of_dicts_equal(result_json[0]['country_1'], [
+#         {
+#             '_id': lithuania_0_id
+#         },
+#         {
+#             '_id': lithuania_1_id
+#         }
+#     ])
+#     assert are_lists_of_dicts_equal(result_json[0]['country_array'], [
+#         {
+#             '_id': lithuania_0_id
+#         },
+#         {
+#             '_id': lithuania_1_id
+#         }
+#     ])
+#
+#     # English
+#     assert result_json[1]['country_0'] == {
+#         '_id': poland_0_id
+#     }
+#     assert are_lists_of_dicts_equal(result_json[1]['country_1'], [
+#         {
+#             '_id': poland_0_id
+#         },
+#         {
+#             '_id': poland_1_id
+#         }
+#     ])
+#     assert are_lists_of_dicts_equal(result_json[1]['country_array'], [
+#         {
+#             '_id': lithuania_0_id
+#         },
+#         {
+#             '_id': lithuania_1_id
+#         },
+#         {
+#             '_id': poland_0_id
+#         },
+#         {
+#             '_id': poland_1_id
+#         }
+#     ])
+#
+#     # Russian
+#     assert result_json[2]['country_0'] == {
+#         '_id': poland_1_id
+#     }
+#     assert result_json[2]['country_1'] == []
+#     assert are_lists_of_dicts_equal(result_json[2]['country_array'], [
+#         {
+#             '_id': lithuania_1_id
+#         },
+#         {
+#             '_id': poland_0_id
+#         }
+#     ])
+#
+#     # Empty
+#     assert result_json[3]['country_0'] is None
+#     assert result_json[3]['country_1'] == []
+#     assert result_json[3]['country_array'] == []
 
 
 @pytest.mark.manifests('internal_sql', 'csv')

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1135,7 +1135,7 @@ def test_primary_key_can_not_be_an_array(manifest_type, tmp_path, rc):
               |   |   |   | country  | ref     | Country
         ''', manifest_type)
 
-    assert error.value.message == 'Array type object can not be used as a model primary key.'
+    assert error.value.message == 'Array type property can not be used as a model primary key.'
     assert error.value.context['model'] == 'example/Country'
     assert error.value.context['name'] == 'cities[]'
 

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1141,6 +1141,22 @@ def test_primary_key_can_not_be_an_array(manifest_type, tmp_path, rc):
 
 
 @pytest.mark.manifests('internal_sql', 'csv')
+def test_array_properties_not_inferred_as_pk_when_pk_not_explicitly_defined(manifest_type, tmp_path, rc):
+    check(tmp_path, rc, '''
+        d | r | b | m | property | type    | ref
+        example                  |         |
+                                 |         |
+          |   |   | Country      |         |
+          |   |   |   | id       | string  |
+          |   |   |   | cities[] | backref | City
+                                 |         |
+          |   |   | City         |         | name
+          |   |   |   | name     | string  |
+          |   |   |   | country  | ref     | Country
+    ''', manifest_type)
+
+
+@pytest.mark.manifests('internal_sql', 'csv')
 def test_primary_key_is_a_string_array_is_used_as_backref(manifest_type, tmp_path, rc):
     check(tmp_path, rc, '''
         d | r | b | m | property | type    | ref


### PR DESCRIPTION
`Array` type object can not be a PK for a model. With this pull request the logic is adjusted to throw a nice error message to the user specifying just that.

#### Notes:
- Added two tests, one, that proves that the error is thrown on the specific situation where PK has an array type object and another, that proves that backref works correctly, when the primary key is of allowed type. Not sure how much the second test is required, maybe someone with more experience on this project can tell me.