### PR TITLE
[1415] Improve upon existing `spinta sync` logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ New Features:
   from saved `backends`. (`#1275`_)
 - Implement the skeleton of `spinta sync` command. (`#1378`_)
 - Added OpenAPI(and Swagger 2.0) inline schema to DSA conversion `Model` and `ModelProperty` dimensions (`#1260`_) (`#1377`_) (`#1381`_) (`#1382`_) (`#1389`_)
+- Refactored `spinta sync` into separate functions to improve readability and maintainability. (`#1415_`)
 
   .. _#1274: https://github.com/atviriduomenys/spinta/issues/1274
   .. _#1275: https://github.com/atviriduomenys/spinta/issues/1275
@@ -22,19 +23,16 @@ New Features:
   .. _#1381: https://github.com/atviriduomenys/spinta/issues/1381
   .. _#1382: https://github.com/atviriduomenys/spinta/issues/1382
   .. _#1389: https://github.com/atviriduomenys/spinta/issues/1389
+  .. _#1415: https://github.com/atviriduomenys/spinta/issues/1415
+
 
 Bug fixes:
 
 - Fixed situation where nested properties in `ref` column were giving an error. (`#981`_)
-
-  .. _#981: https://github.com/atviriduomenys/spinta/issues/981
-
-
-Bug fixes:
-
 - Fixed a bug where `spinta` didn't work with Python version 3.13 (`#986`_, `#1357`_)
 - Updated `pyproj` from version 3.6.1 to 3.7.1 to ensure compatibility with Python version 3.13 (`1358`_)
-  
+
+  .. _#981: https://github.com/atviriduomenys/spinta/issues/981
   .. _#986: https://github.com/atviriduomenys/spinta/issues/986
   .. _#1357: https://github.com/atviriduomenys/spinta/issues/1357
   .. _#1358: https://github.com/atviriduomenys/spinta/issues/1358

--- a/poetry.lock
+++ b/poetry.lock
@@ -4162,6 +4162,21 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-requests"
+version = "2.32.4.20250809"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_requests-2.32.4.20250809-py3-none-any.whl", hash = "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163"},
+    {file = "types_requests-2.32.4.20250809.tar.gz", hash = "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -4731,4 +4746,4 @@ migrations = ["alembic"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "92545268f63cc066e0d26066eed99a821ce106a9f76da725d11e5fc4937728b8"
+content-hash = "68a3d8429268bba0e068f57763d9fb30285e8ae76402d6026a61ce4e0e9721cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ cssselect = "*"
 objprint = "*"
 sphinx-rtd-theme = "*"
 sqlalchemy-stubs = "*"
+types-requests = "^2.32.4.20250809"
 
 
 [build-system]

--- a/spinta/cli/helpers/sync/__init__.py
+++ b/spinta/cli/helpers/sync/__init__.py
@@ -1,0 +1,2 @@
+CONTENT_TYPE_TEXT_CSV = "text/csv"
+IDENTIFIER = "_id"

--- a/spinta/cli/helpers/sync/controllers/dataset.py
+++ b/spinta/cli/helpers/sync/controllers/dataset.py
@@ -8,6 +8,22 @@ from spinta.cli.helpers.sync.helpers import validate_api_response
 
 
 def get_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -> Response:
+    """Retrieve a dataset by its unique name (per organization).
+
+    Sends a GET request to the Dataset API with a query parameter `name`.
+    Although this endpoint returns a list, at most one dataset is expected.
+
+    Args:
+        base_path: Base URL of the API.
+        headers: HTTP headers to include in the request.
+        dataset_name: Unique name of the dataset (per organization) to retrieve.
+
+    Returns:
+        Response: The HTTP response object from the request.
+
+    Raises:
+        requests.HTTPError: If the response status is not `200 Ok` or `404 Not Found`.
+    """
     response = requests.get(
         f"{base_path}/Dataset/",
         headers=headers,
@@ -18,6 +34,21 @@ def get_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -> R
 
 
 def create_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -> Response:
+    """Create a new dataset.
+
+    Sends a POST request to the Dataset API to create a dataset.
+
+    Args:
+        base_path: Base URL of the API.
+        headers: HTTP headers to include in the request.
+        dataset_name: Name (and title) of the new dataset.
+
+    Returns:
+        Response: The HTTP response object from the request.
+
+    Raises:
+        requests.HTTPError: If the response status is not `201 Created`.
+    """
     response = requests.post(
         f"{base_path}/Dataset/",
         headers=headers,

--- a/spinta/cli/helpers/sync/controllers/dataset.py
+++ b/spinta/cli/helpers/sync/controllers/dataset.py
@@ -1,0 +1,29 @@
+from http import HTTPStatus
+
+import requests
+
+from spinta.cli.helpers.sync.helpers import check_api_response
+
+
+def get_dataset(base_path, headers, dataset_name):
+    response = requests.get(
+        f"{base_path}/Dataset/",
+        headers=headers,
+        params={"name": dataset_name},
+    )
+    check_api_response(response, {HTTPStatus.OK, HTTPStatus.NOT_FOUND}, "Get dataset")
+    return response
+
+
+def create_dataset(base_path, headers, dataset_name):
+    response = requests.post(
+        f"{base_path}/Dataset/",
+        headers=headers,
+        data={
+            "title": dataset_name,
+            "description": "",
+            "name": dataset_name,
+        }
+    )
+    check_api_response(response, {HTTPStatus.CREATED}, "Create dataset")
+    return response

--- a/spinta/cli/helpers/sync/controllers/dataset.py
+++ b/spinta/cli/helpers/sync/controllers/dataset.py
@@ -1,21 +1,23 @@
+from __future__ import annotations
 from http import HTTPStatus
 
 import requests
+from requests.models import Response
 
-from spinta.cli.helpers.sync.helpers import check_api_response
+from spinta.cli.helpers.sync.helpers import validate_api_response
 
 
-def get_dataset(base_path, headers, dataset_name):
+def get_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -> Response:
     response = requests.get(
         f"{base_path}/Dataset/",
         headers=headers,
         params={"name": dataset_name},
     )
-    check_api_response(response, {HTTPStatus.OK, HTTPStatus.NOT_FOUND}, "Get dataset")
+    validate_api_response(response, {HTTPStatus.OK, HTTPStatus.NOT_FOUND}, "Get dataset")
     return response
 
 
-def create_dataset(base_path, headers, dataset_name):
+def create_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -> Response:
     response = requests.post(
         f"{base_path}/Dataset/",
         headers=headers,
@@ -25,5 +27,5 @@ def create_dataset(base_path, headers, dataset_name):
             "name": dataset_name,
         }
     )
-    check_api_response(response, {HTTPStatus.CREATED}, "Create dataset")
+    validate_api_response(response, {HTTPStatus.CREATED}, "Create dataset")
     return response

--- a/spinta/cli/helpers/sync/controllers/dataset.py
+++ b/spinta/cli/helpers/sync/controllers/dataset.py
@@ -25,7 +25,7 @@ def create_dataset(base_path: str, headers: dict[str, str], dataset_name: str) -
             "title": dataset_name,
             "description": "",
             "name": dataset_name,
-        }
+        },
     )
     validate_api_response(response, {HTTPStatus.CREATED}, "Create dataset")
     return response

--- a/spinta/cli/helpers/sync/controllers/distribution.py
+++ b/spinta/cli/helpers/sync/controllers/distribution.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
 from http import HTTPStatus
 from io import BytesIO
 
 import requests
 
 from spinta.cli.helpers.sync import CONTENT_TYPE_TEXT_CSV
-from spinta.cli.helpers.sync.helpers import check_api_response
+from spinta.cli.helpers.sync.helpers import validate_api_response
+from spinta.manifests.components import ManifestPath
 
 
-def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests):
+def create_distribution(base_path: str, headers: dict[str, str], dataset_name: str, file_bytes: bytes, dataset_id: str, manifests: list[ManifestPath]) -> None:
     response = requests.post(
         f"{base_path}/Distribution/",
         headers=headers,
@@ -19,4 +21,4 @@ def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id
             "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
         }
     )
-    check_api_response(response, {HTTPStatus.CREATED}, "Create distribution")
+    validate_api_response(response, {HTTPStatus.CREATED}, "Create distribution")

--- a/spinta/cli/helpers/sync/controllers/distribution.py
+++ b/spinta/cli/helpers/sync/controllers/distribution.py
@@ -17,6 +17,25 @@ def create_distribution(
     dataset_id: str,
     manifests: list[ManifestPath],
 ) -> None:
+    """Create a distribution for a dataset with a CSV file.
+
+    Sends a POST request to the Distribution API, attaching the given CSV file.
+    The distribution is linked to the dataset identified by `dataset_id`.
+
+    Args:
+        base_path: Base URL of the API.
+        headers: HTTP headers to include in the request.
+        dataset_name: Name/title of the dataset for which the distribution is created.
+        file_bytes: Content of the CSV file to upload as bytes.
+        dataset_id: ID of the dataset to link the distribution to.
+        manifests: List of ManifestPath objects representing file paths.
+
+    Returns:
+        None
+
+    Raises:
+        requests.HTTPError: If the response status is not `201 Created`.
+    """
     response = requests.post(
         f"{base_path}/Distribution/",
         headers=headers,

--- a/spinta/cli/helpers/sync/controllers/distribution.py
+++ b/spinta/cli/helpers/sync/controllers/distribution.py
@@ -9,7 +9,14 @@ from spinta.cli.helpers.sync.helpers import validate_api_response
 from spinta.manifests.components import ManifestPath
 
 
-def create_distribution(base_path: str, headers: dict[str, str], dataset_name: str, file_bytes: bytes, dataset_id: str, manifests: list[ManifestPath]) -> None:
+def create_distribution(
+    base_path: str,
+    headers: dict[str, str],
+    dataset_name: str,
+    file_bytes: bytes,
+    dataset_id: str,
+    manifests: list[ManifestPath],
+) -> None:
     response = requests.post(
         f"{base_path}/Distribution/",
         headers=headers,
@@ -19,6 +26,6 @@ def create_distribution(base_path: str, headers: dict[str, str], dataset_name: s
         },
         files={
             "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
-        }
+        },
     )
     validate_api_response(response, {HTTPStatus.CREATED}, "Create distribution")

--- a/spinta/cli/helpers/sync/controllers/distribution.py
+++ b/spinta/cli/helpers/sync/controllers/distribution.py
@@ -1,0 +1,22 @@
+from http import HTTPStatus
+from io import BytesIO
+
+import requests
+
+from spinta.cli.helpers.sync import CONTENT_TYPE_TEXT_CSV
+from spinta.cli.helpers.sync.helpers import check_api_response
+
+
+def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests):
+    response = requests.post(
+        f"{base_path}/Distribution/",
+        headers=headers,
+        data={
+            "dataset": dataset_id,
+            "title": dataset_name,
+        },
+        files={
+            "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
+        }
+    )
+    check_api_response(response, {HTTPStatus.CREATED}, "Create distribution")

--- a/spinta/cli/helpers/sync/controllers/dsa.py
+++ b/spinta/cli/helpers/sync/controllers/dsa.py
@@ -1,22 +1,23 @@
+from __future__ import annotations
 from http import HTTPStatus
 
 import requests
 
 from spinta.cli.helpers.sync import CONTENT_TYPE_TEXT_CSV
-from spinta.cli.helpers.sync.helpers import check_api_response
+from spinta.cli.helpers.sync.helpers import validate_api_response
 from spinta.exceptions import NotImplementedFeature
 
 
-def create_dsa(base_path, headers, dataset_id, content):
+def create_dsa(base_path: str, headers: dict[str, str], dataset_id: str, content: str) -> None:
     response = requests.post(
         f"{base_path}/Dataset/{dataset_id}/dsa/",
         headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **headers},
         data=content,
     )
-    check_api_response(response, {HTTPStatus.NO_CONTENT}, "Create DSA")
+    validate_api_response(response, {HTTPStatus.NO_CONTENT}, "Create DSA")
 
 
-def update_dsa(base_path, headers, dataset_id):
+def update_dsa(base_path: str, headers: dict[str, str], dataset_id: str) -> None:
     # TODO: Unfinished: implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
     response = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=headers)
     raise NotImplementedFeature(

--- a/spinta/cli/helpers/sync/controllers/dsa.py
+++ b/spinta/cli/helpers/sync/controllers/dsa.py
@@ -9,6 +9,23 @@ from spinta.exceptions import NotImplementedFeature
 
 
 def create_dsa(base_path: str, headers: dict[str, str], dataset_id: str, content: str) -> None:
+    """Create a DSA (Duomenų Struktūros Aprašas) for a dataset.
+
+    Sends a POST request to the Dataset DSA API endpoint, uploading the
+    provided CSV content for the dataset identified by `dataset_id`.
+
+    Args:
+        base_path: Base URL of the API.
+        headers: HTTP headers to include in the request.
+        dataset_id: ID of the dataset to create the DSA for.
+        content: CSV content representing the dataset structure.
+
+    Returns:
+        None
+
+    Raises:
+        requests.HTTPError: If the response status is not `204 No Content`.
+    """
     response = requests.post(
         f"{base_path}/Dataset/{dataset_id}/dsa/",
         headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **headers},
@@ -18,6 +35,20 @@ def create_dsa(base_path: str, headers: dict[str, str], dataset_id: str, content
 
 
 def update_dsa(base_path: str, headers: dict[str, str], dataset_id: str) -> None:
+    """Update the DSA of an existing dataset.
+
+    Currently not implemented. Planned to send a PUT request to the
+    Dataset DSA API endpoint to update the dataset structure.
+
+    Args:
+        base_path: Base URL of the API.
+        headers: HTTP headers to include in the request.
+        dataset_id: ID of the dataset whose DSA is to be updated.
+
+    Raises:
+        NotImplementedFeature: Always raised to indicate that updating
+            existing datasets is not yet supported.
+    """
     # TODO: Unfinished: implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
     response = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=headers)
     raise NotImplementedFeature(

--- a/spinta/cli/helpers/sync/controllers/dsa.py
+++ b/spinta/cli/helpers/sync/controllers/dsa.py
@@ -1,0 +1,26 @@
+from http import HTTPStatus
+
+import requests
+
+from spinta.cli.helpers.sync import CONTENT_TYPE_TEXT_CSV
+from spinta.cli.helpers.sync.helpers import check_api_response
+from spinta.exceptions import NotImplementedFeature
+
+
+def create_dsa(base_path, headers, dataset_id, content):
+    response = requests.post(
+        f"{base_path}/Dataset/{dataset_id}/dsa/",
+        headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **headers},
+        data=content,
+    )
+    check_api_response(response, {HTTPStatus.NO_CONTENT}, "Create DSA")
+
+
+def update_dsa(base_path, headers, dataset_id):
+    # TODO: Unfinished: implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
+    response = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=headers)
+    raise NotImplementedFeature(
+        status=response.status_code,
+        dataset_id=dataset_id,
+        feature="Updates on existing Datasets",
+    )

--- a/spinta/cli/helpers/sync/helpers.py
+++ b/spinta/cli/helpers/sync/helpers.py
@@ -30,7 +30,7 @@ def validate_api_response(response: Response, expected_status_codes: set[HTTPSta
             operation=operation,
             expected_status_code=expected_status_codes,
             response_status_code=response.status_code,
-            response_data=format_error_response_data(response.json())
+            response_data=format_error_response_data(response.json()),
         )
 
 
@@ -85,7 +85,7 @@ def format_error_response_data(data: dict[str, Any]) -> dict:
     return data
 
 
-def extract_dataset_id(response, response_type):
+def extract_dataset_id(response: Response, response_type: str) -> str:
     dataset_id = None
     if response_type == "list":
         dataset_id = response.json().get("_data", [{}])[0].get(IDENTIFIER)
@@ -95,7 +95,7 @@ def extract_dataset_id(response, response_type):
     if not dataset_id:
         raise UnexpectedAPIResponseData(
             operation=f"Retrieve dataset `{IDENTIFIER}`",
-            context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
+            context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset.",
         )
 
     return dataset_id

--- a/spinta/cli/helpers/sync/helpers.py
+++ b/spinta/cli/helpers/sync/helpers.py
@@ -1,0 +1,62 @@
+from typing import List, Tuple, Dict
+
+from typer import Context as TyperContext
+
+from spinta.auth import DEFAULT_CREDENTIALS_SECTION
+from spinta.cli.helpers.manifest import convert_str_to_manifest_path
+from spinta.cli.helpers.store import prepare_manifest
+from spinta.client import get_client_credentials, RemoteClientCredentials, get_access_token
+from spinta.components import Config, Context
+from spinta import commands
+from spinta.core.context import configure_context
+from spinta.core.enums import Mode
+from spinta.exceptions import NotImplementedFeature, ManifestFileNotProvided
+from spinta.manifests.components import ManifestPath, Manifest
+
+
+def get_manifest_paths(manifests: List[str]):
+    manifests = convert_str_to_manifest_path(manifests)
+    if not manifests:
+        raise ManifestFileNotProvided
+
+    return manifests
+
+
+def build_manifest_and_context(ctx: TyperContext, manifests: List[str]) -> Tuple[Context, Manifest]:
+    context = configure_context(ctx.obj, manifests, mode=Mode.external)
+    store = prepare_manifest(context, verbose=False, full_load=True)
+    return context, store.manifest
+
+
+def get_dataset_name(context: Context, manifest: Manifest) -> str:
+    datasets = commands.get_datasets(context, manifest)
+    if len(datasets) > 1:
+        # TODO: https://github.com/atviriduomenys/spinta/issues/1404
+        raise NotImplementedFeature(feature="Synchronizing more than 1 dataset at a time")
+
+    return next(iter(datasets))
+
+
+def get_file_bytes_and_decoded_content(manifests: List[ManifestPath]) -> Tuple[bytes, str]:
+    with open(manifests[0].path, "rb") as file:
+        file_bytes = file.read()
+        content = file_bytes.decode("utf-8")
+    return file_bytes, content
+
+
+def get_base_path_and_headers(context: Context) -> Tuple[str, Dict[str, str]]:
+    config: Config = context.get("config")
+    credentials: RemoteClientCredentials = get_client_credentials(config.credentials_file, DEFAULT_CREDENTIALS_SECTION)
+
+    access_token = get_access_token(credentials)
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    resource_server = credentials.resource_server or credentials.server
+    base_path = f"{resource_server}/uapi/datasets/org/vssa/isris/dcat"
+
+    return base_path, headers
+
+
+def format_error_response_data(data: dict) -> dict:
+    data.pop("context", None)
+    return data

--- a/spinta/cli/helpers/sync/helpers.py
+++ b/spinta/cli/helpers/sync/helpers.py
@@ -40,7 +40,7 @@ def validate_api_response(response: Response, expected_status_codes: set[HTTPSta
     if response.status_code not in expected_status_codes:
         raise UnexpectedAPIResponse(
             operation=operation,
-            expected_status_code=expected_status_codes,
+            expected_status_code={code.value for code in expected_status_codes},
             response_status_code=response.status_code,
             response_data=format_error_response_data(response.json()),
         )

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -1,131 +1,22 @@
 import logging
 from http import HTTPStatus
-from io import BytesIO
-from typing import List, Tuple
+from typing import List
 
-import requests
 from typer import Context as TyperContext, Argument
 
+from spinta.cli.helpers.sync.controllers.dataset import get_dataset, create_dataset
+from spinta.cli.helpers.sync.controllers.distribution import create_distribution
+from spinta.cli.helpers.sync.controllers.dsa import update_dsa, create_dsa
 from spinta.cli.helpers.sync.helpers import (
-    format_error_response_data,
     get_dataset_name,
     get_file_bytes_and_decoded_content,
     get_base_path_and_headers,
     get_manifest_paths,
-    build_manifest_and_context,
+    build_manifest_and_context, extract_dataset_id,
 )
-from spinta.exceptions import NotImplementedFeature, UnexpectedAPIResponse, UnexpectedAPIResponseData
 
 
 logger = logging.getLogger(__name__)
-
-
-CONTENT_TYPE_TEXT_CSV = "text/csv"
-IDENTIFIER = "_id"
-
-
-def get_dataset(base_path, headers, dataset_name):
-    response = requests.get(
-        f"{base_path}/Dataset/",
-        headers=headers,
-        params={"name": dataset_name},
-    )
-
-    if response.status_code not in {HTTPStatus.OK, HTTPStatus.NOT_FOUND}:
-        raise UnexpectedAPIResponse(
-            operation="Get dataset",
-            expected_status_code={HTTPStatus.OK, HTTPStatus.NOT_FOUND},
-            response_status_code=response.status_code,
-            response_data=format_error_response_data(response.json()),
-        )
-
-    return response
-
-
-def extract_dataset_id(response, response_type):
-    dataset_id = None
-    if response_type == "list":
-        dataset_id = response.json().get("_data", [{}])[0].get(IDENTIFIER)
-    elif response_type == "detail":
-        dataset_id = response.json().get(IDENTIFIER)
-
-    if not dataset_id:
-        raise UnexpectedAPIResponseData(
-            operation=f"Retrieve dataset `{IDENTIFIER}`",
-            context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
-        )
-
-    return dataset_id
-
-
-def update_dsa(base_path, headers, dataset_id):
-    # TODO: Unfinished: implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
-    response = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=headers)
-    raise NotImplementedFeature(
-        status=response.status_code,
-        dataset_id=dataset_id,
-        feature="Updates on existing Datasets",
-    )
-
-
-def create_dataset(base_path, headers, dataset_name):
-    response = requests.post(
-        f"{base_path}/Dataset/",
-        headers=headers,
-        data={
-            "title": dataset_name,
-            "description": "",
-            "name": dataset_name,
-        }
-    )
-
-    if response.status_code != HTTPStatus.CREATED:
-        raise UnexpectedAPIResponse(
-            operation="Create dataset",
-            expected_status_code=HTTPStatus.CREATED,
-            response_status_code=response.status_code,
-            response_data=format_error_response_data(response.json()),
-        )
-
-    return response
-
-
-def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests):
-    response = requests.post(
-        f"{base_path}/Distribution/",
-        headers=headers,
-        data={
-            "dataset": dataset_id,
-            "title": dataset_name,
-        },
-        files={
-            "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
-        }
-    )
-
-    if response.status_code != HTTPStatus.CREATED:
-        raise UnexpectedAPIResponse(
-            operation="Create dataset distribution",
-            expected_status_code=HTTPStatus.CREATED,
-            response_status_code=response.status_code,
-            response_data=format_error_response_data(response.json()),
-        )
-
-
-def create_dsa(base_path, headers, dataset_id, content):
-    response = requests.post(
-        f"{base_path}/Dataset/{dataset_id}/dsa/",
-        headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **headers},
-        data=content,
-    )
-
-    if response.status_code != HTTPStatus.NO_CONTENT:
-        raise UnexpectedAPIResponse(
-            operation="Create DSA for dataset",
-            expected_status_code=HTTPStatus.CREATED,
-            response_status_code=response.status_code,
-            response_data=format_error_response_data(response.json()),
-        )
 
 
 def sync(

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -12,7 +12,8 @@ from spinta.cli.helpers.sync.helpers import (
     get_file_bytes_and_decoded_content,
     get_base_path_and_headers,
     get_manifest_paths,
-    build_manifest_and_context, extract_dataset_id,
+    build_manifest_and_context,
+    extract_dataset_id,
 )
 from spinta.manifests.components import ManifestPath
 

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -42,17 +42,17 @@ def _get_file_bytes_and_decoded_content(manifests: List[ManifestPath]) -> Tuple[
     return file_bytes, content
 
 
-def _get_base_path_and_authorization_headers(context: Context) -> Tuple[str, Dict[str, str]]:
+def _get_base_path_and_headers(context: Context) -> Tuple[str, Dict[str, str]]:
     config: Config = context.get("config")
     credentials: RemoteClientCredentials = get_client_credentials(config.credentials_file, DEFAULT_CREDENTIALS_SECTION)
 
     access_token = get_access_token(credentials)
-    authorization_headers = {"Authorization": f"Bearer {access_token}"}
+    headers = {"Authorization": f"Bearer {access_token}"}
 
     resource_server = credentials.resource_server or credentials.server
     base_path = f"{resource_server}/uapi/datasets/org/vssa/isris/dcat"
 
-    return base_path, authorization_headers
+    return base_path, headers
 
 
 def _format_error_response_data(data: dict) -> dict:
@@ -60,102 +60,141 @@ def _format_error_response_data(data: dict) -> dict:
     return data
 
 
+def get_manifest_paths(manifests: List[str]):
+    manifests = convert_str_to_manifest_path(manifests)
+    if not manifests:
+        raise ManifestFileNotProvided
+
+    return manifests
+
+
+def build_manifest_and_context(ctx: TyperContext, manifests: List[str]) -> Tuple[Context, Manifest]:
+    context = configure_context(ctx.obj, manifests, mode=Mode.external)
+    store = prepare_manifest(context, verbose=False, full_load=True)
+    return context, store.manifest
+
+
+def get_dataset(base_path, headers, dataset_name):
+    response = requests.get(
+        f"{base_path}/Dataset/",
+        headers=headers,
+        params={"name": dataset_name},
+    )
+
+    if response.status_code not in {HTTPStatus.OK, HTTPStatus.NOT_FOUND}:
+        raise UnexpectedAPIResponse(
+            operation="Get dataset",
+            expected_status_code={HTTPStatus.OK, HTTPStatus.NOT_FOUND},
+            response_status_code=response.status_code,
+            response_data=_format_error_response_data(response.json()),
+        )
+
+    return response
+
+
+def extract_dataset_id(response, response_type):
+    dataset_id = None
+    if response_type == "list":
+        dataset_id = response.json().get("_data", [{}])[0].get(IDENTIFIER)
+    elif response_type == "detail":
+        dataset_id = response.json().get(IDENTIFIER)
+
+    if not dataset_id:
+        raise UnexpectedAPIResponseData(
+            operation=f"Retrieve dataset `{IDENTIFIER}`",
+            context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
+        )
+
+    return dataset_id
+
+
+def update_dsa(base_path, headers, dataset_id):
+    # TODO: Unfinished: implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
+    response = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=headers)
+    raise NotImplementedFeature(
+        status=response.status_code,
+        dataset_id=dataset_id,
+        feature="Updates on existing Datasets",
+    )
+
+
+def create_dataset(base_path, headers, dataset_name):
+    response = requests.post(
+        f"{base_path}/Dataset/",
+        headers=headers,
+        data={
+            "title": dataset_name,
+            "description": "",
+            "name": dataset_name,
+        }
+    )
+
+    if response.status_code != HTTPStatus.CREATED:
+        raise UnexpectedAPIResponse(
+            operation="Create dataset",
+            expected_status_code=HTTPStatus.CREATED,
+            response_status_code=response.status_code,
+            response_data=_format_error_response_data(response.json()),
+        )
+
+    return response
+
+
+def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests):
+    response = requests.post(
+        f"{base_path}/Distribution/",
+        headers=headers,
+        data={
+            "dataset": dataset_id,
+            "title": dataset_name,
+        },
+        files={
+            "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
+        }
+    )
+
+    if response.status_code != HTTPStatus.CREATED:
+        raise UnexpectedAPIResponse(
+            operation="Create dataset distribution",
+            expected_status_code=HTTPStatus.CREATED,
+            response_status_code=response.status_code,
+            response_data=_format_error_response_data(response.json()),
+        )
+
+
+def create_dsa(base_path, headers, dataset_id, content):
+    response = requests.post(
+        f"{base_path}/Dataset/{dataset_id}/dsa/",
+        headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **headers},
+        data=content,
+    )
+
+    if response.status_code != HTTPStatus.NO_CONTENT:
+        raise UnexpectedAPIResponse(
+            operation="Create DSA for dataset",
+            expected_status_code=HTTPStatus.CREATED,
+            response_status_code=response.status_code,
+            response_data=_format_error_response_data(response.json()),
+        )
+
+
 def sync(
     ctx: TyperContext,
     manifests: List[str] = Argument(None, help=("Manifest files to load")),
 ):
-    manifests = convert_str_to_manifest_path(manifests)
-    if not manifests:
-        raise ManifestFileNotProvided
-    context = configure_context(ctx.obj, manifests, mode=Mode.external)
-    store = prepare_manifest(context, verbose=False, full_load=True)
-    manifest: Manifest = store.manifest
+    manifests = get_manifest_paths(manifests)
+    context, manifest = build_manifest_and_context(ctx, manifests)
 
     dataset_name = _get_dataset_name(context, manifest)
     file_bytes, content = _get_file_bytes_and_decoded_content(manifests)
-    base_path, authorization_headers = _get_base_path_and_authorization_headers(context)
+    base_path, headers = _get_base_path_and_headers(context)
 
-    response_get_dataset = requests.get(
-        f"{base_path}/Dataset/",
-        headers=authorization_headers,
-        params={"name": dataset_name},
-    )
-    if response_get_dataset.status_code not in {HTTPStatus.OK, HTTPStatus.NOT_FOUND}:
-        raise UnexpectedAPIResponse(
-            operation="Get dataset",
-            expected_status_code={HTTPStatus.OK, HTTPStatus.NOT_FOUND},
-            response_status_code=response_get_dataset.status_code,
-            response_data=_format_error_response_data(response_get_dataset.json()),
-        )
-
+    response_get_dataset = get_dataset(base_path, headers, dataset_name)
     if response_get_dataset.status_code == HTTPStatus.OK:
-        if not (dataset_id := response_get_dataset.json().get("_data", [{}])[0].get(IDENTIFIER)):
-            raise UnexpectedAPIResponseData(
-                operation=f"Retrieve dataset `{IDENTIFIER}`",
-                context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
-            )
-        response_update_dsa = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=authorization_headers)
-        # TODO: Implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
-        raise NotImplementedFeature(
-            status=response_update_dsa.status_code,
-            dataset_id=dataset_id,
-            feature="Updates on existing Datasets",
-        )
+        dataset_id = extract_dataset_id(response_get_dataset, "list")
+        update_dsa(base_path, headers, dataset_id)
     elif response_get_dataset.status_code == HTTPStatus.NOT_FOUND:
-        response_post_dataset = requests.post(
-            f"{base_path}/Dataset/",
-            headers=authorization_headers,
-            data={
-                "title": dataset_name,
-                "description": "",
-                "name": dataset_name,
-            }
-        )
-
-        if response_post_dataset.status_code != HTTPStatus.CREATED:
-            raise UnexpectedAPIResponse(
-                operation="Create dataset",
-                expected_status_code=HTTPStatus.CREATED,
-                response_status_code=response_post_dataset.status_code,
-                response_data=_format_error_response_data(response_post_dataset.json()),
-            )
-
-        dataset_id = response_post_dataset.json().get(IDENTIFIER)
-        if not dataset_id:
-            raise UnexpectedAPIResponseData(
-                operation=f"Retrieve dataset `{IDENTIFIER}`",
-                context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
-            )
-        response_post_distribution = requests.post(
-            f"{base_path}/Distribution/",
-            headers=authorization_headers,
-            data={
-                "dataset": dataset_id,
-                "title": dataset_name,
-            },
-            files={
-                "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
-            }
-        )
-
-        if response_post_distribution.status_code != HTTPStatus.CREATED:
-            raise UnexpectedAPIResponse(
-                operation="Create dataset distribution",
-                expected_status_code=HTTPStatus.CREATED,
-                response_status_code=response_post_distribution.status_code,
-                response_data=_format_error_response_data(response_post_distribution.json()),
-            )
-
-        response_create_dsa = requests.post(
-            f"{base_path}/Dataset/{dataset_id}/dsa/",
-            headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **authorization_headers},
-            data=content,
-        )
-
-        if response_create_dsa.status_code != HTTPStatus.NO_CONTENT:
-            raise UnexpectedAPIResponse(
-                operation="Create DSA for dataset",
-                expected_status_code=HTTPStatus.CREATED,
-                response_status_code=response_create_dsa.status_code,
-                response_data=_format_error_response_data(response_create_dsa.json()),
-            )
+        response_create_dataset = create_dataset(base_path, headers, dataset_name)
+        dataset_id = extract_dataset_id(response_create_dataset, "detail")
+        create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests)
+        create_dsa(base_path, headers, dataset_id, content)

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -1,22 +1,20 @@
 import logging
 from http import HTTPStatus
 from io import BytesIO
-from typing import List, Tuple, Dict
+from typing import List, Tuple
 
 import requests
 from typer import Context as TyperContext, Argument
 
-from spinta.auth import DEFAULT_CREDENTIALS_SECTION
-from spinta.client import get_client_credentials, RemoteClientCredentials, get_access_token
-from spinta.components import Config, Context
-from spinta import commands
-from spinta.cli.helpers.manifest import convert_str_to_manifest_path
-from spinta.cli.helpers.store import prepare_manifest
-from spinta.core.enums import Mode
-from spinta.core.context import configure_context
-from spinta.exceptions import NotImplementedFeature, UnexpectedAPIResponse, UnexpectedAPIResponseData, \
-    ManifestFileNotProvided
-from spinta.manifests.components import ManifestPath, Manifest
+from spinta.cli.helpers.sync.helpers import (
+    format_error_response_data,
+    get_dataset_name,
+    get_file_bytes_and_decoded_content,
+    get_base_path_and_headers,
+    get_manifest_paths,
+    build_manifest_and_context,
+)
+from spinta.exceptions import NotImplementedFeature, UnexpectedAPIResponse, UnexpectedAPIResponseData
 
 
 logger = logging.getLogger(__name__)
@@ -24,54 +22,6 @@ logger = logging.getLogger(__name__)
 
 CONTENT_TYPE_TEXT_CSV = "text/csv"
 IDENTIFIER = "_id"
-
-
-def _get_dataset_name(context: Context, manifest: Manifest) -> str:
-    datasets = commands.get_datasets(context, manifest)
-    if len(datasets) > 1:
-        # TODO: https://github.com/atviriduomenys/spinta/issues/1404
-        raise NotImplementedFeature(feature="Synchronizing more than 1 dataset at a time")
-
-    return next(iter(datasets))
-
-
-def _get_file_bytes_and_decoded_content(manifests: List[ManifestPath]) -> Tuple[bytes, str]:
-    with open(manifests[0].path, "rb") as file:
-        file_bytes = file.read()
-        content = file_bytes.decode("utf-8")
-    return file_bytes, content
-
-
-def _get_base_path_and_headers(context: Context) -> Tuple[str, Dict[str, str]]:
-    config: Config = context.get("config")
-    credentials: RemoteClientCredentials = get_client_credentials(config.credentials_file, DEFAULT_CREDENTIALS_SECTION)
-
-    access_token = get_access_token(credentials)
-    headers = {"Authorization": f"Bearer {access_token}"}
-
-    resource_server = credentials.resource_server or credentials.server
-    base_path = f"{resource_server}/uapi/datasets/org/vssa/isris/dcat"
-
-    return base_path, headers
-
-
-def _format_error_response_data(data: dict) -> dict:
-    data.pop("context", None)
-    return data
-
-
-def get_manifest_paths(manifests: List[str]):
-    manifests = convert_str_to_manifest_path(manifests)
-    if not manifests:
-        raise ManifestFileNotProvided
-
-    return manifests
-
-
-def build_manifest_and_context(ctx: TyperContext, manifests: List[str]) -> Tuple[Context, Manifest]:
-    context = configure_context(ctx.obj, manifests, mode=Mode.external)
-    store = prepare_manifest(context, verbose=False, full_load=True)
-    return context, store.manifest
 
 
 def get_dataset(base_path, headers, dataset_name):
@@ -86,7 +36,7 @@ def get_dataset(base_path, headers, dataset_name):
             operation="Get dataset",
             expected_status_code={HTTPStatus.OK, HTTPStatus.NOT_FOUND},
             response_status_code=response.status_code,
-            response_data=_format_error_response_data(response.json()),
+            response_data=format_error_response_data(response.json()),
         )
 
     return response
@@ -134,7 +84,7 @@ def create_dataset(base_path, headers, dataset_name):
             operation="Create dataset",
             expected_status_code=HTTPStatus.CREATED,
             response_status_code=response.status_code,
-            response_data=_format_error_response_data(response.json()),
+            response_data=format_error_response_data(response.json()),
         )
 
     return response
@@ -158,7 +108,7 @@ def create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id
             operation="Create dataset distribution",
             expected_status_code=HTTPStatus.CREATED,
             response_status_code=response.status_code,
-            response_data=_format_error_response_data(response.json()),
+            response_data=format_error_response_data(response.json()),
         )
 
 
@@ -174,7 +124,7 @@ def create_dsa(base_path, headers, dataset_id, content):
             operation="Create DSA for dataset",
             expected_status_code=HTTPStatus.CREATED,
             response_status_code=response.status_code,
-            response_data=_format_error_response_data(response.json()),
+            response_data=format_error_response_data(response.json()),
         )
 
 
@@ -185,9 +135,9 @@ def sync(
     manifests = get_manifest_paths(manifests)
     context, manifest = build_manifest_and_context(ctx, manifests)
 
-    dataset_name = _get_dataset_name(context, manifest)
-    file_bytes, content = _get_file_bytes_and_decoded_content(manifests)
-    base_path, headers = _get_base_path_and_headers(context)
+    dataset_name = get_dataset_name(context, manifest)
+    file_bytes, content = get_file_bytes_and_decoded_content(manifests)
+    base_path, headers = get_base_path_and_headers(context)
 
     response_get_dataset = get_dataset(base_path, headers, dataset_name)
     if response_get_dataset.status_code == HTTPStatus.OK:

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -24,6 +24,34 @@ def sync(
     ctx: TyperContext,
     manifests: List[str] = Argument(None, help=("Manifest files to load")),
 ):
+    """Synchronize datasets from data source to the data Catalog.
+
+    This command reads the specified data sources (databases, files, etc.), retrieves or creates the
+    corresponding datasets in the catalog, and ensures that their distributions and DSA are up to date.
+
+    The workflow is as follows:
+    1. Load and parse data sources.
+    2. Build a Spinta context and load the manifest.
+    3. Determine the dataset name from the manifest.
+    4. Retrieve the dataset from the catalog:
+       - If it exists, update its DSA.
+       - If it does not exist, create the dataset, its distributions, and its DSA in the Catalog.
+
+    Args:
+        ctx: Typer CLI context object.
+        manifests: List of manifest file paths to synchronize.
+
+    Raises:
+        NotImplementedFeature: If an unsupported operation is encountered
+            (e.g., updating existing datasets not fully implemented).
+        ManifestFileNotProvided: If no manifest files are given.
+        UnexpectedAPIResponse: If the API responds with an unexpected status code.
+        UnexpectedAPIResponseData: If expected dataset identifiers are missing
+            from the API response.
+
+    Documentation:
+        https://atviriduomenys.readthedocs.io/agentas.html#sinchronizacija
+    """
     manifest_objects: List[ManifestPath] = get_manifest_paths(manifests)
     context, manifest = build_manifest_and_context(ctx, manifest_objects)
 

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -14,7 +14,7 @@ from spinta.cli.helpers.sync.helpers import (
     get_manifest_paths,
     build_manifest_and_context, extract_dataset_id,
 )
-
+from spinta.manifests.components import ManifestPath
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +23,11 @@ def sync(
     ctx: TyperContext,
     manifests: List[str] = Argument(None, help=("Manifest files to load")),
 ):
-    manifests = get_manifest_paths(manifests)
-    context, manifest = build_manifest_and_context(ctx, manifests)
+    manifest_objects: List[ManifestPath] = get_manifest_paths(manifests)
+    context, manifest = build_manifest_and_context(ctx, manifest_objects)
 
     dataset_name = get_dataset_name(context, manifest)
-    file_bytes, content = get_file_bytes_and_decoded_content(manifests)
+    file_bytes, content = get_file_bytes_and_decoded_content(manifest_objects)
     base_path, headers = get_base_path_and_headers(context)
 
     response_get_dataset = get_dataset(base_path, headers, dataset_name)
@@ -37,5 +37,5 @@ def sync(
     elif response_get_dataset.status_code == HTTPStatus.NOT_FOUND:
         response_create_dataset = create_dataset(base_path, headers, dataset_name)
         dataset_id = extract_dataset_id(response_create_dataset, "detail")
-        create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifests)
+        create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifest_objects)
         create_dsa(base_path, headers, dataset_id, content)

--- a/spinta/manifests/internal_sql/commands/manifest.py
+++ b/spinta/manifests/internal_sql/commands/manifest.py
@@ -123,7 +123,7 @@ def get_namespace_name_list(context: Context, manifest: InternalSQLManifest, loa
             yield row['mpath']
 
 
-def _get_dataset_name_list(context: Context, manifest: InternalSQLManifest, loaded: bool):
+def get_dataset_name_list(context: Context, manifest: InternalSQLManifest, loaded: bool):
     manifest = get_manifest(context, manifest)
     table = manifest.table
     conn = get_transaction_connection(context)
@@ -433,7 +433,7 @@ def get_dataset(context: Context, manifest: InternalSQLManifest, dataset: str, *
 
 @commands.get_datasets.register(Context, InternalSQLManifest)
 def get_datasets(context: Context, manifest: InternalSQLManifest, loaded: bool = False, **kwargs):
-    dataset_names = _get_dataset_name_list(context, manifest, loaded)
+    dataset_names = get_dataset_name_list(context, manifest, loaded)
     objs = manifest.get_objects()
     for name in dataset_names:
         # get_dataset loads the dataset if it has not been loaded

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -76,7 +76,7 @@ def test_success_existing_dataset(
 
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
-        "status": HTTPStatus.NOT_IMPLEMENTED,
+        "status": HTTPStatus.NOT_IMPLEMENTED.value,
         "dataset_id": 1,
         "feature": "Updates on existing Datasets"
     }
@@ -159,7 +159,7 @@ def test_failure_get_access_token_api_call(
     with pytest.raises(Exception) as exception:
         cli.invoke(rc, args=["sync", manifest_path], catch_exceptions=False)
 
-    assert exception.value.response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert exception.value.response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
 
 
 def test_failure_get_dataset_returns_unexpected_status_code(
@@ -179,7 +179,7 @@ def test_failure_get_dataset_returns_unexpected_status_code(
             "type": "DatasetNotFound",
             "template": "The requested Dataset could not be found.",
             "message": f"No dataset matched the provided query.",
-            "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+            "status_code": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         }
     )
 
@@ -189,8 +189,8 @@ def test_failure_get_dataset_returns_unexpected_status_code(
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
     assert exception.value.context == {
         "operation": "Get dataset",
-        "expected_status_code": str({HTTPStatus.OK, HTTPStatus.NOT_FOUND}),
-        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "expected_status_code": str({HTTPStatus.OK.value, HTTPStatus.NOT_FOUND.value}),
+        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         "response_data": str({
             "code": "dataset_not_found",
             "type": "DatasetNotFound",
@@ -219,7 +219,7 @@ def test_failure_get_dataset_returns_invalid_data(
     with pytest.raises(UnexpectedAPIResponseData) as exception:
         cli.invoke(rc, args=["sync", manifest_path], catch_exceptions=False)
 
-    assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
         "operation": "Retrieve dataset `_id`",
         "context": "Dataset did not return the `_id` field which can be used to identify the dataset."
@@ -255,7 +255,7 @@ def test_failure_put_dataset_returns_invalid_data(
 
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
-        "status": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "status": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         "dataset_id": 1,
         "feature": "Updates on existing Datasets"
     }
@@ -288,8 +288,8 @@ def test_failure_post_dataset_returns_unexpected_status_code(
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
         "operation": "Create dataset",
-        "expected_status_code": str({HTTPStatus.CREATED}),
-        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "expected_status_code": str({HTTPStatus.CREATED.value}),
+        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         "response_data": str({})
     }
 
@@ -357,8 +357,8 @@ def test_failure_post_distribution_returns_unexpected_status_code(
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
         "operation": "Create distribution",
-        "expected_status_code": str({HTTPStatus.CREATED}),
-        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "expected_status_code": str({HTTPStatus.CREATED.value}),
+        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         "response_data": str({})
     }
 
@@ -400,7 +400,7 @@ def test_failure_post_dsa_returns_unexpected_status_code(
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
         "operation": "Create DSA",
-        "expected_status_code": str({HTTPStatus.NO_CONTENT}),
-        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+        "expected_status_code": str({HTTPStatus.NO_CONTENT.value}),
+        "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR.value,
         "response_data": str({})
     }

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,7 +7,7 @@ import pytest
 from spinta.client import RemoteClientCredentials
 from spinta.core.config import RawConfig
 from spinta.exceptions import NotImplementedFeature, UnexpectedAPIResponse, UnexpectedAPIResponseData, \
-    ManifestFileNotProvided
+ManifestFileNotProvided
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.context import ContextForTests
@@ -24,7 +24,7 @@ def patched_credentials():
         server="http://example.com",
         scopes="scope1 scope2",
     )
-    with patch('spinta.cli.sync.get_client_credentials', return_value=credentials):
+    with patch('spinta.cli.helpers.sync.helpers.get_client_credentials', return_value=credentials):
         yield credentials
 
 
@@ -288,7 +288,7 @@ def test_failure_post_dataset_returns_unexpected_status_code(
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
         "operation": "Create dataset",
-        "expected_status_code": HTTPStatus.CREATED,
+        "expected_status_code": str({HTTPStatus.CREATED}),
         "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
         "response_data": str({})
     }
@@ -356,8 +356,8 @@ def test_failure_post_distribution_returns_unexpected_status_code(
 
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
-        "operation": "Create dataset distribution",
-        "expected_status_code": HTTPStatus.CREATED,
+        "operation": "Create distribution",
+        "expected_status_code": str({HTTPStatus.CREATED}),
         "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
         "response_data": str({})
     }
@@ -399,8 +399,8 @@ def test_failure_post_dsa_returns_unexpected_status_code(
 
     assert exception.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
     assert exception.value.context == {
-        "operation": "Create DSA for dataset",
-        "expected_status_code": HTTPStatus.CREATED,
+        "operation": "Create DSA",
+        "expected_status_code": str({HTTPStatus.NO_CONTENT}),
         "response_status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
         "response_data": str({})
     }


### PR DESCRIPTION
### Context

Preparing synchronization (`spinta sync`) command code for further improvements.

❗ Any & all code logic changes (not typing/formatting/moving files/code around) are marked w/ additional comments on the particular code parts by yours truly.

### Improvements

1. Separated the main function into multiple functions for readability (`get_dataset`, `create_distribution`, etc.).
2. Helper functions moved as per already existing standards (`cli/helpers/<command>/`).
3. Business logic moved to controllers for easier maintainability (`cli/helpers/sync/controllers/`)
4. Mypy checks & fixes.
5. Ruff linting & formatting.
6. Docstrings

Different parts can be reviewed by commits, following the same order as above:
- [88197d7](https://github.com/atviriduomenys/spinta/pull/1422/commits/88197d762bf1476798d97c3d6624985cdbe29997)
- [9d07ed0](https://github.com/atviriduomenys/spinta/pull/1422/commits/9d07ed0ab6b585dbef9ffab7c4f974ee3248a654)
- [809c461](https://github.com/atviriduomenys/spinta/pull/1422/commits/809c46153b2bd0e54b635bfb999b5948b4c17504)
- [bdc983e](https://github.com/atviriduomenys/spinta/pull/1422/commits/bdc983e5bbef0406af08e233d67bca970f078fdd)
- [33bcf7c](https://github.com/atviriduomenys/spinta/pull/1422/commits/33bcf7c7d110439c48ab23ee2549d89768f19a7b)
- [2a59278](https://github.com/atviriduomenys/spinta/pull/1422/commits/2a59278cc82f1926d320107755fb85fefce52a0d)

### Notes

This is how the current sync function looks:

<details>

```python
def sync(
    ctx: TyperContext,
    manifests: List[str] = Argument(None, help=("Manifest files to load")),
):
    manifest_objects: List[ManifestPath] = get_manifest_paths(manifests)
    context, manifest = build_manifest_and_context(ctx, manifest_objects)

    dataset_name = get_dataset_name(context, manifest)
    file_bytes, content = get_file_bytes_and_decoded_content(manifest_objects)
    base_path, headers = get_base_path_and_headers(context)

    response_get_dataset = get_dataset(base_path, headers, dataset_name)
    if response_get_dataset.status_code == HTTPStatus.OK:
        dataset_id = extract_dataset_id(response_get_dataset, "list")
        update_dsa(base_path, headers, dataset_id)
    elif response_get_dataset.status_code == HTTPStatus.NOT_FOUND:
        response_create_dataset = create_dataset(base_path, headers, dataset_name)
        dataset_id = extract_dataset_id(response_create_dataset, "detail")
        create_distribution(base_path, headers, dataset_name, file_bytes, dataset_id, manifest_objects)
        create_dsa(base_path, headers, dataset_id, content)
```

</details>

In comparison w/ the old one:

<details>

```python
def sync(
    ctx: TyperContext,
    manifests: List[str] = Argument(None, help=("Manifest files to load")),
):
    manifests = convert_str_to_manifest_path(manifests)
    if not manifests:
        raise ManifestFileNotProvided
    context = configure_context(ctx.obj, manifests, mode=Mode.external)
    store = prepare_manifest(context, verbose=False, full_load=True)
    manifest: Manifest = store.manifest

    dataset_name = _get_dataset_name(context, manifest)
    file_bytes, content = _get_file_bytes_and_decoded_content(manifests)
    base_path, authorization_headers = _get_base_path_and_authorization_headers(context)

    response_get_dataset = requests.get(
        f"{base_path}/Dataset/",
        headers=authorization_headers,
        params={"name": dataset_name},
    )
    if response_get_dataset.status_code not in {HTTPStatus.OK, HTTPStatus.NOT_FOUND}:
        raise UnexpectedAPIResponse(
            operation="Get dataset",
            expected_status_code={HTTPStatus.OK, HTTPStatus.NOT_FOUND},
            response_status_code=response_get_dataset.status_code,
            response_data=_format_error_response_data(response_get_dataset.json()),
        )

    if response_get_dataset.status_code == HTTPStatus.OK:
        if not (dataset_id := response_get_dataset.json().get("_data", [{}])[0].get(IDENTIFIER)):
            raise UnexpectedAPIResponseData(
                operation=f"Retrieve dataset `{IDENTIFIER}`",
                context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
            )
        response_update_dsa = requests.put(f"{base_path}/Dataset/{dataset_id}/dsa/", headers=authorization_headers)
        # TODO: Implement w/ https://github.com/atviriduomenys/katalogas/issues/1600.
        raise NotImplementedFeature(
            status=response_update_dsa.status_code,
            dataset_id=dataset_id,
            feature="Updates on existing Datasets",
        )
    elif response_get_dataset.status_code == HTTPStatus.NOT_FOUND:
        response_post_dataset = requests.post(
            f"{base_path}/Dataset/",
            headers=authorization_headers,
            data={
                "title": dataset_name,
                "description": "",
                "name": dataset_name,
            }
        )

        if response_post_dataset.status_code != HTTPStatus.CREATED:
            raise UnexpectedAPIResponse(
                operation="Create dataset",
                expected_status_code=HTTPStatus.CREATED,
                response_status_code=response_post_dataset.status_code,
                response_data=_format_error_response_data(response_post_dataset.json()),
            )

        dataset_id = response_post_dataset.json().get(IDENTIFIER)
        if not dataset_id:
            raise UnexpectedAPIResponseData(
                operation=f"Retrieve dataset `{IDENTIFIER}`",
                context=f"Dataset did not return the `{IDENTIFIER}` field which can be used to identify the dataset."
            )
        response_post_distribution = requests.post(
            f"{base_path}/Distribution/",
            headers=authorization_headers,
            data={
                "dataset": dataset_id,
                "title": dataset_name,
            },
            files={
                "file": (manifests[0].path, BytesIO(file_bytes), CONTENT_TYPE_TEXT_CSV),
            }
        )

        if response_post_distribution.status_code != HTTPStatus.CREATED:
            raise UnexpectedAPIResponse(
                operation="Create dataset distribution",
                expected_status_code=HTTPStatus.CREATED,
                response_status_code=response_post_distribution.status_code,
                response_data=_format_error_response_data(response_post_distribution.json()),
            )

        response_create_dsa = requests.post(
            f"{base_path}/Dataset/{dataset_id}/dsa/",
            headers={"Content-Type": CONTENT_TYPE_TEXT_CSV, **authorization_headers},
            data=content,
        )

        if response_create_dsa.status_code != HTTPStatus.NO_CONTENT:
            raise UnexpectedAPIResponse(
                operation="Create DSA for dataset",
                expected_status_code=HTTPStatus.CREATED,
                response_status_code=response_create_dsa.status_code,
                response_data=_format_error_response_data(response_create_dsa.json()),
            )
```

</details>