### PR TITLE
Add xs:key support for XSD manifests (#1472)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,11 +14,13 @@ Improvements:
 - Calling getall with soap backend will always return list of object, even if SOAP response has one element (`#1486`_)
 - Introduce `base64()` prepare function that decodes base64 string (`#1486`_)
 - `base64()` prepare function that decodes base64 binary now does this outside dask dataframes. Also, raises `InvalidBase64String` for invalid base64 (`#1486`_)
+- XSD manifests now support `xs:key` element to define primary keys. Keys are extracted from `xs:selector` and `xs:field` elements and mapped to the `ref` column in generated manifests. Supports both simple and composite keys. (`#1472`_)
 
   .. _#605: https://github.com/atviriduomenys/spinta/issues/605
   .. _#675: https://github.com/atviriduomenys/spinta/issues/675
   .. _#1461: https://github.com/atviriduomenys/spinta/issues/1461
   .. _#1462: https://github.com/atviriduomenys/spinta/issues/1462
+  .. _#1472: https://github.com/atviriduomenys/spinta/issues/1472
   .. _#1486: https://github.com/atviriduomenys/spinta/issues/1486
 
 Other:

--- a/spinta/manifests/xsd2/helpers.py
+++ b/spinta/manifests/xsd2/helpers.py
@@ -132,7 +132,7 @@ class XSDKey:
 
     name: str
     selector_xpath: str
-    field_xpaths: List[str]
+    field_xpaths: list[str]
 
 
 """


### PR DESCRIPTION
Closes #1472

## Problem

XSD schemas use `xs:key` elements to define primary key constraints, but `spinta inspect` was not extracting this information when generating DSA manifests from XSD files. This meant that primary key information had to be manually added to manifests after inspection.

## Solution

Added support for parsing `xs:key` elements from XSD schemas. The implementation extracts key definitions from `xs:selector` (scope) and `xs:field` (field paths) elements and maps them to the `ref` column in generated manifests. Supports both simple and composite keys.

## Changes

- `spinta/manifests/xsd2/helpers.py`: 
  - Added `XSDKey` dataclass to represent key constraints
  - Added `keys` dict to `XSDReader` to store parsed key definitions
  - Implemented `_post_process_keys()` to extract keys after model parsing
  - Updated `XSDModel` to store and export `ref` (primary keys) in external dict
  - Added "key", "selector", "field" to `NODE_TYPES`
- `tests/manifests/xsd2/test_xsd.py`: Added comprehensive tests for key extraction
- `CHANGES.rst`: Documented new feature

## Testing

Unit tests:
- `test_xsd_key_simple()` - Single field primary key
- `test_xsd_key_composite()` - Multi-field composite key
- `test_xsd_key_multiple_models()` - Multiple keys in same schema
- `test_xsd_key_nested_xpath()` - Keys with nested XPath selectors