### PR TITLE
1569: support multiple jwks, rotation. New GET jwks API (auth-server)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,22 @@ Changes
 #######
 
 0.2dev9 (unreleased)
-===================
+====================
+
+New Features:
+
+- Spinta as auth server - introduce /.well-known/jwks.json API endpoint to retrieve public verification keys,
+also known as well-known, jwk.
+- Spinta as Agent:
+    - add support for multiple public keys picked dynamically for each access token by kid value. If not found, then by
+      algorithm (`alg` & `kty`).
+      This unlocks using auth servers with public key rotation, like gravitee.
+    - add new `spinta key download` command to download public keys (JWKs) to a local file to use it later for
+      verification.
+    - move existing `spinta genkeys` command to `spinta key generate`.
+
+
+.. _#1569: https://github.com/atviriduomenys/spinta/issues/1569
 
 New Features:
 - Added new scope `client_backends_update_self` that only allows updating own client file backends attribute (`#1582`_)

--- a/docs/manual/configuration/auth.rst
+++ b/docs/manual/configuration/auth.rst
@@ -18,3 +18,17 @@ When `http_basic_auth` is set to `true`, and if `default_auth_client` is not
 set, then HTTP Basic Auth will be required for all requests.
 
 Client name and secret will be used from `<config_path>/clients` directory.
+
+
+Public verification keys download url (when spinta as Agent)
+----------
+If your server periodically rotates JWT public verification keys (also known as well-known or jwk), there is option to
+use `token_validation_keys_download_url` values setting which once is set will retrieve and cache those keys from provided url.
+Automatically handles cache wipe and refresh with new values.
+
+Example:
+
+.. code-block:: yaml
+
+    token_validation_keys_download_url: https://get-test.data.gov.lt/auth/token/.well-known/jwks.json
+

--- a/notes/access/public.sh
+++ b/notes/access/public.sh
@@ -26,7 +26,7 @@ tree ~/.config/spinta/clients
 
 export SPINTA_CONFIG_PATH=$BASEDIR/config
 mkdir -p $BASEDIR/config
-poetry run spinta genkeys
+poetry run spinta key generate
 #| Private key saved to var/instances/access/public/config/keys/private.json.
 #| Public key saved to var/instances/access/public/config/keys/public.json.
 

--- a/notes/spinta/server.sh
+++ b/notes/spinta/server.sh
@@ -34,7 +34,7 @@ accesslog:
 EOF
 
 tree ~/.config/spinta/
-poetry run spinta genkeys
+poetry run spinta key generate
 
 
 # Check configuration

--- a/spinta/auth.py
+++ b/spinta/auth.py
@@ -13,14 +13,15 @@ import uuid
 from collections import defaultdict
 from functools import cached_property
 from threading import Lock
-from typing import Set, Any
+from typing import Set, Any, TypedDict, Literal
 from typing import Type
 from typing import Union, List, Tuple
 
+import requests
 import ruamel.yaml
-from authlib.jose import JsonWebKey
+from authlib.jose import JsonWebKey, RSAKey, JWTClaims
 from authlib.jose import jwt
-from authlib.jose.errors import JoseError
+from authlib.jose.errors import JoseError, DecodeError, InvalidTokenError, BadSignatureError
 from authlib.oauth2 import OAuth2Error
 from authlib.oauth2 import OAuth2Request
 from authlib.oauth2 import rfc6749
@@ -34,6 +35,7 @@ from cachetools.keys import hashkey
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from multipledispatch import dispatch
+from requests import RequestException
 from starlette.datastructures import FormData, QueryParams, Headers
 from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse
@@ -77,6 +79,20 @@ DEPRECATED_SCOPE_PREFIX = "spinta_"
 
 # Scope types taken from authlib.oauth2.rfc6749.util.scope_to_list
 SCOPE_TYPE = Union[tuple, list, set, str, None]
+Kid = str  # key id
+
+
+class JWK(TypedDict):
+    kid: str
+    kty: str
+    alg: str
+    use: str
+    n: str
+    e: str
+
+
+class JWKS(TypedDict):
+    keys: List[JWK]
 
 
 class KeyType(enum.Enum):
@@ -168,11 +184,103 @@ class ResourceProtector(rfc6749.ResourceProtector):
         self.register_token_validator(Validator(context))
 
 
+def load_all_public_keys(context: Context) -> list[RSAKey]:
+    config = context.get("config")
+    token_validation_key = config.token_validation_key
+    token_validation_keys_download_url = config.token_validation_keys_download_url
+
+    if isinstance(token_validation_key, dict) and token_validation_key:
+        local_public_keys: list[RSAKey] = []
+        if "keys" in token_validation_key:
+            for key in token_validation_key["keys"]:
+                local_public_keys.append(JsonWebKey.import_key(key))
+        else:
+            local_public_keys = [JsonWebKey.import_key(token_validation_key)]
+        return local_public_keys
+    elif token_validation_keys_download_url:
+        return load_downloaded_public_keys(context)
+    else:
+        return [load_key(context, KeyType.public)]
+
+
+def load_downloaded_public_keys(context: Context) -> list[RSAKey]:
+    config = context.get("config")
+    if not config.downloaded_public_keys_file:
+        log.error("config.downloaded_public_keys_file is not set")
+        return []
+    if not config.downloaded_public_keys_file.exists():
+        log.error(f"File {config.downloaded_public_keys_file} does not exist")
+        return []
+
+    with config.downloaded_public_keys_file.open() as f:
+        return [JsonWebKey.import_key(key) for key in json.load(f)["keys"]]
+
+
+def download_and_store_public_keys(context: Context) -> JWKS | None:
+    config = context.get("config")
+    if not config.token_validation_keys_download_url:
+        return None
+    log.info("Downloading public keys from %s", config.token_validation_keys_download_url)
+    try:
+        response = requests.get(config.token_validation_keys_download_url)
+    except RequestException as e:
+        log.exception(
+            f"Failed to download public keys from {config.token_validation_keys_download_url}. Exception: {e}"
+        )
+        return None
+    if not response.ok or "keys" not in response.json():
+        log.error(
+            f"Failed to download public keys from {config.token_validation_keys_download_url}. Response: {response.text}"
+        )
+        return None
+
+    jwks: JWKS = response.json()
+
+    if not os.path.exists(config.downloaded_public_keys_file):
+        log.warning(f"Warning: {config.downloaded_public_keys_file=} does not exist. Creating it now.")
+        os.makedirs(os.path.dirname(config.downloaded_public_keys_file), exist_ok=True)
+        with open(config.downloaded_public_keys_file, "x") as f:
+            json.dump({}, f)
+
+    with open(config.downloaded_public_keys_file, "w") as f:
+        json.dump(jwks, f, indent=4)
+        log.info(f"Successfully downloaded public keys ({jwks}) from {config.downloaded_public_keys_file=}")
+
+    return jwks
+
+
 class BearerTokenValidator(rfc6750.BearerTokenValidator):
-    def __init__(self, context):
+    def __init__(self, context: Context):
         super().__init__()
         self._context = context
-        self._public_key = load_key(context, KeyType.public)
+        self._default_public_key: RSAKey = load_key(context, KeyType.public)
+        self._all_public_keys: list[RSAKey] = load_all_public_keys(context)
+
+    def decode_token(self, token_string: str) -> JWTClaims:
+        if not token_string:
+            raise InvalidToken("Token string is required")
+
+        try:
+            token_header = decode_unverified_header(token_string)
+            if kid := token_header.get("key"):
+                for key in self._all_public_keys:
+                    if key.kid and str(key.kid) == str(kid):
+                        return jwt.decode(token_string, key)
+
+            token_kty = decode_kty_from_alg(token_header["alg"])
+            for key in self._all_public_keys:
+                is_not_encryption_key = key.tokens.get("use") != "enc"
+                key_algorithm = key.tokens.get("alg")
+                is_same_algorithm = key_algorithm and token_header["alg"] == key_algorithm
+                is_same_algorithm_type = key.kty and key.kty == token_kty
+                if is_not_encryption_key and (is_same_algorithm or is_same_algorithm_type):
+                    try:
+                        return jwt.decode(token_string, key)
+                    except BadSignatureError:
+                        continue
+        except (JoseError, DecodeError, InvalidTokenError) as e:
+            raise InvalidToken(error=str(e))
+        raise InvalidToken(f"No public key found for token {token_header=}")
 
     def authenticate_token(self, token_string: str) -> Token:
         return Token(token_string, self)
@@ -248,12 +356,34 @@ class Client(rfc6749.ClientMixin):
             return True
 
 
+def decode_unverified_header(token: str) -> dict[str, Any]:
+    try:
+        if isinstance(token, bytes):
+            token = token.decode("utf-8")
+
+        header_b64 = token.split(".")[0]
+
+        # Add padding if missing
+        header_b64 += "=" * (-len(header_b64) % 4)
+        header_bytes = base64.urlsafe_b64decode(header_b64)
+
+        return json.loads(header_bytes)
+    except (UnicodeDecodeError, DecodeError, json.JSONDecodeError, ValueError, IndexError) as e:
+        raise InvalidToken(token=token) from e
+
+
+def decode_kty_from_alg(alg: str) -> Literal["RSA", "EC", None]:
+    """Get Key Type from Token Algorithm."""
+    if alg.startswith("RS"):
+        return "RSA"
+    if alg.startswith("ES"):
+        return "EC"
+    return None
+
+
 class Token(rfc6749.TokenMixin):
     def __init__(self, token_string, validator: BearerTokenValidator):
-        try:
-            self._token = jwt.decode(token_string, validator._public_key)
-        except JoseError as e:
-            raise InvalidToken(error=str(e))
+        self._token = validator.decode_token(token_string)
 
         self.expires_in = self._token["exp"] - self._token["iat"]
         self.client_id = self.get_aud()
@@ -463,9 +593,18 @@ def create_key_pair():
     return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
 
 
-def load_key(context: Context, key_type: KeyType, *, required: bool = True):
+def load_key_from_file(config: Config, key_type: KeyType) -> dict | None:
+    keypath = config.config_path / "keys" / f"{key_type.value}.json"
+    if keypath.exists():
+        with keypath.open() as f:
+            return json.load(f)
+    return None
+
+
+def load_key(context: Context, key_type: KeyType, *, required: bool = True) -> RSAKey | None:
     key = None
     config = context.get("config")
+    default_key = load_key_from_file(config, key_type)
 
     # Public key can be set via configuration.
     if key_type == KeyType.public:
@@ -473,22 +612,23 @@ def load_key(context: Context, key_type: KeyType, *, required: bool = True):
 
     # Load key from a file.
     if key is None:
-        keypath = config.config_path / "keys" / f"{key_type.value}.json"
-        if keypath.exists():
-            with keypath.open() as f:
-                key = json.load(f)
+        key = default_key
+
+    if isinstance(key, dict) and "keys" in key:
+        # Left for backwards compatibility in case private/public file has multiple keys.
+        keys = [k for k in key["keys"] if k["alg"] == "RS512"]
+        if keys:
+            key = keys[0]
+        elif key != default_key:
+            key = default_key
+        else:
+            key = None
 
     if key is None:
         if required:
             raise NoTokenValidationKey(key_type=key_type.value)
         else:
-            return
-
-    if isinstance(key, dict) and "keys" in key:
-        # XXX: Maybe I should load all keys and then pick right one by algorithm
-        #      used in token?
-        keys = [k for k in key["keys"] if k["alg"] == "RS512"]
-        key = keys[0]
+            return None
 
     return JsonWebKey.import_key(key)
 

--- a/spinta/cli/main.py
+++ b/spinta/cli/main.py
@@ -36,7 +36,7 @@ app = Typer()
 add(app, "config", config.config, short_help="Show current configuration values")
 add(app, "check", config.check, short_help="Check configuration and manifests")
 
-add(app, "genkeys", auth.genkeys, short_help="Generate client token validation keys")
+add(app, "key", auth.key, short_help="Manage client token validation keys")
 add(app, "token", auth.token, short_help="Tools for encoding/decode auth tokens")
 add(app, "client", auth.client, short_help="Manage auth clients")
 

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -1082,7 +1082,9 @@ class Config:
     scope_log: bool
     default_auth_client: str
     http_basic_auth: bool
-    token_validation_key: dict = None
+    token_validation_key: dict | None = None
+    token_validation_keys_download_url: str | None = None
+    downloaded_public_keys_file: pathlib.Path
     datasets: dict
     env: str
     docs_path: pathlib.Path

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -74,6 +74,10 @@ def load(context: Context, config: Config) -> Config:
     config.default_auth_client = rc.get("default_auth_client")
     config.http_basic_auth = rc.get("http_basic_auth", default=False, cast=asbool)
     config.token_validation_key = rc.get("token_validation_key", cast=json.loads) or None
+    config.token_validation_keys_download_url = rc.get("token_validation_keys_download_url")
+    config.downloaded_public_keys_file = (
+        rc.get("downloaded_public_keys_file") or DEFAULT_CONFIG_PATH / "downloaded-well-knows.json"
+    )
     config.datasets = rc.get("datasets", default={})
     config.env = rc.get("env")
     config.docs_path = rc.get("docs_path", default=None)
@@ -102,6 +106,11 @@ def load(context: Context, config: Config) -> Config:
     config.upgrade_mode = rc.get("upgrade_mode", default=False)
 
     config.cache_control = rc.get("cache_control_header", default="")
+
+    if config.token_validation_keys_download_url and config.token_validation_key:
+        raise ValueError(
+            "token_validation_keys_download_url and token_validation_keys_download_url are mutually exclusive and can't be used together. Use one."
+        )
 
     return config
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,16 +1,27 @@
+import datetime
 import json
 import pathlib
 import shutil
 import uuid
+from http import HTTPStatus
 
 import pytest
 import ruamel.yaml
 from authlib.jose import JsonWebKey
 from authlib.jose import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from spinta import auth, commands
-from spinta.auth import get_client_file_path, query_client, get_clients_path, ensure_client_folders_exist
+from spinta.auth import (
+    get_client_file_path,
+    query_client,
+    get_clients_path,
+    ensure_client_folders_exist,
+    KeyType,
+    load_key_from_file,
+)
 from spinta.components import Context
+from spinta.core.config import RawConfig
 from spinta.core.enums import Action
 from spinta.exceptions import InvalidClientFileFormat
 from spinta.testing.cli import SpintaCliRunner
@@ -18,6 +29,47 @@ from spinta.testing.client import create_test_client, get_yaml_data
 from spinta.testing.context import create_test_context
 from spinta.testing.utils import get_error_codes
 from spinta.utils.config import get_keymap_path
+
+
+def generate_rsa_keypair(kid: str):
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    public_numbers = public_key.public_numbers()
+
+    # Build JWK dict
+    jwk = {
+        "kty": "RSA",
+        "kid": kid,
+        "use": "sig",
+        "alg": "RS512",
+        "n": int_to_base64(public_numbers.n),
+        "e": int_to_base64(public_numbers.e),
+    }
+
+    return private_key, jwk
+
+
+def int_to_base64(val):
+    import base64
+
+    b = val.to_bytes((val.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("utf-8")
+
+
+def generate_jwt(private_key, kid, scopes="spinta_getall"):
+    now = datetime.datetime.now()
+    payload = {
+        "sub": "user1",
+        "exp": now + datetime.timedelta(minutes=5),
+        "scope": scopes,
+        "iat": int(now.timestamp()),
+    }
+    token = jwt.encode(
+        {"kid": kid, "alg": "RS512"},
+        payload,
+        private_key,
+    )
+    return token
 
 
 def test_app(context, app):
@@ -57,7 +109,7 @@ def test_app(context, app):
 
 
 def test_genkeys(rc, cli: SpintaCliRunner, tmp_path):
-    result = cli.invoke(rc, ["genkeys", "-p", tmp_path])
+    result = cli.invoke(rc, ["key", "generate", "-p", tmp_path])
 
     private_path = tmp_path / "keys" / "private.json"
     public_path = tmp_path / "keys" / "public.json"
@@ -65,6 +117,44 @@ def test_genkeys(rc, cli: SpintaCliRunner, tmp_path):
     assert result.output == f"Private key saved to {private_path}.\nPublic key saved to {public_path}.\n"
     JsonWebKey.import_key(json.loads(private_path.read_text()))
     JsonWebKey.import_key(json.loads(public_path.read_text()))
+
+
+def test_cant_download_keys(rc, cli: SpintaCliRunner, tmp_path, context, requests_mock):
+    result = cli.invoke(rc, ["key", "download"])
+    assert result.output == "Error, config.token_validation_keys_download_url is not set.\n"
+
+
+def test_download_keys(rc: RawConfig, cli: SpintaCliRunner, tmp_path, context, requests_mock):
+    mock_url = "https://www.example.com/.well-known/jwks.json"
+    rc = rc.fork({"token_validation_keys_download_url": mock_url})
+    config = context.get("config")
+    well_known = {
+        "keys": [
+            {
+                "kid": "rotation-1",
+                "kty": "RSA",
+                "alg": "RS512",
+                "use": "sig",
+                "n": "oAXjeXtZxiEUI7EcG6uITGCuUHmMQxMdTuSkQMaijmX0R1xSN--xBwVRpCJaM_ZYLdmtiBvX7qoNhEXC5H_uzHNxdw",
+                "e": "AQAB",
+            },
+            {
+                "kty": "RSA",
+                "n": "ngg7HGoRkBDkhLFZpFIF5qOSnWPt7FoThHpP5-HOeVZzrM2NlVKhcJ4sRwn9FFQu1_hHwRt-Lx5UyQ",
+                "e": "AQAB",
+            },
+        ]
+    }
+    download_mock = requests_mock.get(
+        mock_url,
+        status_code=HTTPStatus.OK,
+        json=well_known,
+        headers={"Content-Type": "application/json"},
+    )
+    result = cli.invoke(rc, ["key", "download"])
+    assert download_mock.called
+    assert json.loads(config.downloaded_public_keys_file.read_text()) == well_known
+    assert result.output == f"Successfully downloaded and stored public keys: {well_known}.\n"
 
 
 def test_client_add_old(rc, cli: SpintaCliRunner, tmp_path):
@@ -570,3 +660,47 @@ def test_invalid_client_file_data_type_str(
     yaml.dump(str(scopes), client_file)
     with pytest.raises(InvalidClientFileFormat, match="File .* data must be a dictionary, not a <class 'str'>."):
         query_client(get_clients_path(tmp_path), "test", is_name=True)
+
+
+def test_get_public_jwk_verification_keys_from_config(app, context):
+    config = context.get("config")
+    jwk_keys = [
+        {"alg": "RS512", "e": "AQAB", "kid": "rotation-1", "kty": "RSA", "n": "jwkrimvoifsdvicmdf", "use": "sig"},
+        {"alg": "RS512", "e": "AQAB", "kid": "rotation-2", "kty": "RSA", "n": "asdsad-asd", "use": "sig"},
+    ]
+    config.token_validation_key = {"keys": jwk_keys}
+    resp = app.get("/.well-known/jwks.json")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()
+    received_keys = resp.json()["keys"]
+    assert received_keys
+    for key in jwk_keys:
+        assert key in received_keys
+    assert load_key_from_file(config, KeyType.public) not in received_keys
+    config.token_validation_key = None
+
+
+def test_get_public_jwk_verification_keys_from_file(app, context):
+    config = context.get("config")
+    config.token_validation_key = None
+    resp = app.get("/.well-known/jwks.json")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()
+    received_keys = resp.json()["keys"]
+    assert received_keys
+    assert [load_key_from_file(config, KeyType.public)] == received_keys
+
+
+def test_pick_correct_key(app, context):
+    config = context.get("config")
+
+    private_1, jwk1 = generate_rsa_keypair("rotation-1")
+    private_2, jwk2 = generate_rsa_keypair("rotation-2")
+
+    config.token_validation_key = {"keys": [jwk1, jwk2]}
+
+    token = generate_jwt(private_2, "rotation-2")
+
+    resp = app.get("/datasets/backends/postgres/dataset/:all", headers={"Authorization": f"Bearer {token.decode()}"})
+    assert resp.status_code == 200, resp.text
+    config.token_validation_key = None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,6 +16,7 @@ def test_cache_control_postgres_get_one(context, app):
             "status": "1",
         },
     )
+    assert resp.status_code == 201, resp.text
     entry_id = resp.json()["_id"]
     app.post(
         f"/{model}",


### PR DESCRIPTION
### 1. New spinta (as auth server) GET API to retrieve JWKs (public keys to verify jwt tokens)

`GET https://get-test.data.gov.lt/.well-known/jwks.json` gives response like:

```
{
  "keys": [
    {
      "kid": "rotation-1",
      "kty": "RSA",
      "alg": "RS512",
      "use": "sig",
      "n": "oAXjeXtZxiEUI7EcG6uITGCuUHmMQxMdTuSkQMaijmX0R1xSN-sQOgrunTqzldGWYhn4CQXmE34TgoZs2l6pZKNEyzap5IstPAUTFfHamyLka-xBwVRpCJaM_ZY9dEhzn9NUB-mx1ud9_clhmlef0SRQ1E5N_oU9wA_Hgd6hdnRzzTDJzmueF_03fEEf27fd69qzPZerOO7E9ytHJm0RpTF-50MGDL9pJaomAry_m0cw66DRd8rwqE-MiSg1xo02YWYIbaNA13K7jO33lW3iqgLdmtiBvX7qoNhEXC5H_umLvd5hgETGVemFcdFgL0Xnj85uk3puiVMsYXqmzHNxdw",
      "e": "AQAB"
    },
    {
      "kid": "rotation-2",
      "kty": "RSA",
      "alg": "RS512",
      "use": "sig",
      "n": "1NYpTUTJlKS3t0OzhsPIzUS91IzV7hZEloQ_EsLXFReNDb4nm16Hnp1ohWsBnWHivxu0oCM2V3Vjw-8xnkopzgRZyDJujvaK9mwklapPAjY9OdmxRhDTpdD9wJf0DiAj-AxTo6RBiTuUM5k1A95BjI0ZXO9QQjEivNnoBNJ121-tmjDgx63pTsmkhwFQxkXjBN9TyKmeXOOPVadazpeLqUUEfCuYjZ1Mb9u8oBeBlGsGYrQLmqqWF3vZBcEJcxTc0w9qVQxbCqlyFhA5qKG_mm_K09WrtzzU3_u_EqMm9GD9ubcMKG6XCYInn6jA2tJmy_niY5DL0DUYipcLByYEGw",
      "e": "AQAB"
    },
    {
      "kty": "RSA",
      "n": "ngg7HGoRkBDkhLFZpFIF5qOSnWPt7FoThHpP5-HOeVZzrM2NlVhmn93Rl32o83jJ3GCP_l4_ExPJsRCOwJb0trMUH9hLwwkpe63ENJs3y8yH75GrGkIyVtS4sKYtJpNOWgyFQoVheRN28KV3TQxSySspooFYkNa0Z_jPlP5lA5PXS_uqYNleBNPi7zw4StOze6AqIq3F7MDQQe5lQUUnxI1ORrW2PgVPe0yKjQIxslxTBuW7spHzaU1RFlfzla8eP5k0nFEMtk8LVtHonpK7W_UDa4DgYIOzmQPJH5fwXDSUZspQaUpvkAd8SCKhcJ4sRwn9FFQu1_hHwRt-Lx5UyQ",
      "e": "AQAB"
    }
  ],
}
```

### 2. Spinta (as agent) now is able to work with multiple JWKs and pick dynamically correct for different keys (use kid header claim). JWK also can be retrieved dynamically (instead of env vars) from url - `token_validation_keys_download_url` new config value for that.
Scenario when multiple jwks exists - some auth server, for instance - gravitee, periodically rotate their public keys, which are used to encrypt JWT access tokens (signature). But after the rotation - old access tokens are still used (as their expiration is still valid) and need to be verified, but conditionally - new access token with new public key, old with the old one. All this mapping is passed on a `kid` (stand for key id) claim field both inside of a public key and access token. Sometimes (for instance our current setup) `kid` field does not exists.


Vadovas PR - https://github.com/atviriduomenys/vadovas/pull/53