### PR TITLE
Run Spinta tests on pull request to any branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ master, '[0-9]+.[0-9]+' ]
   pull_request:
-    branches: [ master, '[0-9]+.[0-9]+' ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
**Summary:**

Run Spinta CI/CD on every opened, reopened and edited pull request. Helps when working with multiple branches that are not merged to master yet.