### PR TITLE
1462 adding ErrorHandler and ErrorManager to handle InvalidValue error from check_level

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,12 @@ Improvements:
 - Updated `authlib` minimal version to 1.0.0 (`#675`_).
 - `private` and `public` keys now include `kid` field (`#675`_).
 - Added support for scopes following the UDTS format. Now users can use either the UDTS format scopes or the old scopes. If old scopes are used, a deprecation warning is shown. (`#1461`_)
+- Introduced a new error handling framework with CLI integration, including error reporting and post-processing in `spinta copy` and `spinta check` (`#1462`_)
 
   .. _#605: https://github.com/atviriduomenys/spinta/issues/605
   .. _#675: https://github.com/atviriduomenys/spinta/issues/675
   .. _#1461: https://github.com/atviriduomenys/spinta/issues/1461
+  .. _#1462: https://github.com/atviriduomenys/spinta/issues/1462
 
 Other:
 - Removed dependency `mypy`

--- a/spinta/cli/config.py
+++ b/spinta/cli/config.py
@@ -4,7 +4,6 @@ from typing import Optional
 from typer import Argument
 from typer import Context as TyperContext
 from typer import Option
-from typer import echo
 
 from spinta.cli.helpers.manifest import convert_str_to_manifest_path
 from spinta.cli.helpers.store import prepare_manifest

--- a/spinta/cli/config.py
+++ b/spinta/cli/config.py
@@ -34,4 +34,5 @@ def check(
     manifests = convert_str_to_manifest_path(manifests)
     context = configure_context(ctx.obj, manifests, mode=mode, check_names=check_names)
     prepare_manifest(context, ensure_config_dir=True, full_load=True)
-    echo("OK")
+    manager = context.get("error_manager")
+    manager.handler.post_process()

--- a/spinta/cli/config.py
+++ b/spinta/cli/config.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import Optional
 
+from typer import echo
 from typer import Argument
 from typer import Context as TyperContext
 from typer import Option
@@ -34,4 +35,9 @@ def check(
     context = configure_context(ctx.obj, manifests, mode=mode, check_names=check_names)
     prepare_manifest(context, ensure_config_dir=True, full_load=True)
     manager = context.get("error_manager")
-    manager.handler.post_process("check")
+    handler = manager.handler
+
+    if handler.get_counts():
+        handler.post_process()
+    else:
+        echo("OK")

--- a/spinta/cli/config.py
+++ b/spinta/cli/config.py
@@ -1,10 +1,10 @@
 from typing import List
 from typing import Optional
 
-from typer import echo
 from typer import Argument
 from typer import Context as TyperContext
 from typer import Option
+from typer import echo
 
 from spinta.cli.helpers.manifest import convert_str_to_manifest_path
 from spinta.cli.helpers.store import prepare_manifest

--- a/spinta/cli/config.py
+++ b/spinta/cli/config.py
@@ -34,4 +34,4 @@ def check(
     context = configure_context(ctx.obj, manifests, mode=mode, check_names=check_names)
     prepare_manifest(context, ensure_config_dir=True, full_load=True)
     manager = context.get("error_manager")
-    manager.handler.post_process()
+    manager.handler.post_process("check")

--- a/spinta/cli/manifest.py
+++ b/spinta/cli/manifest.py
@@ -70,6 +70,8 @@ def copy(
         rename_duplicates=rename_duplicates,
         manifests=manifests
     )
+    manager = context.get("error_manager")
+    manager.handler.post_process()
 
 
 def copy_manifest(

--- a/spinta/core/context.py
+++ b/spinta/core/context.py
@@ -8,6 +8,7 @@ from spinta.core.config import RawConfig
 from spinta.core.config import configure_rc
 
 from spinta.core.config import read_config
+from spinta.handlers import CLIErrorHandler, ErrorManager
 from spinta.utils.imports import importstr
 
 
@@ -34,6 +35,10 @@ def create_context(
 
     Config = rc.get("components", "core", "config", cast=importstr, required=True)
     context.set("config", Config())
+
+    handler = CLIErrorHandler()
+    manager = ErrorManager(handler)
+    context.set("error_manager", manager)
 
     Store = rc.get("components", "core", "store", cast=importstr, required=True)
     context.set("store", Store())

--- a/spinta/core/enums.py
+++ b/spinta/core/enums.py
@@ -9,7 +9,7 @@ from spinta.utils.enums import enum_by_name, enum_by_value
 from spinta.utils.errors import report_error
 
 if TYPE_CHECKING:
-    from spinta.components import Component
+    from spinta.components import Component, Context
 
 
 class Access(enum.IntEnum):
@@ -138,7 +138,7 @@ class Mode(enum.Enum):
     external = "external"
 
 
-def load_level(component: Component, given_level: Level | int | str) -> None:
+def load_level(context: Context, component: Component, given_level: Level | int | str) -> None:
     if given_level:
         if isinstance(given_level, Level):
             level = given_level
@@ -147,7 +147,7 @@ def load_level(component: Component, given_level: Level | int | str) -> None:
                 given_level = int(given_level)
             if not isinstance(given_level, int):
                 raise InvalidLevel(component, level=given_level)
-            level = enum_by_value(component, "level", Level, given_level)
+            level = enum_by_value(context, component, "level", Level, given_level)
     else:
         level = None
     component.level = level

--- a/spinta/dimensions/enum/helpers.py
+++ b/spinta/dimensions/enum/helpers.py
@@ -48,7 +48,7 @@ def _load_enum_item(
         item.prepare = env.resolve(expr)
 
     load_access_param(item, data.get("access"), parents)
-    load_level(item, data.get("level"))
+    load_level(context, item, data.get("level"))
     load_status(item, data.get("status"))
     load_visibility(item, data.get("visibility"))
     return item

--- a/spinta/handlers.py
+++ b/spinta/handlers.py
@@ -23,9 +23,6 @@ class CLIErrorHandler(ErrorHandler):
     def get_counts(self) -> dict[str, int]:
         return self._error_counts
 
-    def clear(self) -> None:
-        self._error_counts.clear()
-
     def post_process(self) -> None:
         counts = self.get_counts()
         if not counts:

--- a/spinta/handlers.py
+++ b/spinta/handlers.py
@@ -8,7 +8,10 @@ from spinta.exceptions import BaseError
 
 class ErrorHandler(ABC):
     @abstractmethod
-    def handle_error(self, error: Exception, file: str | None = None) -> None: ...
+    def handle_error(self, error: BaseError, file: str | None = None) -> None: ...
+
+    @abstractmethod
+    def post_process(self, command: str | None = None) -> None: ...
 
 
 class CLIErrorHandler(ErrorHandler):
@@ -23,10 +26,12 @@ class CLIErrorHandler(ErrorHandler):
     def get_counts(self) -> dict[str, int]:
         return self._error_counts
 
-    def post_process(self) -> None:
+    def post_process(self, command: str | None = None) -> None:
         counts = self.get_counts()
         if not counts:
-            echo("OK")
+            if command:
+                echo("OK")
+            return
 
         total_errors = sum(counts.values())
         echo(f"Total errors: {total_errors}")

--- a/spinta/handlers.py
+++ b/spinta/handlers.py
@@ -8,8 +8,7 @@ from spinta.exceptions import BaseError
 
 class ErrorHandler(ABC):
     @abstractmethod
-    def handle_error(self, error: Exception, file: str | None = None) -> None:
-        ...
+    def handle_error(self, error: Exception, file: str | None = None) -> None: ...
 
 
 class CLIErrorHandler(ErrorHandler):

--- a/spinta/handlers.py
+++ b/spinta/handlers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typer import echo
+
+from spinta.exceptions import BaseError
+
+
+class ErrorHandler(ABC):
+    @abstractmethod
+    def handle_error(self, error: Exception, file: str | None = None) -> None:
+        ...
+
+
+class CLIErrorHandler(ErrorHandler):
+    def __init__(self) -> None:
+        self._error_counts: dict[str, int] = {}
+
+    def handle_error(self, error: BaseError, file: str | None = None) -> None:
+        key = file
+        self._error_counts[key] = self._error_counts.get(key, 0) + 1
+        echo(error)
+
+    def get_counts(self) -> dict[str, int]:
+        return self._error_counts
+
+    def clear(self) -> None:
+        self._error_counts.clear()
+
+    def post_process(self) -> None:
+        counts = self.get_counts()
+        if not counts:
+            echo("OK")
+
+        total_errors = sum(counts.values())
+        echo(f"Total errors: {total_errors}")
+        for file, cnt in counts.items():
+            echo(f"- {file}: {cnt} error(s)")
+
+
+class ErrorManager:
+    def __init__(self, handler: CLIErrorHandler, re_raise: bool = False) -> None:
+        self.handler: CLIErrorHandler = handler
+        self.re_raise = re_raise
+        self.current_file: str | None = None
+
+    def handle_error(self, error: Exception, file: str | None = None) -> None:
+        target_file = file or self.current_file
+        if self.re_raise:
+            raise error
+
+        self.handler.handle_error(error, file=target_file)

--- a/spinta/handlers.py
+++ b/spinta/handlers.py
@@ -11,7 +11,7 @@ class ErrorHandler(ABC):
     def handle_error(self, error: BaseError, file: str | None = None) -> None: ...
 
     @abstractmethod
-    def post_process(self, command: str | None = None) -> None: ...
+    def post_process(self) -> None: ...
 
 
 class CLIErrorHandler(ErrorHandler):
@@ -26,11 +26,9 @@ class CLIErrorHandler(ErrorHandler):
     def get_counts(self) -> dict[str, int]:
         return self._error_counts
 
-    def post_process(self, command: str | None = None) -> None:
+    def post_process(self) -> None:
         counts = self.get_counts()
         if not counts:
-            if command:
-                echo("OK")
             return
 
         total_errors = sum(counts.values())

--- a/spinta/manifests/yaml/commands/load.py
+++ b/spinta/manifests/yaml/commands/load.py
@@ -79,6 +79,7 @@ def load(
     full_load: bool = False,
 ):
     assert freezed, "InlineManifest does not have unfreezed version of manifest."
+    manager = context.get("error_manager")
 
     if load_internal:
         target = into or manifest
@@ -105,6 +106,7 @@ def load(
         load_manifest_nodes(context, manifest, schemas)
 
     for source in manifest.sync:
+        manager.current_file = source.path
         commands.load(
             context,
             source,

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -92,7 +92,7 @@ def load(
             model.ns.parents(),
         ),
     )
-    load_level(model, model.level)
+    load_level(context, model, model.level)
     load_status(model, model.status)
     load_visibility(model, model.visibility)
 
@@ -166,7 +166,7 @@ def load(
 
 @load.register(Context, Base, dict, Manifest)
 def load(context: Context, base: Base, data: dict, manifest: Manifest) -> None:
-    load_level(base, data["level"])
+    load_level(context, base, data["level"])
 
 
 @overload
@@ -287,7 +287,7 @@ def load(
     prop.comments = load_comments(prop, prop.comments)
     if prop.prepare_given:
         prop.given.prepare = prop.prepare_given
-    load_level(prop, prop.level)
+    load_level(context, prop, prop.level)
 
     # todo properties should inherit those from model OR have a default. They shouldn't be empty
     #  Now they are empty in cases when model gets a default value, for example in inspect - tests/apie/test_inspect.py

--- a/spinta/utils/enums.py
+++ b/spinta/utils/enums.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Type, TYPE_CHECKING
 from spinta import exceptions
 
 if TYPE_CHECKING:
-    from spinta.components import Component
+    from spinta.components import Component, Context
 
 
 def get_enum_by_name(enum, value):
@@ -30,6 +30,7 @@ def enum_by_name(
 
 
 def enum_by_value(
+    context: Context,
     component: Component,
     param: Optional[str],  # component param
     enum: Type[Enum],
@@ -40,4 +41,8 @@ def enum_by_value(
     for item in enum:
         if item.value == value:
             return item
-    raise exceptions.InvalidValue(component, param=param, given=value)
+
+    error = exceptions.InvalidValue(component, param=param, given=value)
+
+    manager = context.get("error_manager")
+    manager.handle_error(error)

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -250,7 +250,6 @@ def test_check_level_multiple_manifests(context: Context, rc, cli: SpintaCliRunn
             "check",
             tmp_path / "manifest.csv",
             tmp_path / "manifest2.csv",
-
         ],
         fail=False,
     )

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -172,7 +172,7 @@ def test_check_level(context: Context, rc, cli: SpintaCliRunner, tmp_path):
     datasets/gov/example2    |        |         |             |         |        |
       | data                 | sql    |         |             |         |        |        
                              |        |         |             |         |        |              
-      |   |   | Country      |        | code    | salis       |         |        |
+      |   |   | Country      |        | code    | salis       |         |        | 9
       |   |   |   | code     | string |         | kodas       |         | public |
       |   |   |   | name     | string |         | pavadinimas |         | open   |
     """),
@@ -186,10 +186,84 @@ def test_check_level(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         ],
         fail=False,
     )
+    assert result.exit_code == 0
+    assert "Invalid value." in result.stdout
+    assert "component: spinta.dimensions.enum.components.EnumItem" in result.stdout
+    assert "component: spinta.components.Model" in result.stdout
+    assert "model: datasets/gov/example2/Country" in result.stdout
+    assert "param: level" in result.stdout
+    assert "given: 9" in result.stdout
+    assert "Total errors: 2" in result.stdout
+    assert "manifest.csv" in result.stdout
 
-    assert result.exit_code != 0
-    assert result.exc_info[0] is InvalidValue
-    assert result.exception.context.get("given") == 9
+
+def test_check_level_multiple_manifests(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref     | source      | prepare | access | level
+    datasets/gov/example     |        |         |             |         |        |
+      | data                 | sql    |         |             |         |        |
+                             |        |         |             |         |        |
+      |   |   | Country      |        | code    | salis       |         |        | 
+      |   |   |   | code     | string |         | kodas       |         | public | 1
+      |   |   |   | name     | string |         | pavadinimas |         | open   | 2
+      |   |   |   | driving  | string |         | vairavimas  |         | open   | 3
+                             | enum   |         | l           | 'left'  | open   | 9
+                             |        |         | r           | 'right' | open   |
+    datasets/gov/example2    |        |         |             |         |        |
+      | data                 | sql    |         |             |         |        |        
+                             |        |         |             |         |        |              
+      |   |   | Country      |        | code    | salis       |         |        |
+      |   |   |   | code     | string |         | kodas       |         | public |
+      |   |   |   | name     | string |         | pavadinimas |         | open   |
+    """),
+    )
+
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest2.csv",
+        striptable("""
+        d | r | b | m | property | type   | ref     | source      | prepare | access | level
+        datasets/gov/example3    |        |         |             |         |        |
+          | data                 | sql    |         |             |         |        |
+                                 |        |         |             |         |        |
+          |   |   | Salis        |        | code    | salis       |         |        | 
+          |   |   |   | code     | string |         | kodas       |         | public | 1
+          |   |   |   | name     | string |         | pavadinimas |         | open   | 2
+          |   |   |   | driving  | string |         | vairavimas  |         | open   | 3
+                                 | enum   |         | l           | 'left'  | open   | 9
+                                 |        |         | r           | 'right' | open   |
+        datasets/gov/example4    |        |         |             |         |        |
+          | data                 | sql    |         |             |         |        |        
+                                 |        |         |             |         |        |              
+          |   |   | Salis        |        | code    | salis       |         |        | 9
+          |   |   |   | code     | string |         | kodas       |         | public |
+          |   |   |   | name     | string |         | pavadinimas |         | open   |
+        """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "check",
+            tmp_path / "manifest.csv",
+            tmp_path / "manifest2.csv",
+
+        ],
+        fail=False,
+    )
+    assert result.exit_code == 0
+    assert "Invalid value." in result.stdout
+    assert "component: spinta.dimensions.enum.components.EnumItem" in result.stdout
+    assert "component: spinta.components.Model" in result.stdout
+    assert "model: datasets/gov/example4/Salis" in result.stdout
+    assert "param: level" in result.stdout
+    assert "given: 9" in result.stdout
+    assert "Total errors: 3" in result.stdout
+    assert "manifest.csv" in result.stdout
+    assert "manifest2.csv" in result.stdout
 
 
 def test_check_access(context: Context, rc, cli: SpintaCliRunner, tmp_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -23,14 +23,6 @@ def test_handle_error_multiple_files():
     assert counts["data2.csv"] == 1
 
 
-def test_post_process_ok_check(capsys):
-    handler = CLIErrorHandler()
-    handler.post_process()
-    captured = capsys.readouterr()
-    output = captured.out
-    assert "OK" in output
-
-
 def test_post_process_summary(capsys):
     handler = CLIErrorHandler()
     handler.handle_error(InvalidValue("bad"), file="data.csv")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -25,7 +25,7 @@ def test_handle_error_multiple_files():
 
 def test_post_process_ok_check(capsys):
     handler = CLIErrorHandler()
-    handler.post_process("check")
+    handler.post_process()
     captured = capsys.readouterr()
     output = captured.out
     assert "OK" in output

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -23,9 +23,9 @@ def test_handle_error_multiple_files():
     assert counts["data2.csv"] == 1
 
 
-def test_post_process_ok(capsys):
+def test_post_process_ok_check(capsys):
     handler = CLIErrorHandler()
-    handler.post_process()
+    handler.post_process("check")
     captured = capsys.readouterr()
     output = captured.out
     assert "OK" in output

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,61 @@
+import pytest
+
+from spinta.exceptions import InvalidValue
+from spinta.handlers import CLIErrorHandler, ErrorManager
+
+
+def test_handle_error_increments_count():
+    handler = CLIErrorHandler()
+    handler.handle_error(InvalidValue("bad value"), file="data.csv")
+
+    counts = handler.get_counts()
+    assert counts["data.csv"] == 1
+
+
+def test_handle_error_multiple_files():
+    handler = CLIErrorHandler()
+    handler.handle_error(InvalidValue("bad"), file="data1.csv")
+    handler.handle_error(InvalidValue("bad"), file="data1.csv")
+    handler.handle_error(InvalidValue("bad"), file="data2.csv")
+
+    counts = handler.get_counts()
+    assert counts["data1.csv"] == 2
+    assert counts["data2.csv"] == 1
+
+
+def test_post_process_ok(capsys):
+    handler = CLIErrorHandler()
+    handler.post_process()
+    captured = capsys.readouterr()
+    output = captured.out
+    assert "OK" in output
+
+
+def test_post_process_summary(capsys):
+    handler = CLIErrorHandler()
+    handler.handle_error(InvalidValue("bad"), file="data.csv")
+    handler.post_process()
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "Total errors: 1" in output
+    assert "- data.csv: 1 error(s)" in output
+
+
+def test_manager_delegates_to_handler():
+    handler = CLIErrorHandler()
+    manager = ErrorManager(handler)
+    manager.current_file = "data.csv"
+
+    manager.handle_error(InvalidValue("oops"))
+
+    counts = handler.get_counts()
+    assert counts["data.csv"] == 1
+
+
+def test_manager_reraises_when_enabled():
+    handler = CLIErrorHandler()
+    manager = ErrorManager(handler, re_raise=True)
+
+    with pytest.raises(InvalidValue):
+        manager.handle_error(InvalidValue("oops"))

--- a/tests/types/test_model.py
+++ b/tests/types/test_model.py
@@ -3,11 +3,13 @@ from unittest.mock import Mock
 import pytest
 
 from spinta.core.enums import Level
+from spinta.testing.context import create_test_context
 from spinta.types.model import load_level
 
 
 @pytest.mark.parametrize("level", [Level.open, 3, "3"])
-def test_load_level(level):
+def test_load_level(level, rc):
+    context = create_test_context(rc)
     node = Mock()
-    load_level(node, level)
+    load_level(context, node, level)
     assert node.level is Level.open


### PR DESCRIPTION
Summary:

- Added handlers.py file which contains:
  - `ErrorHandler` base abstract class, with two abstract methods: `handle_error` and `post_process`
  - `CliErrorHandler`, which inherits from `ErrorHandler`, implements:
    - `handle_error`, which prints errors to the console
    - `post_process`, which outputs a summary of error counts and affected files
  - `ErrorManager`, an orchestrator that coordinates error handlers

- Added error_manager context, used in function `enum_by_value` to manage errors
- Added `post_process` calls to `spinta copy` and `spinta check` CLI commands to process and summarize errors

Ticket: https://github.com/atviriduomenys/spinta/issues/1462