### PR TITLE
1656 Rename existing sync controllers to manifest sync

### DIFF
--- a/spinta/cli/helpers/sync/controllers/synchronization/manifest_catalog_to_agent.py
+++ b/spinta/cli/helpers/sync/controllers/synchronization/manifest_catalog_to_agent.py
@@ -20,7 +20,7 @@ from spinta.manifests.tabular.helpers import write_tabular_manifest, datasets_to
 PRIVATE_PROPERTY_PREFIX = "_"
 
 
-def execute_synchronization_catalog_to_agent(
+def execute_manifest_synchronization_catalog_to_agent(
     context: Context,
     base_path: str,
     headers: dict[str, str],

--- a/spinta/cli/sync.py
+++ b/spinta/cli/sync.py
@@ -4,8 +4,8 @@ from typer import echo, Context as TyperContext
 
 from spinta.cli.helpers.sync.api_helpers import get_base_path_and_headers
 from spinta.cli.helpers.sync.controllers.data_service import get_data_service_children_dataset_ids
-from spinta.cli.helpers.sync.controllers.synchronization.catalog_to_agent import (
-    execute_synchronization_catalog_to_agent,
+from spinta.cli.helpers.sync.controllers.synchronization.manifest_catalog_to_agent import (
+    execute_manifest_synchronization_catalog_to_agent,
 )
 from spinta.cli.helpers.sync.helpers import (
     get_configuration_credentials,
@@ -44,7 +44,9 @@ def sync(ctx: TyperContext) -> None:
     base_path, headers, agent_name = prepare_api_context(context)
 
     dataset_ids = get_data_service_children_dataset_ids(base_path, headers, agent_name)
-    manifest = execute_synchronization_catalog_to_agent(context, base_path, headers, manifest_path, dataset_ids)
+    manifest = execute_manifest_synchronization_catalog_to_agent(
+        context, base_path, headers, manifest_path, dataset_ids
+    )
     echo(render_tabular_manifest(context, manifest))
 
     # TODO: Part 2: Source -> Agent: https://github.com/atviriduomenys/spinta/issues/1489.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,8 +7,8 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from spinta.cli.helpers.sync.api_helpers import STATIC_BASE_PATH_TAIL
-from spinta.cli.helpers.sync.controllers.synchronization.catalog_to_agent import (
-    execute_synchronization_catalog_to_agent,
+from spinta.cli.helpers.sync.controllers.synchronization.manifest_catalog_to_agent import (
+    execute_manifest_synchronization_catalog_to_agent,
 )
 from spinta.client import RemoteClientCredentials
 from spinta.core.config import RawConfig
@@ -313,7 +313,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 
@@ -366,7 +366,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 
@@ -428,7 +428,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 
@@ -489,7 +489,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 
@@ -557,7 +557,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 
@@ -625,7 +625,7 @@ class TestSynchronizationPathCatalogToAgent:
         context, _ = ensure_temp_context_and_app(rc, tmp_path)
 
         # Do;
-        execute_synchronization_catalog_to_agent(
+        execute_manifest_synchronization_catalog_to_agent(
             context, base_api_path, {"Authorization": "Bearer <token>"}, str(local_manifest_path), [dataset_id]
         )
 


### PR DESCRIPTION
**Summary:**

Contract and client synchronization will be introduced in future. Renaming some sync helpers to better describe which part of sync files are used in.

Renamed files:
```python
# From:
spinta.cli.helpers.sync.controllers.synchronization.catalog_to_agent
# To:
spinta.cli.helpers.sync.controllers.synchronization.manifest_catalog_to_agent
```

Renamed functions:
```python
# From:
execute_synchronization_catalog_to_agent(...)
# To:
execute_manifest_synchronization_catalog_to_agent(...)
```

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1656
