### PR TITLE
[1209] OpenAPI Schema: `Resource` dalies skaitymas

### DIFF
--- a/spinta/core/ufuncs.py
+++ b/spinta/core/ufuncs.py
@@ -29,11 +29,14 @@ class Expr:
         self.args = tuple(args)
         self.kwargs = kwargs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(spyna.unparse(self.todict(), raw=True))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(spyna.unparse(self.todict()))
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Expr) and self.todict() == other.todict()
 
     def todict(self) -> dict:
         args = [
@@ -51,7 +54,7 @@ class Expr:
             'args': args + kwargs,
         }
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Expr:
         return type(self)(self.name, *args, **kwargs)
 
     def resolve(self, env: Env) -> Tuple[List[Any], Dict[str, Any]]:

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -4,57 +4,75 @@ import json
 from pathlib import Path
 from typing import Generator
 
+from spinta.core.ufuncs import Expr
+from spinta.utils.naming import to_dataset_name, to_code_name
+
 
 def read_file_data_and_transform_to_json(path: Path) -> dict:
     with Path(path).open() as file:
         return json.load(file)
 
 
-def get_namespace_schemas(info: dict, title: str, dataset_prefix: str) -> Generator[tuple[None, dict]]:
+def get_namespace_schemas(info: dict, title: str, dataset_prefix: str) -> Generator[tuple[None, dict], None, None]:
     current_path = Path()
     path_parts = dataset_prefix.split('/')
-    is_last_part = lambda i: i == len(path_parts) - 1
 
     for index, part in enumerate(path_parts):
         current_path /= part
+        is_last = index == len(path_parts) - 1
         yield None, {
             'type': 'ns',
             'name': str(current_path),
-            'title': info.get('summary', title) if is_last_part(index) else '',
-            'description': info.get('description', '') if is_last_part(index) else '',
+            'title': info.get('summary', title) if is_last else '',
+            'description': info.get('description', '') if is_last else '',
         }
 
 
 def get_dataset_schemas(data: dict, dataset_prefix: str) -> Generator[tuple[None, dict]]:
-    seen_datasets = set()
-    tag_metadata = {tag['name']: tag.get('description', '') for tag in data.get('tags', {})}
+    datasets = {}
+    tag_metadata = {tag['name']: tag.get('description') for tag in data.get('tags', {})}
 
-    for api_metadata in data.get("paths", {}).values():
-        for http_method_metadata in api_metadata.values():
+    for api_endpoint, api_metadata in data.get('paths', {}).items():
+        for http_method, http_method_metadata in api_metadata.items():
             tags = http_method_metadata.get('tags', [])
             if not tags:
                 continue
 
-            dataset_name = '_'.join(tag.lower().replace(' ', '_') for tag in tags)
-            if dataset_name in seen_datasets:
-                continue
+            dataset_name = to_dataset_name('_'.join(tags))
+            if dataset_name not in datasets:
+                datasets[dataset_name] = {
+                    'type': 'dataset',
+                    'name': f'{dataset_prefix}/{dataset_name}',
+                    'title': ', '.join(tags),
+                    'description': ', '.join(tag_metadata[tag] for tag in tags if tag in tag_metadata),
+                    'resources': {}
+                }
 
-            seen_datasets.add(dataset_name)
-            yield None, {
-                'type': 'dataset',
-                'name': f'{dataset_prefix}/{dataset_name}',
-                'title': ', '.join(tags),
-                'description': ', '.join(tag_metadata[tag] for tag in tags if tag in tag_metadata)
+            resource_source = f'{api_endpoint}/{http_method}'
+            resource_name = to_code_name(resource_source)
+            datasets[dataset_name]['resources'][resource_name] = {
+                'type': 'dask/json',
+                'id': http_method_metadata.get('operationId'),
+                'external': api_endpoint,
+                'prepare': Expr('http', method=http_method.upper(), body='form'),
+                'title': http_method_metadata.get('summary'),
+                'description': http_method_metadata.get('description'),
             }
+
+    for dataset in datasets.values():
+        yield None, dataset
 
 
 def read_open_api_manifest(path: Path) -> Generator[tuple[None, dict]]:
+    """Transforms OpenAPI Schema structure to DSA.
+
+    OpenAPI Schema specification: https://spec.openapis.org/oas/latest.html.
+    """
     data = read_file_data_and_transform_to_json(path)
 
-    # https://spec.openapis.org/oas/latest.html#info-object
     info = data['info']
     title = info['title']
-    dataset_prefix = f'services/{title.lower().replace(" ", "_").replace("/", "_")}'
+    dataset_prefix = f'services/{to_dataset_name(title)}'
 
     yield from get_namespace_schemas(info, title, dataset_prefix)
 

--- a/tests/manifests/open_api/test_helpers.py
+++ b/tests/manifests/open_api/test_helpers.py
@@ -1,6 +1,8 @@
 import json
+import uuid
 from pathlib import Path
 
+from spinta.core.ufuncs import Expr
 from spinta.manifests.open_api.helpers import (
     read_file_data_and_transform_to_json,
     get_dataset_schemas,
@@ -24,7 +26,7 @@ def test_read_file_data_and_transform_to_json(tmp_path: Path):
     assert result == file_data
 
 
-def test_get_namespace_schema():
+def test_get_namespace_schemas():
     title = 'Geography API'
     dataset_prefix = 'services/geography_api'
     data = {
@@ -54,7 +56,9 @@ def test_get_namespace_schema():
     ]
 
 
-def test_get_dataset_schema():
+def test_get_dataset_schemas():
+    resource_countries_id = str(uuid.uuid4().hex)
+    resource_cities_id = str(uuid.uuid4().hex)
     data = {
         'info': {
             'title': 'Geography API',
@@ -62,15 +66,31 @@ def test_get_dataset_schema():
             'summary': 'API for geographic objects',
             'description': 'Intricate description'
         },
+        'tags': [
+            {
+                'name': 'List of Countries',
+                'description': 'List known countries'
+            },
+            {
+                'name': 'Cities',
+                'description': 'Known cities'
+            }
+        ],
         'paths': {
             '/api/countries': {
                 'get': {
-                    'tags': ['List of Countries']
+                    'tags': ['List of Countries'],
+                    'summary': 'List of countries API',
+                    'description': 'List of known countries in the world',
+                    'operationId': resource_countries_id
                 }
             },
             '/api/cities' : {
                 'get': {
-                    'tags': ['List', 'Cities']
+                    'tags': ['List', 'Cities'],
+                    'summary': 'List of cities API',
+                    'description': 'List of known cities in the world',
+                    'operationId': resource_cities_id
                 }
             }
         }
@@ -83,12 +103,32 @@ def test_get_dataset_schema():
             'type': 'dataset',
             'name': 'services/geography_api/list_of_countries',
             'title': "List of Countries",
-            'description': ''
+            'description': 'List known countries',
+            'resources': {
+                'api_countries_get': {
+                    'id': resource_countries_id,
+                    'external': '/api/countries',
+                    'type': 'dask/json',
+                    'prepare': Expr('http', method='GET', body='form'),
+                    'title': 'List of countries API',
+                    'description': 'List of known countries in the world'
+                }
+            }
         },
         {
             'type': 'dataset',
             'name': 'services/geography_api/list_cities',
             'title': "List, Cities",
-            'description': ''
+            'description': 'Known cities',
+            'resources': {
+                'api_cities_get': {
+                    'id': resource_cities_id,
+                    'external': '/api/cities',
+                    'type': 'dask/json',
+                    'prepare': Expr('http', method='GET', body='form'),
+                    'title': 'List of cities API',
+                    'description': 'List of known cities in the world'
+                }
+            }
         }
     ]

--- a/tests/manifests/open_api/test_openapi.py
+++ b/tests/manifests/open_api/test_openapi.py
@@ -7,6 +7,7 @@ from spinta.testing.manifest import load_manifest
 
 def test_open_api_manifest(rc: RawConfig, tmp_path: Path):
     # TODO: Update everytime a new part is supported
+    api_countries_get_id = '097b4270882b4facbd9d9ce453f8c196'
     data = json.dumps({
         'openapi': '3.0.0',
         'info': {
@@ -24,18 +25,22 @@ def test_open_api_manifest(rc: RawConfig, tmp_path: Path):
         'paths': {
             '/api/countries': {
                 'get': {
-                    'tags': ['List of Countries']
+                    'tags': ['List of Countries'],
+                    'summary': 'Countries',
+                    'description': 'Lists known countries',
+                    'operationId': api_countries_get_id
                 }
             },
         }
     })
 
-    table = '''
-    id | d | r | b | m | property               | type | ref | source | prepare | level | access | uri | title             | description
-       | services                               | ns   |     |        |         |       |        |     |                   |
-       | services/example_api                   | ns   |     |        |         |       |        |     | Example of an API | Intricate description
-       |                                        |      |     |        |         |       |        |     |                   |
-       | services/example_api/list_of_countries |      |     |        |         |       |        |     | List of Countries | A list of world countries
+    table = f'''
+    id | d | r | b | m | property               | type      | ref | source         | prepare                           | level | access | uri | title             | description
+       | services                               | ns        |     |                |                                   |       |        |     |                   |
+       | services/example_api                   | ns        |     |                |                                   |       |        |     | Example of an API | Intricate description
+       |                                        |           |     |                |                                   |       |        |     |                   |
+       | services/example_api/list_of_countries |           |     |                |                                   |       |        |     | List of Countries | A list of world countries
+    09 |   | api_countries_get                  | dask/json |     | /api/countries | http(method: 'GET', body: 'form') |       |        |     | Countries         | Lists known countries
     '''
 
     path = tmp_path / 'manifest.json'
@@ -88,10 +93,10 @@ def test_open_api_manifest_title_with_slashes(rc: RawConfig, tmp_path: Path):
     })
 
     table = '''
-        id | d | r | b | m | property                 | type | ref | source | prepare | level | access | uri | title             | description
-           | services                                 | ns   |     |        |         |       |        |     |                   |
-           | services/example_api_example_for_example | ns   |     |        |         |       |        |     | Example of an API | Intricate description
-           |                                          |      |     |        |         |       |        |     |                   |
+        id | d | r | b | m | property     | type | ref | source | prepare | level | access | uri | title             | description
+           | services                     | ns   |     |        |         |       |        |     |                   |
+           | services/example_for_example | ns   |     |        |         |       |        |     | Example of an API | Intricate description
+           |                              |      |     |        |         |       |        |     |                   |
         '''
 
     path = tmp_path / 'manifest.json'


### PR DESCRIPTION
Pridėta galimybė nuskaityti `Resource` dimensiją. Ji yra pateikiama Dataset schemos dalyje, po raktu `resources`. Likęs kodas perrašytas atitinkamai atsižvelgiant į reikalaujamus pokyčius/optimalų duomenų surinkimą.

#### Dokumentacija schemos konvertavimui:
- https://spinta.readthedocs.io/en/latest/contrib/manifests.html#adding-new-manifest-type