### PR TITLE
ft/1275 implement creds() prepare function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,13 @@ Changes
 ====================
 
 New Features:
-- Add support for specifying SOAP request body in SOAP requests.(`#1274`_)
+- Added support for specifying SOAP request body in SOAP requests.(`#1274`_)
+- Allow `Client` POST and PATCH endpoints to save variable `backends` that can store
+  extra authentication data. Implement `.creds("key")` prepare function to read values
+  from saved `backends`. (`#1275`_)
 
   .. _#1274: https://github.com/atviriduomenys/spinta/issues/1274
+  .. _#1275: https://github.com/atviriduomenys/spinta/issues/1275
 
 0.2dev3
 =======

--- a/spinta/datasets/backends/dataframe/backends/soap/commands/read.py
+++ b/spinta/datasets/backends/dataframe/backends/soap/commands/read.py
@@ -13,7 +13,6 @@ from spinta.datasets.backends.dataframe.commands.read import (
     dask_get_all
 )
 from spinta.datasets.backends.dataframe.ufuncs.query.components import DaskDataFrameQueryBuilder
-from spinta.datasets.utils import iterparams
 from spinta.dimensions.param.components import ResolvedParams
 from spinta.exceptions import SoapRequestBodyParseError
 from spinta.typing import ObjectData
@@ -100,10 +99,8 @@ def getall(
     )
     bases = list(bases)
 
-    resource_params = {param.name: param for param in model.external.resource.params}
-
     builder = backend.query_builder_class(context)
-    builder = builder.init(backend=backend, model=model, resource_params=resource_params, query_params=params)
+    builder = builder.init(backend=backend, model=model, query_params=params)
     query = builder.resolve(query)
     builder.build()
 

--- a/spinta/datasets/backends/dataframe/backends/soap/ufuncs/components.py
+++ b/spinta/datasets/backends/dataframe/backends/soap/ufuncs/components.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from spinta.components import Model
 from spinta.datasets.backends.dataframe.backends.soap.components import Soap
-from spinta.datasets.components import Param
 from spinta.ufuncs.querybuilder.components import QueryBuilder, QueryParams
 
 
@@ -16,7 +15,6 @@ class SoapQueryBuilder(QueryBuilder):
         self,
         backend: Soap,
         model: Model,
-        resource_params: list[Param],
         query_params: QueryParams,
     ) -> SoapQueryBuilder:
         builder = self(
@@ -24,7 +22,7 @@ class SoapQueryBuilder(QueryBuilder):
             model=model,
         )
         builder.update(soap_request_body={}, property_values={})
-        builder.update(params=resource_params)
+        builder.update(params={param.name: param for param in model.external.resource.params})
         builder.init_query_params(query_params)
 
         return builder

--- a/spinta/datasets/backends/dataframe/backends/soap/ufuncs/ufuncs.py
+++ b/spinta/datasets/backends/dataframe/backends/soap/ufuncs/ufuncs.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from spinta.auth import authorized
+from spinta.auth import authorized, query_client
 from spinta.components import Property
 from spinta.core.enums import Action
 from spinta.core.ufuncs import ufunc, Expr, Bind, ShortExpr
 from spinta.datasets.backends.dataframe.backends.soap.ufuncs.components import SoapQueryBuilder
 from spinta.datasets.components import Param
+from spinta.exceptions import InvalidClientBackendCredentials, InvalidClientBackend, UnknownMethod
+from spinta.utils.config import get_clients_path
 from spinta.utils.data import take
 from spinta.utils.schema import NA
 
@@ -42,16 +44,32 @@ def and_(env: SoapQueryBuilder, args: list) -> Any:
         return args[0]
 
 
-@ufunc.resolver(SoapQueryBuilder)
-def soap_request_body(env: SoapQueryBuilder) -> None:
-    """
-    Loops through all model properties and populates env.soap_request_body
-    using variables from resource.param and URL parameters
-    """
+def _finalize_soap_request_body_resolve(env: SoapQueryBuilder) -> None:
+    for param_body_key, param_body_value in env.soap_request_body.items():
+        if not isinstance(param_body_value, Expr):
+            continue
+        env.soap_request_body[param_body_key] = env.resolve(param_body_value)
+
+
+def _populate_soap_request_body_with_url_values(env: SoapQueryBuilder) -> None:
     for prop in take(env.model.properties).values():
         if not authorized(env.context, prop, Action.GETALL):
             continue
         env.call("soap_request_body", prop)
+
+
+@ufunc.resolver(SoapQueryBuilder)
+def soap_request_body(env: SoapQueryBuilder) -> None:
+    """
+    Populates env.soap_request_body looping through properties and through resource params
+    """
+    for param in env.params.values():
+        if not hasattr(param, "soap_body"):
+            continue
+        env.soap_request_body.update(param.soap_body)
+
+    _finalize_soap_request_body_resolve(env)
+    _populate_soap_request_body_with_url_values(env)
 
 
 @ufunc.resolver(SoapQueryBuilder, Property)
@@ -70,20 +88,44 @@ def soap_request_body(env: SoapQueryBuilder, prop: Property) -> None:
         return None
 
     resource_param = env(this=prop).resolve(prop.external.prepare)
+
     env.call("soap_request_body", prop, resource_param)
 
 
 @ufunc.resolver(SoapQueryBuilder, Property, Param)
 def soap_request_body(env: SoapQueryBuilder, prop: Property, param: Param) -> None:
-    # Replace default param.soap_body values with url_param values
+    """Replace default param.soap_body values with url_param values"""
     url_param_value = env.query_params.url_params.get(prop.place)
-    param_soap_body = {
-        key: url_param_value or (value if value is not NA else None)
-        for key, value in param.soap_body.items()
-    }
 
-    # param row can only have one value, so we take this value
-    param_value = list(param_soap_body.values())[0] if param_soap_body else None
+    final_value = None
+    for param_body_key in param.soap_body.keys():
+        soap_body_value = env.soap_request_body.get(param_body_key)
+        final_value = url_param_value or (soap_body_value if soap_body_value is not NA else None)
+        env.soap_request_body[param_body_key] = final_value
 
-    env.soap_request_body.update(param_soap_body)
-    env.property_values.update({param.name: param_value})
+    env.property_values.update({param.name: final_value})
+
+
+@ufunc.resolver(SoapQueryBuilder, str)
+def creds(env: SoapQueryBuilder, credential_key: str) -> Any:
+    client_config_file = query_client(
+        get_clients_path(env.context.get('config')),
+        env.context.get('auth.token').get_aud()
+    )
+    backend_name = env.model.external.resource.name
+
+    client_backend = client_config_file.backends.get(backend_name)
+    if not client_backend:
+        raise InvalidClientBackend(backend_name=backend_name)
+
+    try:
+        credential = client_backend[credential_key]
+    except KeyError:
+        raise InvalidClientBackendCredentials(key=credential_key, backend_name=backend_name)
+
+    return credential
+
+
+@ufunc.resolver(SoapQueryBuilder)
+def creds(env: SoapQueryBuilder) -> Any:
+    raise UnknownMethod(expr="creds()", name="creds")

--- a/spinta/dimensions/param/helpers.py
+++ b/spinta/dimensions/param/helpers.py
@@ -11,21 +11,27 @@ from spinta.ufuncs.loadbuilder.components import LoadBuilder
 from spinta.utils.schema import NA
 
 
-def load_param_formulas(context: Context, param: Param, prepare_asts: list[dict]) -> None:
-    formulas = []
+def load_param_formulas_and_sources(
+    context: Context, param: Param, prepare_asts: list[dict], sources: list[str]
+) -> None:
+    param_formulas = []
+    param_sources = []
     builder = LoadBuilder(context)
-    for source, ast in zip(param.sources, prepare_asts):
+    for source, ast in zip(sources, prepare_asts):
         builder.update(this=source, param=param)
 
         # If possible - resolve formulas with LoadBuilder
         expr = asttoexpr(ast)
         if isinstance(expr, Expr):
             if formula := builder.resolve(expr):
-                formulas.append(formula)
+                param_formulas.append(formula)
+                param_sources.append(source)
         else:
-            formulas.append(expr)
+            param_formulas.append(expr)
+            param_sources.append(source)
 
-    param.formulas = formulas
+    param.formulas = param_formulas
+    param.sources = param_sources
 
 
 def load_params(context: Context, manifest: Manifest, param_data: Any) -> List[Param]:
@@ -34,8 +40,7 @@ def load_params(context: Context, manifest: Manifest, param_data: Any) -> List[P
         for key, data in param_data.items():
             param = Param()
             load_node(context, param, data)
-            param.sources = data['source'].copy()
-            load_param_formulas(context, param, data['prepare'])
+            load_param_formulas_and_sources(context, param, data['prepare'], data['source'].copy())
             param.name = data['name']
             params.append(param)
     elif isinstance(param_data, list):
@@ -54,8 +59,7 @@ def load_params(context: Context, manifest: Manifest, param_data: Any) -> List[P
                     'description': ''
                 }
                 load_node(context, param, data)
-                param.sources = data['source'].copy()
-                load_param_formulas(context, param, data['prepare'])
+                load_param_formulas_and_sources(context, param, data['prepare'], data['source'].copy())
                 param.name = data['name']
                 params.append(param)
 
@@ -78,4 +82,3 @@ def finalize_param_link(context, manifest: Manifest):
                         if isinstance(source, Model):
                             if source.external and source.external.resource:
                                 param.dependencies.update(source.external.resource.source_params)
-

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -967,6 +967,14 @@ class InvalidScopes(UserError):
     template = "Request contains invalid, unknown or malformed scopes: {scopes}."
 
 
+class InvalidClientBackend(UserError):
+    template = '''Backend "{backend_name}" does not exist in configured client's backends.'''
+
+
+class InvalidClientBackendCredentials(UserError):
+    template = '''Credential "{key}" does not exist in client's backend "{backend_name}".'''
+
+
 class DirectRefValueUnassignment(UserError):
     template = '''
     Cannot directly set ref's _id value to None.

--- a/tests/datasets/dataframe/backends/soap/ufuncs/test_ufuncs.py
+++ b/tests/datasets/dataframe/backends/soap/ufuncs/test_ufuncs.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
+
+import pathlib
+import uuid
+
 import pytest
+from pytest_mock import MockerFixture
 
 from spinta import auth
-from spinta.auth import AdminToken, BearerTokenValidator
+from spinta.auth import AdminToken, BearerTokenValidator, ensure_client_folders_exist
 from spinta.backends.helpers import load_query_builder_class
 from spinta.commands import get_model
 from spinta.components import Context
@@ -10,27 +15,47 @@ from spinta.core.config import RawConfig
 from spinta.core.enums import Mode
 from spinta.core.ufuncs import asttoexpr
 from spinta.datasets.backends.dataframe.backends.soap.ufuncs.components import SoapQueryBuilder
-from spinta.exceptions import PropertyNotFound, UnknownMethod
+from spinta.exceptions import PropertyNotFound, UnknownMethod, InvalidClientBackend, InvalidClientBackendCredentials
 from spinta.manifests.components import Manifest
 from spinta.spyna import parse, unparse
 from spinta.testing.manifest import prepare_manifest
 from spinta.ufuncs.querybuilder.components import QueryParams
+from spinta.utils.config import get_clients_path
 
 
 def _get_soap_query_builder(
     context: Context,
     manifest: Manifest,
-    resource_params: dict | None = None,
     query_params: QueryParams | None = None,
 ) -> SoapQueryBuilder:
-    resource_params = resource_params or {}
     query_params = query_params or QueryParams()
 
     model = get_model(context, manifest, 'example/City')
     load_query_builder_class(context.get("config"), model.backend)
     query_builder = model.backend.query_builder_class(context)
 
-    return query_builder.init(model.backend, model, resource_params, query_params)
+    return query_builder.init(model.backend, model, query_params)
+
+
+def _set_auth_token_with_client_file(
+    context: Context, clients_path: pathlib.Path, client_backends: dict
+) -> None:
+    ensure_client_folders_exist(clients_path)
+    client_id = uuid.uuid4()
+    auth.create_client_file(
+        clients_path,
+        name=str(client_id),
+        client_id=str(client_id),
+        secret='secret',
+        scopes=['spinta_getall'],
+        backends=client_backends,
+        add_secret=True,
+    )
+
+    pkey = auth.load_key(context, auth.KeyType.private)
+    token = auth.create_access_token(context, pkey, str(client_id), scopes={'spinta_getall'})
+    token = auth.Token(token, BearerTokenValidator(context))
+    context.set('auth.token', token)
 
 
 def _get_wsdl_soap_manifest(rc: RawConfig) -> tuple[Context, Manifest]:
@@ -107,7 +132,7 @@ class TestAnd:
 
 
 class TestSoapRequestBody:
-    def test_only_use_properties_if_node_is_authorized(self, rc: RawConfig) -> None:
+    def test_only_read_url_values_for_authorized_properties(self, rc: RawConfig) -> None:
         context, manifest = prepare_manifest(rc, """
             d | r | b | m | property | type    | ref        | source                                          | access | prepare
             example                  | dataset |            |                                                 |        |
@@ -125,17 +150,15 @@ class TestSoapRequestBody:
         token = auth.Token(token, BearerTokenValidator(context))
         context.set('auth.token', token)
 
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
-        soap_query_builder = _get_soap_query_builder(context, manifest, resource_params=resource_params)
+        query_params = QueryParams()
+        query_params.url_params = {"p1": "url_value"}
+        soap_query_builder = _get_soap_query_builder(context, manifest, query_params)
         soap_query_builder.build()
 
-        assert soap_query_builder.soap_request_body == {}
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "default_val"}
         assert soap_query_builder.property_values == {}
 
-    def test_skip_property_if_it_has_external_name(self, rc: RawConfig) -> None:
+    def test_skip_url_param_reading_if_property_has_external_name(self, rc: RawConfig) -> None:
         context, manifest = prepare_manifest(rc, """
             d | r | b | m | property | type    | ref        | source                                          | access | prepare
             example                  | dataset |            |                                                 |        |
@@ -148,17 +171,15 @@ class TestSoapRequestBody:
             """, mode=Mode.external)
         context.set('auth.token', AdminToken())
 
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
-        soap_query_builder = _get_soap_query_builder(context, manifest, resource_params=resource_params)
+        query_params = QueryParams()
+        query_params.url_params = {"p1": "url_value"}
+        soap_query_builder = _get_soap_query_builder(context, manifest, query_params)
         soap_query_builder.build()
 
-        assert soap_query_builder.soap_request_body == {}
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "default_val"}
         assert soap_query_builder.property_values == {}
 
-    def test_skip_property_if_it_has_no_expression_in_prepare(self, rc: RawConfig) -> None:
+    def test_skip_url_param_reading_if_property_has_no_expression_in_prepare(self, rc: RawConfig) -> None:
         context, manifest = prepare_manifest(rc, """
             d | r | b | m | property | type    | ref        | source                                          | access | prepare
             example                  | dataset |            |                                                 |        |
@@ -168,18 +189,15 @@ class TestSoapRequestBody:
               |   |   | City         |         | id         | /                                               | open   |
               |   |   |   | id       | integer |            | id                                              |        |
               |   |   |   | p1       | integer |            |                                                 |        |
-
             """, mode=Mode.external)
         context.set('auth.token', AdminToken())
 
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
-        soap_query_builder = _get_soap_query_builder(context, manifest, resource_params=resource_params)
+        query_params = QueryParams()
+        query_params.url_params = {"p1": "url_value"}
+        soap_query_builder = _get_soap_query_builder(context, manifest, query_params)
         soap_query_builder.build()
 
-        assert soap_query_builder.soap_request_body == {}
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "default_val"}
         assert soap_query_builder.property_values == {}
 
     def test_build_body_from_request_param_source_and_default_value_if_url_param_not_given(self, rc: RawConfig) -> None:
@@ -192,15 +210,10 @@ class TestSoapRequestBody:
               |   |   | City         |         | id         | /                                               | open   |
               |   |   |   | id       | integer |            | id                                              |        |
               |   |   |   | p1       | integer |            |                                                 |        | param(parameter1)
-
             """, mode=Mode.external)
         context.set('auth.token', AdminToken())
 
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
-        soap_query_builder = _get_soap_query_builder(context, manifest, resource_params=resource_params)
+        soap_query_builder = _get_soap_query_builder(context, manifest)
         soap_query_builder.build()
 
         assert soap_query_builder.soap_request_body == {"request_model/param1": "default_val"}
@@ -216,21 +229,13 @@ class TestSoapRequestBody:
               |   |   | City         |         | id         | /                                               | open   |
               |   |   |   | id       | integer |            | id                                              |        |
               |   |   |   | p1       | integer |            |                                                 |        | param(parameter1)
-
             """, mode=Mode.external)
         context.set('auth.token', AdminToken())
 
         query_params = QueryParams()
         query_params.url_params = {"p1": "url_value"}
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
         soap_query_builder = _get_soap_query_builder(
-            context,
-            manifest,
-            resource_params=resource_params,
-            query_params=query_params,
+            context, manifest, query_params=query_params
         )
         soap_query_builder.build()
 
@@ -249,16 +254,183 @@ class TestSoapRequestBody:
               |   |   | City         |         | id         | /                                               | open   |
               |   |   |   | id       | integer |            | id                                              |        |
               |   |   |   | p1       | integer |            |                                                 |        | param(parameter1)
-
             """, mode=Mode.external)
         context.set('auth.token', AdminToken())
 
-        model = get_model(context, manifest, 'example/City')
-        resource_params = {
-            param.name: param for param in model.external.resource.params
-        }
-        soap_query_builder = _get_soap_query_builder(context, manifest, resource_params=resource_params)
+        soap_query_builder = _get_soap_query_builder(context, manifest)
         soap_query_builder.build()
 
         assert soap_query_builder.soap_request_body == {"request_model/param1": None}
         assert soap_query_builder.property_values == {"parameter1": None}
+
+    def test_build_body_from_params_without_property_defined(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = prepare_manifest(rc, """
+            d | r | b | m | property | type    | ref        | source                                          | access | prepare
+            example                  | dataset |            |                                                 |        |
+              | wsdl_resource        | wsdl    |            | tests/datasets/backends/wsdl/data/wsdl.xml      |        |
+              | soap_resource        | soap    |            | CityService.CityPort.CityPortType.CityOperation |        | wsdl(wsdl_resource)
+              |   |   |   |          | param   | parameter1 | request_model/param1                            | open   | creds("foo").input()
+              |   |   | City         |         | id         | /                                               | open   |
+              |   |   |   | id       | integer |            | id                                              |        |
+            """, mode=Mode.external)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"foo": "foo_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+        soap_query_builder.build()
+
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "foo_result"}
+        assert soap_query_builder.property_values == {}
+
+    def test_skip_build_body_if_soap_body_does_not_exist(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = prepare_manifest(rc, """
+            d | r | b | m | property | type    | ref        | source                                          | access | prepare
+            example                  | dataset |            |                                                 |        |
+              | wsdl_resource        | wsdl    |            | tests/datasets/backends/wsdl/data/wsdl.xml      |        |
+              | soap_resource        | soap    |            | CityService.CityPort.CityPortType.CityOperation |        | wsdl(wsdl_resource)
+              |   |   |   |          | param   | parameter1 | request_model/param1                            | open   | creds("foo")
+              |   |   | City         |         | id         | /                                               | open   |
+              |   |   |   | id       | integer |            | id                                              |        |
+            """, mode=Mode.external)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"foo": "foo_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+        soap_query_builder.build()
+
+        assert soap_query_builder.soap_request_body == {}
+        assert soap_query_builder.property_values == {}
+
+    def test_soap_request_body_values_does_not_persist_between_multiple_calls(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = prepare_manifest(rc, """
+        d | r | b | m | property | type    | ref        | source                                          | access | prepare
+        example                  | dataset |            |                                                 |        |
+          | wsdl_resource        | wsdl    |            | tests/datasets/backends/wsdl/data/wsdl.xml      |        |
+          | soap_resource        | soap    |            | CityService.CityPort.CityPortType.CityOperation |        | wsdl(wsdl_resource)
+          |   |   |   |          | param   | parameter1 | request_model/param1                            | open   | creds("par1").input()
+          |   |   | City         |         | id         | /                                               | open   |
+          |   |   |   | id       | integer |            | id                                              |        |
+          |   |   |   | p1       | integer |            |                                                 |        | param(parameter1)
+        """, mode=Mode.external)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"par1": "cred_value"}}
+        )
+
+        query_params = QueryParams()
+        query_params.url_params = {"p1": "url_value"}
+        soap_query_builder = _get_soap_query_builder(context, manifest, query_params=query_params)
+        soap_query_builder.build()
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "url_value"}
+        assert soap_query_builder.property_values == {"parameter1": "url_value"}
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+        soap_query_builder.build()
+        assert soap_query_builder.soap_request_body == {"request_model/param1": "cred_value"}
+        assert soap_query_builder.property_values == {"parameter1": "cred_value"}
+
+
+class TestCreds:
+    def test_return_value_from_client_config_backend(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = _get_wsdl_soap_manifest(rc)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"foo": "foo_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+
+        expr = asttoexpr(parse('creds("foo")'))
+        assert soap_query_builder.resolve(expr) == "foo_result"
+
+    def test_raise_error_if_resource_name_is_not_part_of_client_config_backends(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = _get_wsdl_soap_manifest(rc)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"test_resource": {"foo": "foo_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+
+        expr = asttoexpr(parse('creds("foo")'))
+        with pytest.raises(InvalidClientBackend):
+            soap_query_builder.resolve(expr)
+
+    def test_raise_error_if_credential_key_is_not_defined_in_client_config_backend(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = _get_wsdl_soap_manifest(rc)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"bar": "bar_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+
+        expr = asttoexpr(parse('creds("foo")'))
+        with pytest.raises(InvalidClientBackendCredentials):
+            soap_query_builder.resolve(expr)
+
+    def test_raise_error_if_creds_given_without_key(
+        self, rc: RawConfig, tmp_path: pathlib.Path, mocker: MockerFixture
+    ) -> None:
+        context, manifest = _get_wsdl_soap_manifest(rc)
+
+        clients_path = get_clients_path(tmp_path)
+        mocker.patch(
+            "spinta.datasets.backends.dataframe.backends.soap.ufuncs.ufuncs.get_clients_path",
+            return_value=clients_path
+        )
+        _set_auth_token_with_client_file(
+            context, clients_path, client_backends={"soap_resource": {"bar": "bar_result"}}
+        )
+
+        soap_query_builder = _get_soap_query_builder(context, manifest)
+
+        expr = asttoexpr(parse('creds()'))
+        with pytest.raises(UnknownMethod, match="Unknown method 'creds' with args"):
+            soap_query_builder.resolve(expr)

--- a/tests/dimensions/param/test_helpers.py
+++ b/tests/dimensions/param/test_helpers.py
@@ -1,34 +1,36 @@
 from spinta.components import Context
 from spinta.core.ufuncs import asttoexpr
 from spinta.datasets.components import Param
-from spinta.dimensions.param.helpers import load_param_formulas
+from spinta.dimensions.param.helpers import load_param_formulas_and_sources
 from spinta.spyna import parse
 
 
 class TestLoadParamFormulas:
-    def test_add_expr_to_formula_if_it_cannot_be_resolved_by_load_builder(self, context: Context) -> None:
+    def test_add_to_formula_and_source_if_formula_cannot_be_resolved_by_load_builder(self, context: Context) -> None:
         param = Param()
-        param.sources = ["test_source"]
 
         ast = parse("read()")
-        load_param_formulas(context, param, [ast])
+        load_param_formulas_and_sources(context, param, [ast], ["test_source"])
 
         assert param.formulas == [asttoexpr(ast)]
+        assert param.sources == ["test_source"]
 
-    def test_add_multiple_formulas_if_it_cannot_be_resolved_by_load_builder(self, context: Context) -> None:
+    def test_add_multiple_formula_and_source_if_formula_cannot_be_resolved_by_load_builder(
+        self, context: Context
+    ) -> None:
         param = Param()
-        param.sources = ["test_source1", "test_source2"]
 
         ast = parse("read()")
-        load_param_formulas(context, param, [ast, ast])
+        load_param_formulas_and_sources(context, param, [ast, ast], ["test_source1", "test_source2"])
 
         assert param.formulas == [asttoexpr(ast), asttoexpr(ast)]
+        assert param.sources == ["test_source1", "test_source2"]
 
-    def test_do_not_add_formula_if_it_is_resolved_by_load_builder(self, context: Context) -> None:
+    def test_do_not_add_formula_and_source_if_formula_is_resolved_by_load_builder(self, context: Context) -> None:
         param = Param()
-        param.sources = ["test_source"]
 
         ast = parse("input()")
-        load_param_formulas(context, param, [ast])
+        load_param_formulas_and_sources(context, param, [ast], ["test_source"])
 
         assert param.formulas == []
+        assert param.sources == []


### PR DESCRIPTION
**Summary:**
Adds `creds("key")` prepare function that used with resource parameters that reads extra data service authentication data from client file. If `creds(...).input()` used - it will read `key` from client file and will use it in SOAP request body.

For this to work, client file must have backends saved:
```yml
client_id: ...
...
...
backends:        # Hardcoded element where we save these values
  resource:      # Resource name 
    key: value   # Actual key-value pairs  
```
This can be done via API calls: `POST /auth/clients` and `PATCH /auth/clients/{client}`

Extra authentication data must be saved for each resource separately.

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1275
