### PR TITLE
1260 open api nuskaitymas model ir model property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,10 +12,16 @@ New Features:
   extra authentication data. Implement `.creds("key")` prepare function to read values
   from saved `backends`. (`#1275`_)
 - Implement the skeleton of `spinta sync` command. (`#1378`_)
+- Added OpenAPI(and Swagger 2.0) inline schema to DSA conversion `Model` and `ModelProperty` dimensions (`#1260`_) (`#1377`_) (`#1381`_) (`#1382`_) (`#1389`_)
 
   .. _#1274: https://github.com/atviriduomenys/spinta/issues/1274
   .. _#1275: https://github.com/atviriduomenys/spinta/issues/1275
   .. _#1378: https://github.com/atviriduomenys/spinta/issues/1378
+  .. _#1260: https://github.com/atviriduomenys/spinta/issues/1260
+  .. _#1377: https://github.com/atviriduomenys/spinta/issues/1377
+  .. _#1381: https://github.com/atviriduomenys/spinta/issues/1381
+  .. _#1382: https://github.com/atviriduomenys/spinta/issues/1382
+  .. _#1389: https://github.com/atviriduomenys/spinta/issues/1389
 
 Bug fixes:
 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -140,7 +140,6 @@ class Model:
                 "name": self.name,
                 "title": self.title,
                 "description": self.description,
-                "access": "open",
                 "external": {
                     "dataset": self.dataset,
                     "resource": self.resource,
@@ -176,6 +175,7 @@ class Property:
         self.datatype: str = datatype or self.get_datatype()
         self.ref: Model = ref_model
         self.enum: dict = self.get_enums(self.json_schema.get("enum", []))
+        self.required: bool = not bool(json_schema.get("nullable", False))
 
 
     def get_datatype(self) -> str:
@@ -219,6 +219,7 @@ class Property:
             "title": self.title,
             "description": self.description,
             "external": {"name": self.source},
+            "required": self.required,
         }
 
         if self.datatype in ["ref", "backref"]:

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -97,14 +97,21 @@ class Model:
 
             self.properties.append(prop)
 
+    def add_child(self, basename:str, json_schema: dict) -> Model:
+        """
+        TODO: Children model "source" should be empty and name should have "/:part" suffix. e.g. f"{self.name}/:part"
+        Link to task https://github.com/atviriduomenys/spinta/issues/997
+        """
+        model = Model(self.dataset, self.resource, basename, json_schema)
+        self.children.append(model)
+        return model
+
     def _add_ref_model(self, parent_prop: Property) -> None:
-        child_model = Model(self.dataset, self.resource, parent_prop.basename, parent_prop.json_schema)
-        parent_prop.ref = child_model
-        self.children.append(child_model)
+        parent_prop.ref = self.add_child(parent_prop.basename, parent_prop.json_schema)
 
     def _add_backref_model(self, parent_prop: Property) -> None:
         json_schema = parent_prop.json_schema.get("items", {})
-        child_model = Model(self.dataset, self.resource, parent_prop.basename, json_schema)
+        child_model = self.add_child(parent_prop.basename, json_schema)
 
         backref_prop = Property(parent_prop.basename, {}, datatype="backref", source=".", ref_model=child_model)
         backref_prop.name += "[]"
@@ -113,8 +120,6 @@ class Model:
         ref_prop = Property(self.basename, {}, datatype="ref", source="", ref_model=self)
         ref_prop.ref = self
         child_model.properties.append(ref_prop)
-
-        self.children.append(child_model)
 
     def get_node_schema_dicts(self) -> list[dict]:
         schena_dict = [

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -11,6 +11,7 @@ from spinta.utils.naming import Deduplicator, to_code_name, to_dataset_name, to_
 SUPPORTED_PARAMETER_LOCATIONS = {"query", "header", "path"}
 DEFAULT_DATASET_NAME = "default"
 SCHEMA_REF_KEY = "$ref"
+DEFAULT_PROPERTY_DATATYPE = "string"
 
 
 def replace_url_parameters(endpoint: str) -> str:
@@ -215,7 +216,7 @@ class Property:
         """
         Returns Property datatype as a string. If type cannot be detected, defaults to "string"
         """
-        datatype = self.json_schema.get("type", "string")
+        datatype = self.json_schema.get("type", DEFAULT_PROPERTY_DATATYPE)
 
         basic_types = {
             "boolean": "boolean",
@@ -236,7 +237,7 @@ class Property:
             if (string_format := self.json_schema.get("format")) in date_time_types:
                 return date_time_types[string_format]
 
-        return "string"
+        return DEFAULT_PROPERTY_DATATYPE
     
     def get_enums(self, items:list) -> dict:
         enum = {}
@@ -279,8 +280,8 @@ def get_schema_from_response(response: dict, root: dict) -> dict:
     return json_schema
 
 
-def get_model_schemas(dataset_name: str, resource_name: str, response_200: dict, root: dict) -> list[dict]:
-    if not (json_schema := get_schema_from_response(response_200, root)):
+def get_model_schemas(dataset_name: str, resource_name: str, response: dict, root: dict) -> list[dict]:
+    if not (json_schema := get_schema_from_response(response, root)):
         return []
 
     if json_schema.get("type") == "array":
@@ -290,7 +291,7 @@ def get_model_schemas(dataset_name: str, resource_name: str, response_200: dict,
         root_source = "."
 
     if json_schema.get("type") == "object":
-        basename = json_schema.get("title", response_200["description"]) or f"{dataset_name} {resource_name}"
+        basename = json_schema.get("title", response["description"]) or f"{dataset_name} {resource_name}"
         model_schema = json_schema
         model = Model(dataset_name, resource_name, basename, model_schema, source=root_source)
 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -83,7 +83,7 @@ class Model:
         self.resource: str = resource
         self.basename: str = basename
         self.json_schema: dict = json_schema
-        self.source: str = source or basename
+        self.source: str = source if source is not None else basename
         self.title: str = self.json_schema.get("title")
         self.description: str = self.json_schema.get("description")
         self.name: str = model_deduplicator(f"{self.dataset}/{to_model_name(self.basename)}")
@@ -109,7 +109,7 @@ class Model:
         TODO: Children model "source" should be empty and name should have "/:part" suffix. e.g. f"{self.name}/:part"
         Link to task https://github.com/atviriduomenys/spinta/issues/997
         """
-        model = Model(self.dataset, self.resource, basename, json_schema, parent=self)
+        model = Model(self.dataset, self.resource, basename, json_schema, source="", parent=self)
         self.children.append(model)
         return model
 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -156,7 +156,7 @@ class Model:
         json_schema = parent_prop.json_schema.get("items", {})
         child_model = self.add_child(parent_prop.basename, json_schema)
 
-        backref_prop = self.add_property(parent_prop.basename, {}, datatype="backref", source=".", ref_model=child_model)
+        backref_prop = self.add_property(parent_prop.basename, {}, datatype="backref", source="", ref_model=child_model)
         backref_prop.name += "[]"
         """
         TODO: Temporary workaround — adds a ref to the backref's model. 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -123,7 +123,12 @@ class Model:
         backref_prop = Property(parent_prop.basename, {}, datatype="backref", source=".", ref_model=child_model)
         backref_prop.name += "[]"
         self.properties.append(backref_prop)
+        """
+        TODO: Temporary workaround — adds a ref to the backref's model. 
+        This should be removed once proper backref handling is implemented.
 
+        See task: https://github.com/atviriduomenys/spinta/issues/1314
+        """
         ref_prop = Property(self.basename, {}, datatype="ref", source="", ref_model=self)
         ref_prop.ref = self
         child_model.properties.append(ref_prop)

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -16,6 +16,8 @@ SUPPORTED_PARAMETER_LOCATIONS = {"query", "header", "path"}
 DEFAULT_DATASET_NAME = "default"
 SCHEMA_REF_KEY = "$ref"
 DEFAULT_PROPERTY_DATATYPE = "string"
+OPENAPI = "openapi"
+SWAGGER = "swagger"
 
 
 def replace_url_parameters(endpoint: str) -> str:
@@ -239,12 +241,12 @@ def get_nested_value(search_key: str, data: dict) -> Any:
 
 def get_schema_from_response(response: dict, root: dict) -> dict:
     json_schema = {}
-    if "openapi" in root:
+    if OPENAPI in root:
         for content_type, content in response.get("content", {}).items():
             if content_type == "application/json" or content_type.endswith("+json"):
                 json_schema = content.get("schema", {})
                 break
-    elif "swagger" in root:
+    elif SWAGGER in root:
         json_schema = response.get("schema", {})
     else:
         json_schema = get_nested_value("schema", response) or {}
@@ -256,7 +258,7 @@ def get_schema_from_response(response: dict, root: dict) -> dict:
 def get_model_schemas(dataset_name: str, resource_name: str, response: dict, root: dict) -> list[dict]:
     if not (json_schema := get_schema_from_response(response, root)):
         return []
-
+    
     if json_schema.get("type") == "array":
         json_schema = json_schema.get("items", {})
         root_source = ".[]"

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -174,9 +174,8 @@ class Property:
         self.required: bool = not bool(json_schema.get("nullable", False))
 
     def get_datatype(self) -> str:
-        """
-        Returns "Property" data type as a string. If type cannot be detected, defaults to "string"
-        """
+        """Returns "Property" data type as a string. If type cannot be detected, defaults to "string"."""
+
         data_type = self.json_schema.get("type", DEFAULT_PROPERTY_DATATYPE)
 
         basic_types = {
@@ -203,7 +202,7 @@ class Property:
     def get_enums(self, items: list) -> dict:
         enum = {}
         for item in items:
-            if isinstance(item,(list, dict)):  # Only handling primitive type enums
+            if isinstance(item, (list, dict)):  # Only handling primitive type enums
                 return {}
             enum[item] = {"source": item}
         return enum
@@ -227,14 +226,14 @@ class Property:
         return schema
 
 def get_schema_from_unknown_structure(json_dict: dict) -> dict:
-    if isinstance(json_dict, dict):
-        for key, value in json_dict.items():
-            if key == "schema":
-                return value
-            schema = get_schema_from_unknown_structure(value)
-            if schema:
-                return schema
-    return {}
+    if not isinstance(json_dict, dict):
+        return {}
+    for key, value in json_dict.items():
+        if key == "schema":
+            return value
+        schema = get_schema_from_unknown_structure(value)
+        if schema:
+            return schema
 
 
 def get_schema_from_response(response: dict, root: dict) -> dict:

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -225,15 +225,16 @@ class Property:
 
         return schema
 
-def get_schema_from_unknown_structure(json_dict: dict) -> dict:
-    if not isinstance(json_dict, dict):
-        return {}
-    for key, value in json_dict.items():
-        if key == "schema":
+def get_nested_value(search_key: str, data: dict) -> Any:
+    if not isinstance(data, dict):
+        return None
+    for key, value in data.items():
+        if key == search_key:
             return value
-        schema = get_schema_from_unknown_structure(value)
-        if schema:
-            return schema
+        result = get_nested_value(search_key, value)
+        if result is not None:
+            return result
+    return None
 
 
 def get_schema_from_response(response: dict, root: dict) -> dict:
@@ -246,9 +247,9 @@ def get_schema_from_response(response: dict, root: dict) -> dict:
     elif "swagger" in root:
         json_schema = response.get("schema", {})
     else:
-        json_schema = get_schema_from_unknown_structure(response)
+        json_schema = get_nested_value("schema", response) or {}
 
-    if SCHEMA_REF_KEY in json_schema:
+    if get_nested_value(SCHEMA_REF_KEY, json_schema):
         raise NotImplementedFeature(feature="Reading OpenAPI with '$ref' structure")
     return json_schema
 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -6,11 +6,20 @@ from pathlib import Path
 from typing import Generator
 
 from spinta.core.ufuncs import Expr
-from spinta.utils.naming import to_dataset_name, to_code_name
-
+from spinta.utils.naming import to_dataset_name, to_code_name, to_model_name, to_property_name
+from spinta.utils.naming import Deduplicator
 
 SUPPORTED_PARAMETER_LOCATIONS = {'query', 'header', 'path'}
 DEFAULT_DATASET_NAME = 'default'
+DEFAULT_MODEL_NAME = 'default'
+PROPERTY_DATA_TYPES = {
+    "string": "string",
+    "number": "number",
+    "integer": "integer",
+    "boolean": "boolean",
+    "array": "array",
+    "object": "ref"
+}
 
 
 def replace_url_parameters(endpoint: str) -> str:
@@ -50,9 +59,93 @@ def get_resource_parameters(parameters: list[dict]) -> dict[str, dict]:
 
     return resource_parameters
 
+model_deduplicator = Deduplicator()
+
+def build_models(dataset: str, resource: str, model_name: str, model_source_name: str, properties_schema: dict, root: bool = False):
+    properties, nested_models = build_properties(dataset, resource, properties_schema, model_name)
+    models = [{
+        'type': 'model',
+        'name': model_name,
+        'access': 'open',
+        'description': '',
+        'visibility': 'absent',
+        'external': {
+            'dataset': dataset,
+            'resource': resource,
+            'name': model_source_name,
+            'prepare': '',
+        },
+        'properties': properties
+    }]
+    if not root:
+        models[0]['comments'] = [
+                {
+                    'id':'smth', 
+                    'access': '',
+                    'parent': 'model',
+                    'author': 'wergfds',
+                    'created': 'werger',
+                    'comment': 'egewg',
+                    # 'prepare': Expr('update', model=f"{model_name}/:part")
+                    # 'external': {
+                    #     'prepare': Expr('update', model=f"{model_name}/:part")
+                    # }
+                    #NOTE: How to add 'prepare' column for comments?
+                    
+                }
+            ]
+    models.extend(nested_models)
+    return models
+
+def build_properties(dataset: str, resource: str, properties_schema: dict, model_name: str) -> tuple[dict, list[dict]]:
+
+    properties = {}
+    nested_models = []
+
+    for property_source_name, property_metadata in properties_schema.items():
+        property_type = property_metadata['type']
+        property_name = to_property_name(property_source_name)
+        properties[property_name] = {
+            'type': property_type, #TODO: Map property types based on 'format' if present, for more precise mapping.
+            'visibility': 'absent',
+            'description': property_metadata.get('description', ''),
+            'external': {
+                'name': property_source_name,
+            }
+        }
+        if property_type == 'ref':
+            properties[property_name]['model'] = property_metadata['model']
+        if property_type == 'array' and property_metadata['items']['type'] == 'object':
+            nested_model_source_name = property_source_name
+            nested_model_name = model_deduplicator(to_model_name(nested_model_source_name))
+            properties[f"{property_name}[]"] = {
+                'type': 'backref',
+                'model': nested_model_name,
+                'visibility': 'absent',
+                'external': {
+                    'prepare': Expr('expand')
+                }
+            }
+            property_metadata['items']['properties'][to_property_name(model_name)]= {
+                'type': 'ref',
+                'model': model_name
+            }
+            nested_models.extend(build_models(dataset, resource, nested_model_name,nested_model_source_name, property_metadata['items']['properties']))
+
+    return properties, nested_models
+
+def get_dataset_models(dataset_name: str, resource_name: str, schema: dict) -> list[dict]:
+
+    model_name = to_model_name(schema['title'] if 'title' in schema else DEFAULT_MODEL_NAME) #TODO: Find a way to construct model name when 'title' is not present
+    model_name = model_deduplicator(model_name)
+    model_properties = schema['properties'] if 'properties' in schema else schema['items']['properties'] 
+
+    return build_models(dataset_name, resource_name, model_name, '.', model_properties, root=True)
+
 
 def get_dataset_schemas(data: dict, dataset_prefix: str) -> Generator[tuple[None, dict]]:
     datasets = {}
+    models = []
     tag_metadata = {tag['name']: tag.get('description', '') for tag in data.get('tags', {})}
 
     for api_endpoint, api_metadata in data.get('paths', {}).items():
@@ -81,6 +174,10 @@ def get_dataset_schemas(data: dict, dataset_prefix: str) -> Generator[tuple[None
                 'params': resource_parameters,
                 'description': http_method_metadata.get('description', ''),
             }
+            if 'content' in (response_200:= http_method_metadata.get('responses', {}).get('200',{})):
+                schema = response_200['content']['application/json']['schema']
+                models += get_dataset_models(f'{dataset_prefix}/{dataset_name}', resource_name, schema)
+            
 
     if not datasets:
         dataset_name = DEFAULT_DATASET_NAME
@@ -94,6 +191,10 @@ def get_dataset_schemas(data: dict, dataset_prefix: str) -> Generator[tuple[None
 
     for dataset in datasets.values():
         yield None, dataset
+
+    if models:
+        for model in models:
+            yield None, model
 
 
 def read_open_api_manifest(path: Path) -> Generator[tuple[None, dict]]:

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -2,24 +2,14 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 from spinta.core.ufuncs import Expr
-from spinta.utils.naming import to_dataset_name, to_code_name, to_model_name, to_property_name
-from spinta.utils.naming import Deduplicator
+from spinta.utils.naming import to_code_name, to_dataset_name, to_model_name
 
-SUPPORTED_PARAMETER_LOCATIONS = {'query', 'header', 'path'}
-DEFAULT_DATASET_NAME = 'default'
-DEFAULT_MODEL_NAME = 'default'
-PROPERTY_DATA_TYPES = {
-    "string": "string",
-    "number": "number",
-    "integer": "integer",
-    "boolean": "boolean",
-    "array": "array",
-    "object": "ref"
-}
+SUPPORTED_PARAMETER_LOCATIONS = {"query", "header", "path"}
+DEFAULT_DATASET_NAME = "default"
 
 
 def replace_url_parameters(endpoint: str) -> str:
@@ -27,7 +17,7 @@ def replace_url_parameters(endpoint: str) -> str:
 
     e.g. /api/cities/{cityId}/ -> /api/cities/{city_id}
     """
-    return re.sub(r'{([^{}]+)}', lambda match: f'{{{to_code_name(match.group(1))}}}', endpoint)
+    return re.sub(r"{([^{}]+)}", lambda match: f"{{{to_code_name(match.group(1))}}}", endpoint)
 
 
 def read_file_data_and_transform_to_json(path: Path) -> dict:
@@ -36,157 +26,148 @@ def read_file_data_and_transform_to_json(path: Path) -> dict:
 
 
 def get_namespace_schema(info: dict, title: str, dataset_prefix: str) -> Generator[tuple[None, dict], None, None]:
-    yield None, {
-        'type': 'ns',
-        'name': dataset_prefix,
-        'title': info.get('summary', title),
-        'description': info.get('description', ''),
-    }
+    yield (
+        None,
+        {
+            "type": "ns",
+            "name": dataset_prefix,
+            "title": info.get("summary", title),
+            "description": info.get("description", ""),
+        },
+    )
 
 
 def get_resource_parameters(parameters: list[dict]) -> dict[str, dict]:
     resource_parameters = {}
     for index, value in enumerate(parameters):
-        name = value['name']
-        location = value['in'] if value['in'] in SUPPORTED_PARAMETER_LOCATIONS else ''
-        resource_parameters[f'parameter_{index}'] = {
-            'name': to_code_name(name),
-            'source': [name],
-            'prepare': [Expr(location)],
-            'type': 'param',
-            'description': value.get('description', ''),
+        name = value["name"]
+        location = value["in"] if value["in"] in SUPPORTED_PARAMETER_LOCATIONS else ""
+        resource_parameters[f"parameter_{index}"] = {
+            "name": to_code_name(name),
+            "source": [name],
+            "prepare": [Expr(location)],
+            "type": "param",
+            "description": value.get("description", ""),
         }
 
     return resource_parameters
 
-model_deduplicator = Deduplicator()
 
-def build_models(dataset: str, resource: str, model_name: str, model_source_name: str, properties_schema: dict, root: bool = False):
-    properties, nested_models = build_properties(dataset, resource, properties_schema, model_name)
-    models = [{
-        'type': 'model',
-        'name': model_name,
-        'access': 'open',
-        'description': '',
-        'visibility': 'absent',
-        'external': {
-            'dataset': dataset,
-            'resource': resource,
-            'name': model_source_name,
-            'prepare': '',
-        },
-        'properties': properties
-    }]
-    if not root:
-        models[0]['comments'] = [
-                {
-                    'id':'smth', 
-                    'access': '',
-                    'parent': 'model',
-                    'author': 'wergfds',
-                    'created': 'werger',
-                    'comment': 'egewg',
-                    # 'prepare': Expr('update', model=f"{model_name}/:part")
-                    # 'external': {
-                    #     'prepare': Expr('update', model=f"{model_name}/:part")
-                    # }
-                    #NOTE: How to add 'prepare' column for comments?
-                    
-                }
-            ]
-    models.extend(nested_models)
-    return models
+class Model:
+    def __init__(
+        self, dataset: str, resource: str, basename: str, source: str, json_schema: dict, parent: Model | None = None
+    ) -> None:
+        self.dataset: str = dataset
+        self.resource: str = resource
+        self.basename: str = basename
+        self.json_schema: dict = json_schema
+        self.parent: Model | None = parent
+        self.source: str = source
+        self.title: str = self.json_schema.get("title")
+        self.description: str = self.json_schema.get("description")
+        self.name: str = f"{self.dataset}/{to_model_name(self.basename)}"
+        self.children: list[Model] = []
+        self.properties: list[Property] = []
+        self.extract_children()
 
-def build_properties(dataset: str, resource: str, properties_schema: dict, model_name: str) -> tuple[dict, list[dict]]:
+    def add_children(self, basename: str, json_schema: dict) -> None:
+        self.children.append(Model(self.dataset, self.resource, basename, basename, json_schema, self))
 
-    properties = {}
-    nested_models = []
+    def extract_children(self) -> None:
+        for property_name, property_metadata in self.json_schema.get("properties", {}).items():
+            if property_metadata.get("type") == "object":
+                self.add_children(property_name, property_metadata)
+            elif property_metadata.get("items", {}).get("type") == "object":
+                self.add_children(property_name, property_metadata["items"])
 
-    for property_source_name, property_metadata in properties_schema.items():
-        property_type = property_metadata['type']
-        property_name = to_property_name(property_source_name)
-        properties[property_name] = {
-            'type': property_type, #TODO: Map property types based on 'format' if present, for more precise mapping.
-            'visibility': 'absent',
-            'description': property_metadata.get('description', ''),
-            'external': {
-                'name': property_source_name,
+    def get_node_schema_dicts(self) -> list[dict]:
+        result = [
+            {
+                "type": "model",
+                "name": self.name,
+                "title": self.title,
+                "description": self.description,
+                "access": "open",
+                "external": {"dataset": self.dataset, "resource": self.resource, "name": self.source},
             }
-        }
-        if property_type == 'ref':
-            properties[property_name]['model'] = property_metadata['model']
-        if property_type == 'array' and property_metadata['items']['type'] == 'object':
-            nested_model_source_name = property_source_name
-            nested_model_name = model_deduplicator(to_model_name(nested_model_source_name))
-            properties[f"{property_name}[]"] = {
-                'type': 'backref',
-                'model': nested_model_name,
-                'visibility': 'absent',
-                'external': {
-                    'prepare': Expr('expand')
-                }
-            }
-            property_metadata['items']['properties'][to_property_name(model_name)]= {
-                'type': 'ref',
-                'model': model_name
-            }
-            nested_models.extend(build_models(dataset, resource, nested_model_name,nested_model_source_name, property_metadata['items']['properties']))
+        ]
+        for child in self.children:
+            result.extend(child.get_node_schema_dicts())
+        return result
 
-    return properties, nested_models
+    def __repr__(self) -> str:
+        return f"<Model {self.name}>"
 
-def get_dataset_models(dataset_name: str, resource_name: str, schema: dict) -> list[dict]:
 
-    model_name = to_model_name(schema['title'] if 'title' in schema else DEFAULT_MODEL_NAME) #TODO: Find a way to construct model name when 'title' is not present
-    model_name = model_deduplicator(model_name)
-    model_properties = schema['properties'] if 'properties' in schema else schema['items']['properties'] 
+class Property:
+    pass
 
-    return build_models(dataset_name, resource_name, model_name, '.', model_properties, root=True)
+
+def get_model_schemas(dataset_name: str, resource_name: str, response_200: dict) -> list[dict]:
+    if not (json_schema := response_200.get("content", {}).get("application/json", {}).get("schema", {})):
+        return []
+
+    json_type = json_schema.get("type")
+
+    basename = json_schema.get("title", response_200["description"])
+
+    if json_type == "object":
+        schema = json_schema
+        source = "."
+
+    elif json_type == "array" and json_schema.get("items", {}).get("type") == "object":
+        schema = json_schema.get("items", {})
+        source = ".[]"
+    else:
+        return []
+
+    model = Model(dataset_name, resource_name, basename, source, schema)
+
+    return model.get_node_schema_dicts()
 
 
 def get_dataset_schemas(data: dict, dataset_prefix: str) -> Generator[tuple[None, dict]]:
     datasets = {}
     models = []
-    tag_metadata = {tag['name']: tag.get('description', '') for tag in data.get('tags', {})}
+    tag_metadata = {tag["name"]: tag.get("description", "") for tag in data.get("tags", {})}
 
-    for api_endpoint, api_metadata in data.get('paths', {}).items():
+    for api_endpoint, api_metadata in data.get("paths", {}).items():
         for http_method, http_method_metadata in api_metadata.items():
-            tags = http_method_metadata.get('tags', [])
+            tags = http_method_metadata.get("tags", [])
 
-            dataset_name = to_dataset_name('_'.join(tags)) or DEFAULT_DATASET_NAME  # Default dataset if no tags given.
+            dataset_name = to_dataset_name("_".join(tags)) or DEFAULT_DATASET_NAME  # Default dataset if no tags given.
             if dataset_name not in datasets:
                 datasets[dataset_name] = {
-                    'type': 'dataset',
-                    'name': f'{dataset_prefix}/{dataset_name}',
-                    'title': ', '.join(tags),
-                    'description': ', '.join(tag_metadata[tag] for tag in tags if tag in tag_metadata),
-                    'resources': {},
+                    "type": "dataset",
+                    "name": f"{dataset_prefix}/{dataset_name}",
+                    "title": ", ".join(tags),
+                    "description": ", ".join(tag_metadata[tag] for tag in tags if tag in tag_metadata),
+                    "resources": {},
                 }
 
-            resource_name = to_code_name(f'{api_endpoint}/{http_method}')
-            resource_parameters = get_resource_parameters(http_method_metadata.get('parameters', {}))
+            resource_name = to_code_name(f"{api_endpoint}/{http_method}")
+            resource_parameters = get_resource_parameters(http_method_metadata.get("parameters", {}))
 
-            datasets[dataset_name]['resources'][resource_name] = {
-                'type': 'dask/json',
-                'id': http_method_metadata.get('operationId', ''),
-                'external': replace_url_parameters(api_endpoint),
-                'prepare': Expr('http', method=http_method.upper(), body='form'),
-                'title': http_method_metadata.get('summary', ''),
-                'params': resource_parameters,
-                'description': http_method_metadata.get('description', ''),
+            datasets[dataset_name]["resources"][resource_name] = {
+                "type": "dask/json",
+                "id": http_method_metadata.get("operationId", ""),
+                "external": replace_url_parameters(api_endpoint),
+                "prepare": Expr("http", method=http_method.upper(), body="form"),
+                "title": http_method_metadata.get("summary", ""),
+                "params": resource_parameters,
+                "description": http_method_metadata.get("description", ""),
             }
-            if 'content' in (response_200:= http_method_metadata.get('responses', {}).get('200',{})):
-                schema = response_200['content']['application/json']['schema']
-                models += get_dataset_models(f'{dataset_prefix}/{dataset_name}', resource_name, schema)
-            
+            response_200 = http_method_metadata.get("responses", {}).get("200", {})
+            models += get_model_schemas(f"{dataset_prefix}/{dataset_name}", resource_name, response_200)
 
     if not datasets:
         dataset_name = DEFAULT_DATASET_NAME
         datasets[dataset_name] = {
-            'type': 'dataset',
-            'name': f'{dataset_prefix}/{dataset_name}',
-            'title': '',
-            'description': '',
-            'resources': {},
+            "type": "dataset",
+            "name": f"{dataset_prefix}/{dataset_name}",
+            "title": "",
+            "description": "",
+            "resources": {},
         }
 
     for dataset in datasets.values():
@@ -204,9 +185,9 @@ def read_open_api_manifest(path: Path) -> Generator[tuple[None, dict]]:
     """
     data = read_file_data_and_transform_to_json(path)
 
-    info = data['info']
-    title = info['title']
-    dataset_prefix = f'services/{to_dataset_name(title)}'
+    info = data["info"]
+    title = info["title"]
+    dataset_prefix = f"services/{to_dataset_name(title)}"
 
     yield from get_namespace_schema(info, title, dataset_prefix)
 

--- a/spinta/manifests/open_api/helpers.py
+++ b/spinta/manifests/open_api/helpers.py
@@ -143,7 +143,6 @@ class Model:
                     "dataset": self.dataset,
                     "resource": self.resource,
                     "name": self.source,
-                    "prepare": Expr("expand") if self.parent else ""
                     },
                 "properties": {prop.name: prop.get_node_schema_dict() for prop in self.properties},
             }
@@ -219,6 +218,7 @@ class Property:
 
         if self.datatype in ["ref", "backref"]:
             schema["model"] = self.ref.name
+            schema["external"]["prepare"] = Expr("expand")
 
         if self.enum:
             schema['enums'] = {"": self.enum}

--- a/tests/manifests/open_api/test_helpers.py
+++ b/tests/manifests/open_api/test_helpers.py
@@ -9,8 +9,9 @@ from spinta.manifests.open_api.helpers import (
     read_file_data_and_transform_to_json,
     get_dataset_schemas,
     get_namespace_schema, get_resource_parameters, replace_url_parameters,
+    get_schema_from_response, get_model_schemas, Model, Property
 )
-
+from spinta.utils.naming import to_model_name, to_property_name
 
 @pytest.mark.parametrize(
     argnames=["url", "expected_result_url"],
@@ -372,3 +373,333 @@ def test_get_dataset_schemas_no_tags_default_dataset():
             }
         }
     ]
+
+SCHEMA = {
+    "properties": {
+        "data": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 1,
+                },
+                "active_from": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2019-12-31"
+                },
+            },
+            "type": "object",
+        },
+        "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-02-19T07:00:11.000000Z",
+        },
+    },
+    "type": "object",
+}
+
+RESPONSE = {
+    "description": "Relation with child and parents",
+    "content": {
+        "application/json": {
+            "schema": SCHEMA
+        }
+    },
+}
+OPENAPI_SCHEMA = {
+    "openapi": "3.0.0",
+    "info": {"title": "Vilnius API", "version": "1.0.0"},
+    "paths": {
+        "/api/spis/relations/child/{personal_code}": {
+            "get": {
+                "tags": ["SPIS"],
+                "summary": "Check all SPIS relations for child personal code",
+                "operationId": "e0e4ad148932d12d438e6a52ebbba641",
+                "parameters": [
+                    {
+                        "name": "personal_code",
+                        "in": "path",
+                        "description": "Personal code to check",
+                        "required": True,
+                        "schema": {"type": "integer", "example": "30101010018"},
+                    }
+                ],
+                "responses": {
+                    "200": RESPONSE
+                },
+            }
+        }
+    },
+}
+
+@pytest.mark.parametrize("response,schema", [
+    (
+        {"description": "User found", "schema": SCHEMA},
+        {
+            "swagger": "2.0",
+            "info": {"title": "User API", "version": "1.0.0"},
+            "paths": {
+                "/users/{id}": {
+                    "get": {
+                        "summary": "Get user by ID",
+                        "responses": {"200": {"description": "User found", "schema": SCHEMA}}
+                    }
+                }
+            }
+        }
+    ),
+    (RESPONSE, OPENAPI_SCHEMA),
+])
+def test_get_schema_from_response(response, schema):
+    assert get_schema_from_response(response, schema) == SCHEMA
+
+def test_get_schema_from_unknown_format():
+    {
+        "openapi": "3.0.0",
+        "info": {"title": "Vilnius API", "version": "1.0.0"},
+        "paths": {
+            "/api/spis/relations/child/{personal_code}": {
+                "get": {
+                    "tags": ["SPIS"],
+                    "summary": "Check all SPIS relations for child personal code",
+                    "operationId": "e0e4ad148932d12d438e6a52ebbba641",
+                    "parameters": [
+                        {
+                            "name": "personal_code",
+                            "in": "path",
+                            "description": "Personal code to check",
+                            "required": True,
+                            "schema": {"type": "integer", "example": "30101010018"},
+                        }
+                    ],
+                    "responses": {
+                        "200": RESPONSE
+                    }
+                }
+            }
+        }
+    }
+    
+
+def test_get_model_schemas():
+    dataset = "dataset_name"
+    resource = "resource_name"
+    result = get_model_schemas(dataset, resource, RESPONSE, OPENAPI_SCHEMA)
+
+    expected = [
+        {
+            "type": "model",
+            "name": f"{dataset}/RelationWithChildAndParents",
+            "title": "",
+            "description": "",
+            "external": {
+                "dataset": dataset,
+                "name": ".",
+                "resource": resource,
+            },
+            "properties": {
+                "created_at": {
+                    "type": "datetime",
+                    "title": "",
+                    "description": "",
+                    "external": {"name": "created_at"},
+                    "required": True,
+                },
+                "data": {
+                    "type": "ref",
+                    "title": "",
+                    "description": "",
+                    "external": {
+                        "name": "data",
+                        "prepare": Expr("expand")
+                        },
+                    "model": f"{dataset}/Data",
+                    "required": True,
+                },
+            },
+        },
+        {
+            "type": "model",
+            "name": f"{dataset}/Data",
+            "title": "",
+            "description": "",
+            "external": {
+                "dataset": dataset,
+                "name": "",
+                "resource": resource,
+            },
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "title": "",
+                    "description": "",
+                    "external": {"name": "id"},
+                    "required": True,
+                },
+                "active_from": {
+                    "type": "date",
+                    "title": "",
+                    "description": "",
+                    "external": {"name": "active_from"},
+                    "required": True,
+
+                }
+            },
+        }
+    ]
+
+
+    assert result == expected
+
+def test_basic_model():
+    dataset = "dataset_name"
+    resource = "resource_name"
+    basename = "MyModel"
+    model = Model(dataset, resource, basename, {})
+
+    assert model.dataset == dataset
+    assert model.resource == resource
+    assert model.basename == basename
+    assert model.json_schema == {}
+    assert model.source == basename
+    assert model.title == ""
+    assert model.description == ""
+    assert model.name == f"{dataset}/{to_model_name(basename)}"
+    assert model.parent is None
+
+    assert len(model.children) == 0
+    assert len(model.properties) == 0
+
+    
+def test_model_add_property():
+    model = Model("dataset", "resource", "MyModel", {})
+
+    assert model.properties == []
+
+    prop = model.add_property("MyProperty", {})
+
+    assert model.properties == [prop]
+
+def test_model_add_child():
+    model = Model("dataset", "resource", "MyModel", {})
+    child = model.add_child("Child", {})
+    assert model.children == [child]
+    assert child.parent == model
+
+def test_model_with_ref_property():
+    schema = {
+        "properties": {
+            "child": {
+                "type": "object", 
+                "properties": {}
+            }
+        }
+    }
+    model = Model("dataset", "resource", "MyModel", schema)
+
+    prop = model.properties[0]
+
+    child = model.children[0]
+    
+    assert len(model.properties) == 1
+    assert len(model.children) == 1
+    assert prop.ref == child
+    assert prop.datatype == "ref"
+
+def test_model_with_backref_property():
+    schema = {
+        "properties": {
+            "child": {
+                "type": "array", 
+                "items": {
+                    "type": "object"
+                }
+            }
+        }
+    }
+    model = Model("dataset", "resource", "MyModel", schema)
+
+    assert len(model.properties) == 2
+
+    prop_array = [prop for prop in model.properties if prop.datatype == "array"][0]
+    prop_backref = [prop for prop in model.properties if prop.datatype == "backref"][0]
+
+    assert len(model.children) == 1
+
+    child = model.children[0]
+
+    assert prop_array.ref is None
+    assert prop_backref.ref == child
+    assert prop_backref.datatype == "backref"
+
+    assert f"{prop_array.name}[]" == prop_backref.name
+
+    assert len(child.properties) == 1
+
+    child_prop = child.properties[0]
+
+    assert child_prop.datatype == "ref"
+    assert child_prop.ref == model
+    
+def test_basic_property():
+    schema = {
+        "type": "string",
+        "title": "Title",
+        "description": "Desc"
+    }
+    basename = "prop_name"
+    prop = Property(basename, schema)
+
+    assert prop.basename == basename
+    assert prop.name == to_property_name(basename)
+    assert prop.title == "Title"
+    assert prop.description == "Desc"
+    assert prop.datatype == "string"
+    assert prop.required is True
+    assert prop.enum == {}
+
+def test_property_nullable():
+    schema = {
+        "type": "string",
+        "nullable": True
+    }
+    prop = Property("prop", schema)
+    assert prop.required is False
+
+def test_property_base64_binary():
+    schema = {
+        "type": "string",
+        "contentEncoding": "base64"
+    }
+    prop = Property("prop", schema)
+    assert prop.datatype == "binary"
+
+def test_property_datetime_format():
+    schema = {
+        "type": "string",
+        "format": "date-time"
+    }
+    prop = Property("prop", schema)
+    assert prop.datatype == "datetime"
+
+def test_property_enum():
+    schema = {
+        "type": "string",
+        "enum": ["a", "b", "c"]
+    }
+    prop = Property("prop", schema)
+    assert prop.enum == {"a": {"source": "a"}, "b": {"source": "b"}, "c": {"source": "c"}}
+
+def test_property_enum_invalid_items():
+    schema = {
+        "type": "string",
+        "enum": [
+            {
+                "label": "a"
+            }, 
+            ["b"]
+        ]
+        }
+    prop = Property("prop", schema)
+    assert prop.enum == {}

--- a/tests/manifests/open_api/test_openapi.py
+++ b/tests/manifests/open_api/test_openapi.py
@@ -127,6 +127,7 @@ def test_open_api_manifest_title_with_slashes(rc: RawConfig, tmp_path: Path):
 
     assert manifest == table
 
+
 def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
     data = json.dumps({
         'openapi': '3.0.0',
@@ -185,6 +186,7 @@ def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
     manifest = load_manifest(rc, path_openapi)
 
     assert manifest == table
+
 
 def test_open_api_manifest_nested_models(rc: RawConfig, tmp_path: Path):
     data = json.dumps({
@@ -274,6 +276,7 @@ def test_open_api_manifest_nested_models(rc: RawConfig, tmp_path: Path):
 
     assert manifest == table
 
+
 def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
     model_deduplicator._names.clear()
     data = json.dumps({
@@ -336,6 +339,7 @@ def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
     manifest = load_manifest(rc, path_openapi)
 
     assert manifest == table
+
 
 def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
     model_deduplicator._names.clear()
@@ -424,6 +428,7 @@ def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
     manifest = load_manifest(rc, path_openapi)
 
     assert manifest == table
+
 
 def test_open_api_manifest_array_of_primitives(rc: RawConfig, tmp_path: Path):
     model_deduplicator._names.clear()

--- a/tests/manifests/open_api/test_openapi.py
+++ b/tests/manifests/open_api/test_openapi.py
@@ -125,3 +125,339 @@ def test_open_api_manifest_title_with_slashes(rc: RawConfig, tmp_path: Path):
     manifest = load_manifest(rc, path_openapi)
 
     assert manifest == table
+
+def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
+    data = json.dumps({
+        "openapi": "3.0.0",
+        "info": {"title": "Vilnius API", "version": "1.0.0"},
+        "paths": {
+            "/api/spis/relations/child": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Relationship",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {
+                                            "id": {
+                                                "type": "integer",
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "example": "2025-02-19T07:00:11.000000Z",
+                                            },
+                                        },
+                                        "type": "object",
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        },
+    })
+
+    table = """
+    id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
+       | services/vilnius_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Vilnius API |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       | services/vilnius_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | Relationship                |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | id                      | integer required  |     | id                        |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | created_at              | datetime required |     | created_at                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       """
+
+
+    path = tmp_path / 'manifest.json'
+    path_openapi = f'openapi+file://{path}'
+    with open(path, 'w') as json_file:
+        json_file.write(data)
+
+    manifest = load_manifest(rc, path_openapi)
+
+    assert manifest == table
+
+def test_open_api_manifest_nested_models(rc: RawConfig, tmp_path: Path):
+    data = json.dumps({
+        "openapi": "3.0.0",
+        "info": {"title": "Vilnius API", "version": "1.0.0"},
+        "paths": {
+            "/api/spis/relations/child": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Relation with child and parents",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "data": {
+                                                    "properties": {
+                                                        "Child_Person": {
+                                                            "properties": {
+                                                                "siblings": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {},
+                                                                    },
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                        },
+                                                        "parents_legal": {
+                                                            "type": "array",
+                                                            "items": {"type": "object"},
+                                                        },
+                                                    },
+                                                    "type": "object",
+                                                }
+                                            },
+                                            "type": "object",
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        },
+    })
+
+    table = """
+    id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
+       | services/vilnius_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Vilnius API |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       | services/vilnius_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | RelationWithChildAndParents |                   |     | .[]                       |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | data                    | ref required      | Data | data                      |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | Data                        |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | child_person            | ref required      | ChildPerson | Child_Person              |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | parents_legal           | array required    |     | parents_legal             |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | parents_legal[]         | backref required  | ParentsLegal |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | ChildPerson                 |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | siblings                | array required    |     | siblings                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | siblings[]              | backref required  | Siblings |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | Siblings                    |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | child_person            | ref required      | ChildPerson |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | ParentsLegal                |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | data                    | ref required      | Data |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+   """
+
+ 
+    path = tmp_path / 'manifest.json'
+    path_openapi = f'openapi+file://{path}'
+    with open(path, 'w') as json_file:
+        json_file.write(data)
+
+    manifest = load_manifest(rc, path_openapi)
+
+    assert manifest == table
+
+def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
+    data = json.dumps({
+        "openapi": "3.0.0",
+        "info": {"title": "Example", "version": "1.0.0"},
+        "paths": {
+            "/api/spis/relations/child": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Relation",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {
+                                            "relation_type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "biological",
+                                                    "adoptive",
+                                                    "foster",
+                                                ]
+                                            }
+                                        },
+                                        "type": "object",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    )
+
+    table = """
+    id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
+       | services/example                        | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example     |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       | services/example/default                |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | Relation                    |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | relation_type           | string required   |     | relation_type             |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         | enum              |     | biological                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | adoptive                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | foster                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       """
+ 
+    path = tmp_path / 'manifest.json'
+    path_openapi = f'openapi+file://{path}'
+    with open(path, 'w') as json_file:
+        json_file.write(data)
+
+    manifest = load_manifest(rc, path_openapi)
+
+    assert manifest == table
+
+def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
+    data = json.dumps({
+        "openapi": "3.0.0",
+        "info": {"title": "Example", "version": "1.0.0"},
+        "paths": {
+            "/api/datatypes": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Example of datatypes",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "integer", "example": 1},
+                                            "active_from": {
+                                                "type": "string",
+                                                "format": "date",
+                                                "example": "2019-12-31",
+                                            },
+                                            "active_to": {
+                                                "nullable": True,
+                                                "type": "string",
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "example": "2025-02-19T07:00:11.000000Z",
+                                            },
+                                            "Subscribed": {"type": "boolean"},
+                                            "weight": {"type": "number"},
+                                            "attachment": {
+                                                "type": "string",
+                                                "contentEncoding": "base64",
+                                            },
+                                            "meeting_time": {
+                                                "type": "string",
+                                                "format": "time",
+                                                "example": "14:30:00",
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+    table = """
+    id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
+       | services/example                        | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example     |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       | services/example/default                |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_datatypes_get                   | dask/json         |     | /api/datatypes            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | ExampleOfDatatypes          |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | id                      | integer required  |     | id                        |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | active_from             | date required     |     | active_from               |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | active_to               | string            |     | active_to                 |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | created_at              | datetime required |     | created_at                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | subscribed              | boolean required  |     | Subscribed                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | weight                  | number required   |     | weight                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | attachment              | binary required   |     | attachment                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | meeting_time            | time required     |     | meeting_time              |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       """
+ 
+    path = tmp_path / 'manifest.json'
+    path_openapi = f'openapi+file://{path}'
+    with open(path, 'w') as json_file:
+        json_file.write(data)
+
+    manifest = load_manifest(rc, path_openapi)
+
+    assert manifest == table
+
+def test_open_api_manifest_array_of_primitives(rc: RawConfig, tmp_path: Path):
+    data = json.dumps({
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/api/array": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Masyvas",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "notes": {
+                                                "type": "array",
+                                                "items": {"type": "string"}
+                                            },
+                                            "numbers": {
+                                                "type": "array",
+                                                "items": {"type": "integer"}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+    table = """
+    id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
+       | services/test_api                       | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Test API    |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       | services/test_api/default               |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_array_get                       | dask/json         |     | /api/array                |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   |   |   | Masyvas                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | notes                   | array required    |     | notes                     |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | notes[]                 | string required   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | numbers                 | array required    |     | numbers                   |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | numbers[]               | integer required  |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+    """
+ 
+    path = tmp_path / 'manifest.json'
+    path_openapi = f'openapi+file://{path}'
+    with open(path, 'w') as json_file:
+        json_file.write(data)
+
+    manifest = load_manifest(rc, path_openapi)
+
+    assert manifest == table

--- a/tests/manifests/open_api/test_openapi.py
+++ b/tests/manifests/open_api/test_openapi.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from spinta.core.config import RawConfig
 from spinta.testing.manifest import load_manifest
+from spinta.manifests.open_api.helpers import model_deduplicator
 
 
 def test_open_api_manifest(rc: RawConfig, tmp_path: Path):
@@ -128,14 +129,19 @@ def test_open_api_manifest_title_with_slashes(rc: RawConfig, tmp_path: Path):
 
 def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
     data = json.dumps({
-        "openapi": "3.0.0",
-        "info": {"title": "Vilnius API", "version": "1.0.0"},
-        "paths": {
-            "/api/spis/relations/child": {
-                "get": {
+        'openapi': '3.0.0',
+        'info': {
+            'title': 'Example API',
+            'version': '1.0.0',
+            'summary': 'Example of an API',
+            'description': 'Intricate description'
+        },
+        'paths': {
+            '/api/countries': {
+                'get': {
                     "responses": {
                         "200": {
-                            "description": "Relationship",
+                            "description": "Country",
                             "content": {
                                 "application/json": {
                                     "schema": {
@@ -143,34 +149,32 @@ def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
                                             "id": {
                                                 "type": "integer",
                                             },
-                                            "created_at": {
-                                                "type": "string",
-                                                "format": "date-time",
-                                                "example": "2025-02-19T07:00:11.000000Z",
+                                            "name": {
+                                                "type": "string"
                                             },
                                         },
-                                        "type": "object",
+                                        "type": "object"
                                     }
                                 }
-                            },
+                            }
                         }
                     }
                 }
             }
-        },
+        }
     })
 
     table = """
     id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
-       | services/vilnius_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Vilnius API |
+       | services/example_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example of an API | Intricate description
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       | services/vilnius_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       | services/example_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_countries_get                   | dask/json         |     | /api/countries            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | Relationship                |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   | Country                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
        |   |   |   |   | id                      | integer required  |     | id                        |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | created_at              | datetime required |     | created_at                |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       """
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+   """
 
 
     path = tmp_path / 'manifest.json'
@@ -184,79 +188,81 @@ def test_open_api_manifest_root_model(rc: RawConfig, tmp_path: Path):
 
 def test_open_api_manifest_nested_models(rc: RawConfig, tmp_path: Path):
     data = json.dumps({
-        "openapi": "3.0.0",
-        "info": {"title": "Vilnius API", "version": "1.0.0"},
-        "paths": {
-            "/api/spis/relations/child": {
-                "get": {
+        'openapi': '3.0.0',
+        'info': {
+            'title': 'Example API',
+            'version': '1.0.0',
+            'summary': 'Example of an API',
+            'description': 'Intricate description'
+        },
+        'paths': {
+            '/api/countries': {
+                'get': {
                     "responses": {
                         "200": {
-                            "description": "Relation with child and parents",
+                            "description": "List of Countries",
                             "content": {
                                 "application/json": {
                                     "schema": {
                                         "type": "array",
                                         "items": {
                                             "properties": {
-                                                "data": {
-                                                    "properties": {
-                                                        "Child_Person": {
-                                                            "properties": {
-                                                                "siblings": {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "object",
-                                                                        "properties": {},
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "cities": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "name": {"type": "string" },
+                                                            "counties": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "name": {"type": "string"}
                                                                     },
+                                                                    "type": "object"
                                                                 }
-                                                            },
-                                                            "type": "object",
+                                                            }
                                                         },
-                                                        "parents_legal": {
-                                                            "type": "array",
-                                                            "items": {"type": "object"},
-                                                        },
-                                                    },
-                                                    "type": "object",
+                                                        "type": "object"
+                                                    }
                                                 }
                                             },
-                                            "type": "object",
-                                        },
+                                            "type": "object"
+                                        }
                                     }
                                 }
-                            },
+                            }
                         }
                     }
                 }
             }
-        },
+        }
     })
 
     table = """
     id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
-       | services/vilnius_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Vilnius API |
+       | services/example_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example of an API | Intricate description
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       | services/vilnius_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       | services/example_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_countries_get                   | dask/json         |     | /api/countries            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | RelationWithChildAndParents |                   |     | .[]                       |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | data                    | ref required      | Data | data                      |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   | ListOfCountries             |                   |     | .[]                       |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | cities                  | array required    |     | cities                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | cities[]                | backref required  | Cities |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | Data                        |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | child_person            | ref required      | ChildPerson | Child_Person              |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | parents_legal           | array required    |     | parents_legal             |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | parents_legal[]         | backref required  | ParentsLegal |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   | Cities                      |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | counties                | array required    |     | counties                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | counties[]              | backref required  | Counties |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | list_of_countries       | ref required      | ListOfCountries |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | ChildPerson                 |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | siblings                | array required    |     | siblings                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | siblings[]              | backref required  | Siblings |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
-       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | Siblings                    |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | child_person            | ref required      | ChildPerson |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
-       |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | ParentsLegal                |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | data                    | ref required      | Data |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
-   """
+       |   |   |   | Counties                    |                   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | cities                  | ref required      | Cities |                           |             | expand()                          |        |       |       | develop | private    |        |     |     |             |
+       """
 
  
     path = tmp_path / 'manifest.json'
@@ -269,29 +275,32 @@ def test_open_api_manifest_nested_models(rc: RawConfig, tmp_path: Path):
     assert manifest == table
 
 def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
+    model_deduplicator._names.clear()
     data = json.dumps({
-        "openapi": "3.0.0",
-        "info": {"title": "Example", "version": "1.0.0"},
-        "paths": {
-            "/api/spis/relations/child": {
-                "get": {
+        'openapi': '3.0.0',
+        'info': {
+            'title': 'Example API',
+            'version': '1.0.0',
+            'summary': 'Example of an API',
+            'description': 'Intricate description'
+        },
+        'paths': {
+            '/api/countries': {
+                'get': {
                     "responses": {
                         "200": {
-                            "description": "Relation",
+                            "description": "Country",
                             "content": {
                                 "application/json": {
                                     "schema": {
                                         "properties": {
-                                            "relation_type": {
+                                            "name": {"type": "string"},
+                                            "region": {
                                                 "type": "string",
-                                                "enum": [
-                                                    "biological",
-                                                    "adoptive",
-                                                    "foster",
-                                                ]
+                                                "enum": ["Europe", "Asia", "Africa", "Americas", "Oceania"]
                                             }
                                         },
-                                        "type": "object",
+                                        "type": "object"
                                     }
                                 }
                             }
@@ -300,21 +309,23 @@ def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
                 }
             }
         }
-    }
-    )
+    })
 
     table = """
     id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
-       | services/example                        | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example     |
+       | services/example_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example of an API | Intricate description
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       | services/example/default                |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   | api_spis_relations_child_get        | dask/json         |     | /api/spis/relations/child |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       | services/example_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_countries_get                   | dask/json         |     | /api/countries            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | Relation                    |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | relation_type           | string required   |     | relation_type             |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |                                         | enum              |     | biological                |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |                                         |                   |     | adoptive                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |                                         |                   |     | foster                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   | Country                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | region                  | string required   |     | region                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         | enum              |     | Europe                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | Asia                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | Africa                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | Americas                  |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |                                         |                   |     | Oceania                   |             |                                   |        |       |       | develop | private    |        |     |     |             |
        """
  
     path = tmp_path / 'manifest.json'
@@ -327,45 +338,53 @@ def test_open_api_manifest_enum(rc: RawConfig, tmp_path: Path):
     assert manifest == table
 
 def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
+    model_deduplicator._names.clear()
     data = json.dumps({
         "openapi": "3.0.0",
-        "info": {"title": "Example", "version": "1.0.0"},
+        "info": {
+            "title": "Example API",
+            "version": "1.0.0",
+            "summary": "Example of an API",
+            "description": "Intricate description",
+        },
         "paths": {
-            "/api/datatypes": {
+            "/api/countries": {
                 "get": {
                     "responses": {
                         "200": {
-                            "description": "Example of datatypes",
+                            "description": "Country",
                             "content": {
                                 "application/json": {
                                     "schema": {
                                         "type": "object",
                                         "properties": {
-                                            "id": {"type": "integer", "example": 1},
-                                            "active_from": {
-                                                "type": "string",
-                                                "format": "date",
-                                                "example": "2019-12-31",
+                                            "name": {
+                                                "type": "string"
                                             },
-                                            "active_to": {
-                                                "nullable": True,
+                                            "independence_date": {
                                                 "type": "string",
+                                                "format": "date"
                                             },
-                                            "created_at": {
+                                            "timezone_offset": {
                                                 "type": "string",
-                                                "format": "date-time",
-                                                "example": "2025-02-19T07:00:11.000000Z",
+                                                "format": "time"
                                             },
-                                            "Subscribed": {"type": "boolean"},
-                                            "weight": {"type": "number"},
-                                            "attachment": {
+                                            "last_updated": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "is_member_of_un": {
+                                                "type": "boolean"
+                                            },
+                                            "population": {
+                                                "type": "integer"
+                                            },
+                                            "gdp": {
+                                                "type": "number"
+                                            },
+                                            "flag_base64": {
                                                 "type": "string",
                                                 "contentEncoding": "base64",
-                                            },
-                                            "meeting_time": {
-                                                "type": "string",
-                                                "format": "time",
-                                                "example": "14:30:00",
                                             }
                                         }
                                     }
@@ -378,22 +397,23 @@ def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
         }
     })
 
+
     table = """
     id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
-       | services/example                        | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example     |
+       | services/example_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example of an API | Intricate description
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       | services/example/default                |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   | api_datatypes_get                   | dask/json         |     | /api/datatypes            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       | services/example_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_countries_get                   | dask/json         |     | /api/countries            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | ExampleOfDatatypes          |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | id                      | integer required  |     | id                        |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | active_from             | date required     |     | active_from               |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | active_to               | string            |     | active_to                 |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | created_at              | datetime required |     | created_at                |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | subscribed              | boolean required  |     | Subscribed                |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | weight                  | number required   |     | weight                    |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | attachment              | binary required   |     | attachment                |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | meeting_time            | time required     |     | meeting_time              |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   | Country                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | independence_date       | date required     |     | independence_date         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | timezone_offset         | time required     |     | timezone_offset           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | last_updated            | datetime required |     | last_updated              |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | is_member_of_un         | boolean required  |     | is_member_of_un           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | population              | integer required  |     | population                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | gdp                     | number required   |     | gdp                       |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | flag_base64             | binary required   |     | flag_base64               |             |                                   |        |       |       | develop | private    |        |     |     |             |
        """
  
     path = tmp_path / 'manifest.json'
@@ -406,27 +426,34 @@ def test_open_api_manifest_datatypes(rc: RawConfig, tmp_path: Path):
     assert manifest == table
 
 def test_open_api_manifest_array_of_primitives(rc: RawConfig, tmp_path: Path):
+    model_deduplicator._names.clear()
     data = json.dumps({
         "openapi": "3.0.0",
-        "info": {"title": "Test API", "version": "1.0.0"},
+        "info": {
+            "title": "Example API",
+            "version": "1.0.0",
+            "summary": "Example of an API",
+            "description": "Intricate description",
+        },
         "paths": {
-            "/api/array": {
+            "/api/countries": {
                 "get": {
                     "responses": {
                         "200": {
-                            "description": "Masyvas",
+                            "description": "Country",
                             "content": {
                                 "application/json": {
                                     "schema": {
                                         "type": "object",
                                         "properties": {
-                                            "notes": {
-                                                "type": "array",
-                                                "items": {"type": "string"}
+                                            "name": {
+                                                "type": "string"
                                             },
-                                            "numbers": {
+                                            "city_names": {
                                                 "type": "array",
-                                                "items": {"type": "integer"}
+                                                "items": {
+                                                    "type": "string"
+                                                }
                                             }
                                         }
                                     }
@@ -441,17 +468,16 @@ def test_open_api_manifest_array_of_primitives(rc: RawConfig, tmp_path: Path):
 
     table = """
     id | d | r | b | m | property                | type              | ref | source                    | source.type | prepare                           | origin | count | level | status  | visibility | access | uri | eli | title       | description
-       | services/test_api                       | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Test API    |
+       | services/example_api                    | ns                |     |                           |             |                                   |        |       |       |         |            |        |     |     | Example of an API | Intricate description
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       | services/test_api/default               |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   | api_array_get                       | dask/json         |     | /api/array                |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
+       | services/example_api/default            |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
+       |   | api_countries_get                   | dask/json         |     | /api/countries            |             | http(method: 'GET', body: 'form') |        |       |       |         |            |        |     |     |             |
        |                                         |                   |     |                           |             |                                   |        |       |       |         |            |        |     |     |             |
-       |   |   |   | Masyvas                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | notes                   | array required    |     | notes                     |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | notes[]                 | string required   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | numbers                 | array required    |     | numbers                   |             |                                   |        |       |       | develop | private    |        |     |     |             |
-       |   |   |   |   | numbers[]               | integer required  |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
-    """
+       |   |   |   | Country                     |                   |     | .                         |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | name                    | string required   |     | name                      |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | city_names              | array required    |     | city_names                |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       |   |   |   |   | city_names[]            | string required   |     |                           |             |                                   |        |       |       | develop | private    |        |     |     |             |
+       """
  
     path = tmp_path / 'manifest.json'
     path_openapi = f'openapi+file://{path}'


### PR DESCRIPTION
**Add OpenAPI (and Swagger 2.0) JSON Schema to DSA Conversion for Models and Properties**

Implemented conversion from OpenAPI/Swagger JSON schemas to DSA structure, supporting both Model and ModelProperty dimensions.
Only flattened JSON schemas are supported.

Implemented functionality:

- Parse and register root-level models
- Handle nested models
- Link ref and backref relationships
- Extract model properties
- Detect ModelProperty datatypes
- Read ModelProperty enums