### PR TITLE
[1415] Strip resource & private source column values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ New Features:
 - Add `spinta inspect` logic to `spinta sync` & loop through all the datasets from inspection instead of using the first one only. (`#1415`_)
 - Refactor tests for synchronization to be more maintainable + assert what endpoints are called with and not only that they are called. (`#1415`_)
 - Build full dataset name following UDTS conventions. (`#1415`_)
-
+- Remove private source/resource values from DSA. (`#1415`_)
 
   .. _#1274: https://github.com/atviriduomenys/spinta/issues/1274
   .. _#1275: https://github.com/atviriduomenys/spinta/issues/1275

--- a/spinta/cli/helpers/sync/helpers.py
+++ b/spinta/cli/helpers/sync/helpers.py
@@ -138,7 +138,6 @@ def clean_private_attributes(resource: Resource) -> dict[str, Model]:
             continue
         model.external.name = ""  # Source column cleanup.
 
-
     return resource_models
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,14 +27,10 @@ def get_request_context(mocked_request: _Matcher, with_text: bool = False) -> li
     """Helper method to build context of what the mocked URLs were called with (Content, query params, URL)."""
     calls = []
     for request in mocked_request.request_history:
-        calls.append(
-            {
-                "method": request.method,
-                "url": request.url,
-                "params": request.qs,
-                "data": parse_qs(request.text),
-            }
-        )
+        data = {"method": request.method, "url": request.url, "params": request.qs, "data": parse_qs(request.text)}
+        if with_text:
+            data.update({"text": request.text.replace("\r\n", "\n").rstrip("\n")})
+        calls.append(data)
     return calls
 
 
@@ -292,7 +288,7 @@ def test_success_new_dataset(
 ,,,,,,,,,,,,,,,,,,,,
 ,,,,City,,,id,,,,,,4,completed,private,open,,,Name,
 ,,,,,id,integer,,,,,,,,,private,,,,,
-,,,,,full_name,string,,,,,,,,,private,,,,,"""
+,,,,,full_name,string,,,,,,,,,private,,,,,""",
         },
         {
             "method": "POST",
@@ -310,7 +306,7 @@ def test_success_new_dataset(
 ,,,,Country,,,id,,,,,,,develop,private,,,,,
 ,,,,,code,string,,,,,,,,develop,private,,,,,
 ,,,,,id,integer,,,,,,,,develop,private,,,,,
-,,,,,name,string,,,,,,,,develop,private,,,,,"""
+,,,,,name,string,,,,,,,,develop,private,,,,,""",
         },
     ]
 
@@ -817,7 +813,6 @@ def test_failure_post_distribution_returns_unexpected_status_code(
             "data": ANY,  # DSA content + SQLite content.
         },
     ]
-
 
 
 def test_failure_post_dsa_returns_unexpected_status_code(


### PR DESCRIPTION
Stripping sources & resource lines from DSA sent to the Catalog.

- Resources are always stripped, because they do not yet have the attribute `visibility`, we assume it is private.
- Source is stripped only if `visibility` is `private` or `None` also assuming, that `None -> private`.