### PR TITLE
ft/1196-better-error-messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 #######
 
+0.2dev3 (unreleased)
+====================
+
+Bug fixes:
+
+- Add missing context to user facing error messages. (`#1196`_)
+
+  .. _#1196: https://github.com/atviriduomenys/spinta/issues/1196
+
 0.2dev2 (unreleased)
 ====================
 

--- a/spinta/backends/__init__.py
+++ b/spinta/backends/__init__.py
@@ -475,7 +475,7 @@ def simple_data_check(
         srid = dtype.srid
 
         if srid is None:
-            raise SRIDNotSetForGeometry(dtype)
+            raise SRIDNotSetForGeometry(dtype, property=prop)
 
         bounding_area = get_crs_bounding_area(srid)
 

--- a/spinta/backends/__init__.py
+++ b/spinta/backends/__init__.py
@@ -2104,3 +2104,7 @@ def get_error_context(backend: Backend, *, prefix='this') -> Dict[str, str]:
         'origin': f'{prefix}.origin',
         'features': f'{prefix}.features',
     }
+
+@commands.get_error_context.register(str)
+def get_error_context(message: str, *, prefix='this') -> Dict[str, str]:
+    return {}

--- a/spinta/backends/postgresql/components.py
+++ b/spinta/backends/postgresql/components.py
@@ -82,19 +82,21 @@ class PostgreSQL(Backend):
         )
         result = list(itertools.islice(result, 2))
 
-        if len(result) == 1:
+        number_of_rows = len(result)
+
+        if number_of_rows == 1:
             if scalar:
                 return result[0][columns[0]]
             else:
                 return result[0]
 
-        elif len(result) == 0:
+        elif number_of_rows == 0:
             if default is NA:
                 raise NotFoundError()
             else:
                 return default
         else:
-            raise MultipleRowsFound()
+            raise MultipleRowsFound(str(condition.left.table), number_of_rows=number_of_rows)
 
     def add_table(
         self,

--- a/spinta/backends/postgresql/types/geometry/helpers.py
+++ b/spinta/backends/postgresql/types/geometry/helpers.py
@@ -17,7 +17,7 @@ from spinta.types.geometry.constants import WGS84
 def get_osm_link(value: BaseGeometry, srid: Optional[Union[int, Geometry]]) -> Optional[str]:
     if isinstance(srid, Geometry):
         if srid.srid is None:
-            raise SRIDNotSetForGeometry(srid)
+            raise SRIDNotSetForGeometry(srid, property=srid.prop)
         srid = srid.srid
 
     if srid and srid != WGS84:

--- a/spinta/commands/write.py
+++ b/spinta/commands/write.py
@@ -550,11 +550,16 @@ async def read_existing_data(
         # When updating by id only, there must be exactly one existing record.
         if data.action == Action.UPSERT or _has_id_in_where(data.given):
             rows = list(itertools.islice(rows, 2))
-            if len(rows) == 1:
+            number_of_rows = len(rows)
+            if number_of_rows == 1:
                 data.saved = rows[0]
                 data.saved['_type'] = data.model.model_type()
-            elif len(rows) > 1:
-                data.error = exceptions.MultipleRowsFound(data.model, _id=rows[0]['_id'])
+            elif number_of_rows > 1:
+                data.error = exceptions.MultipleRowsFound(
+                    data.model,
+                    _id=rows[0]['_id'],
+                    number_of_rows=number_of_rows
+                )
                 report_error(data.error, data.given, stop_on_error=stop_on_error)
             elif data.action != Action.UPSERT:
                 data.error = exceptions.ItemDoesNotExist(data.model, id=data.given['_where']['args'][1])

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -290,7 +290,7 @@ class MultipleRowsFound(BaseError):
 
 
 class ManagedProperty(UserError):
-    template = "Value of this property is managed automatically and cannot be set manually."
+    template = "Value of property ({property}) under {this} is managed automatically and cannot be set manually."
 
 
 class InvalidManagedPropertyName(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -875,7 +875,7 @@ class FileSizeTooLarge(UserError):
 
 
 class SRIDNotSetForGeometry(BaseError):
-    template = "Geometry SRID is required, but was given None."
+    template = "{property} Geometry SRID is required, but was given None."
 
 
 class KeyNotFound(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -740,11 +740,6 @@ class BackendNotGiven(UserError):
     template = "Model ({this}) is operating in external mode, yet it does not have an assigned backend to it."
 
 
-class UnauthorizedKeymapSync(UserError):
-    code = 403
-    template = "You do not have permission to sync this model's keymap."
-
-
 class GivenValueCountMissmatch(BaseError):
     template = '''
     While assigning ref values {given_count} were given, but {expected_count} were expected.

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -371,10 +371,6 @@ class MultipleModelsInDependencies(BaseError):
     template = "Dependencies are allowed only from single model, but more than one model found: {models}."
 
 
-class MultipleCommandCallsInDependencies(BaseError):
-    template = "Only one command call is allowed."
-
-
 class MultipleCallsOrModelsInDependencies(BaseError):
     template = "Only one command call or one model is allowed in dependencies."
 

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -998,7 +998,7 @@ class MissingRefModel(UserError):
 
 
 class UnableToMapIntermediateTable(UserError):
-    template = 'Unable to map intermediate table to `Array` property.'
+    template = 'Unable to map intermediate table ({model}) to `Array` property.'
 
 
 class InvalidIntermediateTableMappingRefCount(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -589,7 +589,7 @@ class DupicateProperty(UserError):
 
 
 class RequiredProperty(UserError):
-    template = "Property is required."
+    template = "Property ({this}) is required."
 
 
 class UnableToCast(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -371,10 +371,6 @@ class MultipleModelsInDependencies(BaseError):
     template = "Dependencies are allowed only from single model, but more than one model found: {models}."
 
 
-class MultipleCallsOrModelsInDependencies(BaseError):
-    template = "Only one command call or one model is allowed in dependencies."
-
-
 class InvalidSource(BaseError):
     template = "Invalid source. {error}"
     context = {

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -860,7 +860,10 @@ class DatasetNameMissmatch(UserError):
 
 
 class DatasetSchemaRequiresIds(UserError):
-    template = "All given schema rows require UUID to be set in the id field."
+    template = """
+     All given schema rows require UUID to be set in the id field.
+     Schema: {this}
+    """
 
 
 class ModifySchemaRequiresFile(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -194,7 +194,7 @@ class ConflictingValue(UserError):
 
 
 class UniqueConstraint(UserError):
-    template = "Given value already exists."
+    template = "Given value ({value}) already exists."
 
 
 class InvalidOperandValue(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -239,7 +239,7 @@ class NoItemRevision(UserError):
 
 
 class JSONError(UserError):
-    template = "Invalid JSON."
+    template = "Invalid JSON for {this}. Original error - {error}."
 
 
 class InvalidValue(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -286,7 +286,7 @@ class AuthorizedClientsOnly(UserError):
 
 
 class MultipleRowsFound(BaseError):
-    template = "Multiple rows were found."
+    template = "Multiple ({number_of_rows}) rows were found under {this}."
 
 
 class ManagedProperty(UserError):

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -732,11 +732,6 @@ class DuplicateRowWhilePaginating(BaseError):
     template = "Encountered a duplicate row with page key: '{key}'"
 
 
-class UnauthorizedPropertyPush(UserError):
-    code = 403
-    template = "You do not have permission to push this property."
-
-
 class InvalidArgumentInExpression(BaseError):
     template = "Invalid {arguments} arguments given to {expr} expression."
 

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -737,7 +737,7 @@ class InvalidArgumentInExpression(BaseError):
 
 
 class BackendNotGiven(UserError):
-    template = "Model is operating in external mode, yet it does not have assigned backend to it."
+    template = "Model ({this}) is operating in external mode, yet it does not have an assigned backend to it."
 
 
 class UnauthorizedKeymapSync(UserError):

--- a/spinta/types/array/link.py
+++ b/spinta/types/array/link.py
@@ -68,7 +68,7 @@ def _extract_intermediate_table_properties(source: Array, intermediate_model: Mo
 
     ref_properties = [prop for prop in intermediate_model.flatprops.values() if isinstance(prop.dtype, Ref)]
     if len(ref_properties) != 2:
-        raise UnableToMapIntermediateTable(source)
+        raise UnableToMapIntermediateTable(source, model=source.model.name)
 
     if all(_compare_models(source.prop.model, prop.dtype.model) for prop in ref_properties):
         raise SameModelIntermediateTableMapping(source)

--- a/tests/backends/test_postgresql.py
+++ b/tests/backends/test_postgresql.py
@@ -233,7 +233,7 @@ def test_exceptions_unique_constraint_single_column(
         "errors": [{
             "type": "property",
             "code": "UniqueConstraint",
-            "template": "Given value already exists.",
+            "template": "Given value ({value}) already exists.",
             "context": {
                 "component": "spinta.components.Property",
                 "manifest": "default",
@@ -244,7 +244,7 @@ def test_exceptions_unique_constraint_single_column(
                 "property": "name",
                 "attribute": ""
             },
-            "message": "Given value already exists."
+            "message": "Given value ([UNKNOWN]) already exists."
         }]
     }
 

--- a/tests/cli/test_push.py
+++ b/tests/cli/test_push.py
@@ -9,7 +9,6 @@ import sqlalchemy_utils as su
 from requests.exceptions import ReadTimeout, ConnectTimeout
 
 from spinta.core.config import RawConfig
-from spinta.exceptions import UnauthorizedKeymapSync, CoordinatesOutOfRange
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.client import create_client, create_rc, configure_remote_server
@@ -1149,53 +1148,6 @@ def test_push_sync_keymap(
     assert resp_city.status_code == 200
     assert listdata(resp_city, 'name') == ['Vilnius']
     assert listdata(resp_city, '_id', 'id', 'name', 'country')[0] == (city_id, 1, 'Vilnius', {'_id': country_id})
-
-
-@pytest.mark.skip("Private now sends warning that model has been skipped syncing rather throwing exception")
-def test_push_sync_keymap_to_private_error(
-    context,
-    postgresql,
-    rc: RawConfig,
-    cli: SpintaCliRunner,
-    responses,
-    tmp_path,
-    geodb,
-    request
-):
-    with pytest.raises(UnauthorizedKeymapSync):
-        table = '''
-            d | r | b | m | property | type    | ref                             | source         | level | access
-            syncdataset              |         |                                 |                |       |
-              | db                   | sql     |                                 |                |       |
-              |   |   | City         |         | id                              | cities         | 4     |
-              |   |   |   | id       | integer |                                 | id             | 4     | open
-              |   |   |   | name     | string  |                                 | name           | 2     | open
-              |   |   |   | country  | ref     | /syncdataset/countries/Country | country        | 4     | open
-              |   |   |   |          |         |                                 |                |       |
-            syncdataset/countries    |         |                                 |                |       |
-              |   |   | Country      |         | code                            |                | 4     |
-              |   |   |   | code     | integer |                                 |                | 4     | private
-              |   |   |   | name     | string  |                                 |                | 2     | open
-            '''
-        create_tabular_manifest(context, tmp_path / 'manifest.csv', striptable(table))
-
-        # Configure local server with SQL backend
-        localrc = create_rc(rc, tmp_path, geodb)
-
-        # Configure remote server
-        remote = configure_remote_server(cli, localrc, rc, tmp_path, responses, remove_source=False)
-        request.addfinalizer(remote.app.context.wipe_all)
-
-        # Push data from local to remote.
-        assert remote.url == 'https://example.com/'
-        result = cli.invoke(localrc, [
-            'push',
-            '-o', remote.url,
-            '--credentials', remote.credsfile,
-            '--sync',
-            '--no-progress-bar',
-        ], fail=False)
-        raise result.exception
 
 
 def test_push_sync_keymap_private_no_error(

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1530,7 +1530,7 @@ def test_intermediate_table_same_model_unknown_mapping(manifest_type, tmp_path, 
 
 @pytest.mark.manifests('internal_sql', 'csv')
 def test_intermediate_table_invalid_mapping_multiple_references(manifest_type, tmp_path, rc):
-    with pytest.raises(UnableToMapIntermediateTable):
+    with pytest.raises(UnableToMapIntermediateTable) as e:
         check(tmp_path, rc, '''
                 d | r | b | m | property    | type    | ref             | access | title
                 example                     |         |                 |        |
@@ -1550,6 +1550,7 @@ def test_intermediate_table_invalid_mapping_multiple_references(manifest_type, t
                   |   |   |   | language    | ref     | Language        | open   |
                   |   |   |   | lang        | ref     | Language        | open   |
             ''', manifest_type)
+    assert e.value.message == 'Unable to map intermediate table (example/CountryLanguage) to `Array` property.'
 
 
 @pytest.mark.manifests('internal_sql', 'csv')

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1451,30 +1451,6 @@ def test_intermediate_table_invalid_mapping_refprops(manifest_type, tmp_path, rc
 
 
 @pytest.mark.manifests('internal_sql', 'csv')
-def test_intermediate_table_invalid_mapping_multiple_references(manifest_type, tmp_path, rc):
-    with pytest.raises(UnableToMapIntermediateTable):
-        check(tmp_path, rc, '''
-                d | r | b | m | property    | type    | ref             | access | title
-                example                     |         |                 |        |
-                                            |         |                 |        |
-                  |   |   | Language        |         | id              |        |
-                  |   |   |   | id          | integer |                 | open   |
-                  |   |   |   | name        | string  |                 | open   |
-                                            |         |                 |        |
-                  |   |   | Country         |         | id              |        |
-                  |   |   |   | id          | integer |                 | open   |
-                  |   |   |   | name        | string  |                 | open   |
-                  |   |   |   | languages   | array   | CountryLanguage | open   |
-                  |   |   |   | languages[] | ref     | Language        | open   |
-                                            |         |                 |        |
-                  |   |   | CountryLanguage |         |                 |        |
-                  |   |   |   | country     | ref     | Country         | open   |
-                  |   |   |   | language    | ref     | Language        | open   |
-                  |   |   |   | lang        | ref     | Language        | open   |
-            ''', manifest_type)
-
-
-@pytest.mark.manifests('internal_sql', 'csv')
 def test_intermediate_table_same_model_mapping_pkey(manifest_type, tmp_path, rc):
     check(tmp_path, rc, '''
             d | r | b | m | property    | type    | ref            | access | title

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,8 +5,8 @@ import spinta.commands  # noqa
 import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
-from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty
-from spinta.components import Node
+from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty, RequiredProperty
+from spinta.components import Node, Property
 
 
 class Error(BaseError):
@@ -234,6 +234,11 @@ def test_json_error_message(context):
             "Value of property (_revision) under <model "
              "name='datasets/backends/postgres/dataset/Report'> is managed automatically "
              "and cannot be set manually."
+        ],
+        [
+            RequiredProperty,
+            {"this": Property()},
+            "Property ([UNKNOWN]) is required."
         ],
     ],
 )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,8 +5,8 @@ import spinta.commands  # noqa
 import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
-from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound
-from spinta.components import Node, Property
+from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty
+from spinta.components import Node
 
 
 class Error(BaseError):
@@ -228,8 +228,18 @@ def test_json_error_message(context):
             {"this": "datasets/gov/push/file/Country", "number_of_rows": 3},
             "Multiple (3) rows were found under datasets/gov/push/file/Country."
         ],
+        [
+            ManagedProperty,
+            {"this": commands.get_model, "property": "_revision"},
+            "Value of property (_revision) under <model "
+             "name='datasets/backends/postgres/dataset/Report'> is managed automatically "
+             "and cannot be set manually."
+        ],
     ],
 )
 def test_error_messages(error: type[BaseError], params: dict, expected_message: str, context):
-    exception = error(params.pop("this"), **params)
+    this = params.pop("this")
+    if callable(this):
+        this = this(context, context.get('store').manifest, 'datasets/backends/postgres/dataset/Report')
+    exception = error(this, **params)
     assert exception.message == expected_message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,12 @@
 # Register get_error_context commands.
+import pytest
+
 import spinta.commands  # noqa
 import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
-from spinta.exceptions import BaseError, error_response, JSONError
-from spinta.components import Node
+from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound
+from spinta.components import Node, Property
 
 
 class Error(BaseError):
@@ -216,3 +218,18 @@ def test_json_error_message(context):
         "Original error - Expecting value: line 1 column 1 (char 0)."
     )
 
+
+
+@pytest.mark.parametrize(
+    argnames=["error", "params", "expected_message"],
+    argvalues=[
+        [
+            MultipleRowsFound,
+            {"this": "datasets/gov/push/file/Country", "number_of_rows": 3},
+            "Multiple (3) rows were found under datasets/gov/push/file/Country."
+        ],
+    ],
+)
+def test_error_messages(error: type[BaseError], params: dict, expected_message: str, context):
+    exception = error(params.pop("this"), **params)
+    assert exception.message == expected_message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,7 +5,8 @@ import spinta.commands  # noqa
 import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
-from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty, RequiredProperty
+from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty, \
+    RequiredProperty, BackendNotGiven
 from spinta.components import Node, Property
 
 
@@ -239,6 +240,12 @@ def test_json_error_message(context):
             RequiredProperty,
             {"this": Property()},
             "Property ([UNKNOWN]) is required."
+        ],
+        [
+            BackendNotGiven,
+            {"this": commands.get_model},
+            "Model (<model name='datasets/backends/postgres/dataset/Report'>) is operating in external mode, "
+            "yet it does not have an assigned backend to it."
         ],
     ],
 )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,8 +6,10 @@ import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
 from spinta.exceptions import BaseError, error_response, JSONError, MultipleRowsFound, ManagedProperty, \
-    RequiredProperty, BackendNotGiven
+    RequiredProperty, BackendNotGiven, SRIDNotSetForGeometry
 from spinta.components import Node, Property
+from spinta.types.datatype import DataType
+from spinta.types.geometry.components import Geometry
 
 
 class Error(BaseError):
@@ -219,7 +221,13 @@ def test_json_error_message(context):
         "Original error - Expecting value: line 1 column 1 (char 0)."
     )
 
-
+def test_geometry_error_message(context):
+    model = commands.get_model(context, context.get('store').manifest, 'Org')
+    property = model.properties['title']
+    error = SRIDNotSetForGeometry(property.dtype, property=property)
+    assert error.message == (
+        "<spinta.components.Property(name='title', type='string', model='Org')> Geometry SRID is required, but was given None."
+    )
 
 @pytest.mark.parametrize(
     argnames=["error", "params", "expected_message"],

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,7 +3,7 @@ import spinta.commands  # noqa
 import spinta.manifests.commands.error  # noqa
 from spinta import commands
 
-from spinta.exceptions import BaseError, error_response
+from spinta.exceptions import BaseError, error_response, JSONError
 from spinta.components import Node
 
 
@@ -207,3 +207,12 @@ def test_this_dataset_model_property(context):
         '    attribute: None\n'
         '    resource.backend: datasets/backends/postgres/dataset/sql\n'
     )
+
+
+def test_json_error_message(context):
+    exception = JSONError(Node(), error="Expecting value: line 1 column 1 (char 0)")
+    assert exception.message == (
+        "Invalid JSON for <spinta.components.Node(name=None)>. "
+        "Original error - Expecting value: line 1 column 1 (char 0)."
+    )
+


### PR DESCRIPTION
## Pull Request Summary  
This PR enhances error messages by adding relevant context and removes unused code to improve maintainability.  

## Error Message Improvements  
- Add property to **SRIDNotSetForGeometry** error message.  
- Add model name to **UnableToMapIntermediateTable** error message.  
- Add model name to **BackendNotGiven** error message.  
- Add property name to **RequiredProperty** error message.  
- Add property and model to **ManagedProperty** error message.  
- Add row count and location to **MultipleRowsFound** error message.  
- Add original error to **JSONError** message.  
- Add manifest **DatasetSchemaRequiresIds** 

## Removal of Unused Code  
- Remove **UnauthorizedKeymapSync** and its **test** (not used anywhere).  
- Remove **UnauthorizedPropertyPush** (not used anywhere).  
- Remove **MultipleCallsOrModelsInDependencies** (not used anywhere).  
- Remove **MultipleCommandCallsInDependencies** (not used anywhere).  

## Test Cleanup  
- Remove duplicated **UnableToMapIntermediateTable** test.  
