### PR TITLE
[1415] Retrieve org credentials from configuration [#2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New Features:
 - Added OpenAPI(and Swagger 2.0) inline schema to DSA conversion `Model` and `ModelProperty` dimensions (`#1260`_) (`#1377`_) (`#1381`_) (`#1382`_) (`#1389`_)
 - Refactored `spinta sync` into separate functions to improve readability and maintainability. (`#1415`_)
 - During synchronization, create a Data Service and not a Dataset as was done initially. (`#1415`_)
+- Adjust synchronization credentials retrieve, to include organization name & type. (`#1415`_)
 
 
   .. _#1274: https://github.com/atviriduomenys/spinta/issues/1274

--- a/spinta/cli/helpers/sync/helpers.py
+++ b/spinta/cli/helpers/sync/helpers.py
@@ -124,7 +124,13 @@ def get_file_bytes_and_decoded_content(manifests: list[ManifestPath]) -> tuple[b
     return file_bytes, content
 
 
-def get_base_path_and_headers(context: Context) -> tuple[str, dict[str, str]]:
+def get_configuration_credentials(context: Context) -> RemoteClientCredentials:
+    config: Config = context.get("config")
+    credentials: RemoteClientCredentials = get_client_credentials(config.credentials_file, DEFAULT_CREDENTIALS_SECTION)
+    return credentials
+
+
+def get_base_path_and_headers(credentials: RemoteClientCredentials) -> tuple[str, dict[str, str]]:
     """Construct the API base path and authentication headers.
 
     Retrieves client credentials, fetches an access token, and prepares
@@ -138,9 +144,6 @@ def get_base_path_and_headers(context: Context) -> tuple[str, dict[str, str]]:
             - `base_path`: The base URL for the dataset API.
             - `headers`: Dictionary with Authorization header including Bearer token.
     """
-    config: Config = context.get("config")
-    credentials: RemoteClientCredentials = get_client_credentials(config.credentials_file, DEFAULT_CREDENTIALS_SECTION)
-
     access_token = get_access_token(credentials)
     headers = {"Authorization": f"Bearer {access_token}"}
 

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -13,7 +13,7 @@ from spinta.cli.helpers.sync.helpers import (
     get_base_path_and_headers,
     get_manifest_paths,
     build_manifest_and_context,
-    extract_dataset_id,
+    extract_dataset_id, get_configuration_credentials,
 )
 from spinta.manifests.components import ManifestPath
 
@@ -57,7 +57,8 @@ def sync(
 
     dataset_name = get_dataset_name(context, manifest)
     file_bytes, content = get_file_bytes_and_decoded_content(manifest_objects)
-    base_path, headers = get_base_path_and_headers(context)
+    credentials = get_configuration_credentials(context)
+    base_path, headers = get_base_path_and_headers(credentials)
 
     response_get_dataset = get_dataset(base_path, headers, dataset_name)
     if response_get_dataset.status_code == HTTPStatus.OK:

--- a/spinta/client.py
+++ b/spinta/client.py
@@ -20,8 +20,10 @@ class RemoteClientCredentials:
     server: str         # server URL
     remote: str         # remote name given in credentials.cfg section
     scopes: List[str]   # allowed scopes given in credentials.cfg section
-    resource_server: Optional[str] = None # host of a server where resources are stored if separate from auth server
-    client_id: Optional[str] = None # identification of client, could be same as client (username)
+    resource_server: Optional[str] = None  # host of a server where resources are stored if separate from auth server
+    client_id: Optional[str] = None  # identification of client, could be same as client (username)
+    organization: Optional[str] = None  # name of the clients organization
+    organization_type: Optional[str] = None  # type of the clients organization
 
 
 def _parse_client_handle(
@@ -81,6 +83,8 @@ def get_client_credentials(
                 creds.scopes = config.get(creds.section, 'scopes', fallback=[])
                 creds.client_id = creds.client_id or config.get(creds.section, 'client_id', fallback=creds.client)
                 creds.resource_server = creds.resource_server or config.get(creds.section, 'resource_server', fallback=creds.server)
+                creds.organization = creds.organization or config.get(creds.section, 'organization', fallback=None)
+                creds.organization_type = creds.organization_type or config.get(creds.section, 'organization_type', fallback=None)
 
             elif check:
                 raise RemoteClientCredentialsNotFound(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -23,6 +23,8 @@ def patched_credentials():
         secret="secret",
         server="http://example.com",
         scopes="scope1 scope2",
+        organization="vssa",
+        organization_type="gov",
     )
     with patch('spinta.cli.helpers.sync.helpers.get_client_credentials', return_value=credentials):
         yield credentials


### PR DESCRIPTION
Add reading logic from credentials file for organization name & type.

More cohesive tests will be added in the future implementations. Currently no tests will be added for this minimal change.

Relates to:
- https://github.com/atviriduomenys/katalogas/pull/1834