### PR TITLE
1795 Model with level=0 does not return "_id"

### DIFF
--- a/spinta/backends/__init__.py
+++ b/spinta/backends/__init__.py
@@ -671,7 +671,7 @@ def prepare_data_for_response(
             prop_names,
             value,
             select,
-            get_model_reserved_props(action, page_in_data(value)),
+            get_model_reserved_props(model, action, page_in_data(value)),
         )
     }
 

--- a/spinta/backends/helpers.py
+++ b/spinta/backends/helpers.py
@@ -316,19 +316,24 @@ def flat_select_to_nested(select: Optional[List[str]]) -> SelectTree:
     return res
 
 
-def get_model_reserved_props(action: Action, include_page: bool) -> List[str]:
+def get_model_reserved_props(model: Model, action: Action, include_page: bool) -> list[str]:
     if action == Action.GETALL:
-        reserved = ["_type", "_id", "_revision"]
+        reserved = ["_type", "_revision"]
     elif action == Action.SEARCH:
-        reserved = ["_type", "_id", "_revision", "_base"]
+        reserved = ["_type", "_revision", "_base"]
+    # TODO: Should CHANGES and MOVE still return _id or no?
     elif action == Action.CHANGES:
         return ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as"]
     elif action == Action.MOVE:
         return ["_type", "_revision", "_id", "_same_as"]
     else:
-        reserved = ["_type", "_id", "_revision"]
+        reserved = ["_type", "_revision"]
+
+    if commands.identifiable(model):
+        reserved.insert(1, "_id")
     if include_page:
         reserved.append("_page")
+
     return reserved
 
 

--- a/spinta/commands/read.py
+++ b/spinta/commands/read.py
@@ -11,7 +11,7 @@ from spinta import commands
 from spinta.accesslog import AccessLog
 from spinta.accesslog import log_response
 from spinta.backends.components import Backend
-from spinta.backends.helpers import get_select_prop_names
+from spinta.backends.helpers import get_select_prop_names, get_model_reserved_props
 from spinta.backends.helpers import get_select_tree
 from spinta.backends.nobackend.components import NoBackend
 from spinta.compat import urlparams_to_expr
@@ -149,12 +149,8 @@ def prepare_data_for_response(
     func_select_tree = get_select_tree(context, action, func_select)
 
     if reserved is None:
-        if action == Action.SEARCH:
-            reserved = ["_type", "_id", "_revision", "_base"]
-        else:
-            reserved = ["_type", "_id", "_revision"]
-        if pagination_enabled(model, params):
-            reserved.append("_page")
+        reserved = get_model_reserved_props(model, action, pagination_enabled(model, params))
+
     prop_names = get_select_prop_names(
         context,
         model,

--- a/spinta/commands/write.py
+++ b/spinta/commands/write.py
@@ -1347,7 +1347,9 @@ async def wipe(  # noqa
 
 def prepare_headers(context: Context, node: Node, resp: dict, action: Action, is_batch: Optional[bool] = False):
     headers = {}
-    if action == Action.INSERT and not is_batch:
+    # TODO: if "_id" not in response, that means model.level < 4.
+    #  In this case, maybe have location as getall + filter for ref fields?
+    if action == Action.INSERT and not is_batch and "_id" in resp:
         server_url = context.get("config").server_url
         headers["location"] = f"{server_url}{node.name}/{resp['_id']}"
     return headers

--- a/spinta/core/enums.py
+++ b/spinta/core/enums.py
@@ -144,18 +144,20 @@ class Mode(enum.Enum):
     external = "external"
 
 
-def load_level(context: Context, component: Component, given_level: Level | int | str) -> None:
-    if given_level:
-        if isinstance(given_level, Level):
-            level = given_level
-        else:
-            if isinstance(given_level, str) and given_level.isdigit():
-                given_level = int(given_level)
-            if not isinstance(given_level, int):
-                raise InvalidLevel(component, level=given_level)
-            level = enum_by_value(context, component, "level", Level, given_level)
-    else:
+def load_level(context: Context, component: Component, given_level: Level | int | str | None) -> None:
+    if given_level is None:
         level = None
+    elif isinstance(given_level, Level):
+        level = given_level
+    elif isinstance(given_level, str) and not given_level:
+        level = None
+    elif isinstance(given_level, str) and given_level.isdigit():
+        level = enum_by_value(context, component, "level", Level, int(given_level))
+    elif isinstance(given_level, int):
+        level = enum_by_value(context, component, "level", Level, given_level)
+    else:
+        raise InvalidLevel(component, level=given_level)
+
     component.level = level
 
 

--- a/spinta/formats/helpers.py
+++ b/spinta/formats/helpers.py
@@ -179,7 +179,7 @@ def get_model_tabular_header(
         if model.name == "_ns":
             reserved = get_ns_reserved_props(action)
         else:
-            reserved = get_model_reserved_props(action, pagination_enabled(model, params))
+            reserved = get_model_reserved_props(model, action, pagination_enabled(model, params))
 
     prop_select = params.select_props
     func_select = params.select_funcs

--- a/spinta/formats/html/commands.py
+++ b/spinta/formats/html/commands.py
@@ -62,13 +62,13 @@ from spinta.utils.schema import NotAvailable
 from spinta.utils.url import build_url_path
 
 
-def _get_model_reserved_props(action: Action, include_page: bool) -> List[str]:
-    if action in [Action.GETALL, Action.SEARCH]:
-        reserved = ["_id"]
-    else:
-        return get_model_reserved_props(action, include_page)
-    if include_page:
-        reserved.append("_page")
+def _get_model_reserved_props_for_html(model: Model, action: Action, include_page: bool) -> list[str]:
+    """HTML returns less reserved_props for getall and search actions"""
+    reserved = get_model_reserved_props(model, action, include_page)
+
+    if action in (Action.GETALL, Action.SEARCH):
+        reserved = [prop for prop in reserved if prop not in ("_type", "_revision", "_base")]
+
     return reserved
 
 
@@ -212,7 +212,7 @@ def _get_model_tabular_header(
     if model.name == "_ns":
         reserved = get_ns_reserved_props(action)
     else:
-        reserved = _get_model_reserved_props(action, pagination_enabled(model, params))
+        reserved = _get_model_reserved_props_for_html(model, action, pagination_enabled(model, params))
     return get_model_tabular_header(
         context,
         model,
@@ -320,7 +320,7 @@ def prepare_data_for_response(
         else:
             value["name"] = _ModelName(value["name"])
 
-    reserved = _get_model_reserved_props(action, page_in_data(value))
+    reserved = _get_model_reserved_props_for_html(model, action, page_in_data(value))
 
     data = {
         prop.name: commands.prepare_dtype_for_response(

--- a/spinta/formats/rdf/commands.py
+++ b/spinta/formats/rdf/commands.py
@@ -315,7 +315,7 @@ def prepare_data_for_response(
     prop_names: List[str],
 ) -> dict:
     value = value.copy()
-    reserved = get_model_reserved_props(action, page_in_data(value))
+    reserved = get_model_reserved_props(model, action, page_in_data(value))
 
     available_prefixes = _get_available_prefixes(context, model)
 

--- a/spinta/manifests/helpers.py
+++ b/spinta/manifests/helpers.py
@@ -27,7 +27,7 @@ from spinta.manifests.components import Manifest
 from spinta.manifests.internal.components import InternalManifest
 from spinta.types.namespace import load_namespace_from_name
 from spinta.utils.enums import enum_by_name
-from spinta.core.enums import Access, Mode
+from spinta.core.enums import Access, Mode, Level
 from spinta.utils.imports import importstr
 
 
@@ -246,7 +246,7 @@ def model_to_schema(model: Optional[Model]) -> ManifestSchema:
         return model.eid, {
             "type": "model",
             "name": model.name,
-            "level": model.level.name if model.level else None,
+            "level": model.level.name if isinstance(model.level, Level) else None,
             "access": model.given.access,
             "title": model.title,
             "description": model.description,

--- a/spinta/manifests/internal_sql/helpers.py
+++ b/spinta/manifests/internal_sql/helpers.py
@@ -9,7 +9,7 @@ from spinta import commands
 from spinta.backends import Backend
 from spinta.backends.constants import BackendOrigin
 from spinta.components import Namespace, Base, Model, Property, Context, Config, EntryId, MetaData
-from spinta.core.enums import Access, Action
+from spinta.core.enums import Access, Action, Level
 from spinta.core.ufuncs import Expr, NoOp
 from spinta.datasets.components import Dataset, Resource, Param
 from spinta.dimensions.comments.components import Comment
@@ -953,7 +953,7 @@ def _model_to_sql(
         "mpath": new_mpath,
         "dim": "model",
         "name": name,
-        "level": model.level.value if model.level else None,
+        "level": model.level.value if isinstance(model.level, Level) else None,
         "access": model.given.access,
         "title": model.title,
         "description": model.description,

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -39,7 +39,7 @@ from spinta.dimensions.enum.components import EnumItem
 from spinta.components import Model
 from spinta.components import Namespace
 from spinta.components import Property
-from spinta.core.enums import Access
+from spinta.core.enums import Access, Level
 from spinta.core.ufuncs import unparse
 from spinta.datasets.components import Dataset
 from spinta.dimensions.enum.components import Enums
@@ -2507,7 +2507,7 @@ def _model_to_tabular(
     data = {
         "id": model.id,
         "model": model.name,
-        "level": model.level.value if model.level else "",
+        "level": model.level.value if isinstance(model.level, Level) else "",
         "access": model.given.access,
         "title": model.title,
         "description": model.description,

--- a/tests/backends/test_helpers.py
+++ b/tests/backends/test_helpers.py
@@ -1,0 +1,59 @@
+import pytest
+
+from spinta.backends import get_model_reserved_props
+from spinta.components import Model, Context
+from spinta.core.enums import Action, Level
+
+
+@pytest.mark.parametrize(
+    "action, include_page, result",
+    [
+        (Action.GETALL, True, ["_type", "_revision", "_page"]),
+        (Action.GETALL, False, ["_type", "_revision"]),
+        (Action.SEARCH, True, ["_type", "_revision", "_base", "_page"]),
+        (Action.SEARCH, False, ["_type", "_revision", "_base"]),
+        (Action.CHANGES, True, ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as"]),
+        (Action.CHANGES, False, ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as"]),
+        (Action.MOVE, True, ["_type", "_revision", "_id", "_same_as"]),
+        (Action.MOVE, False, ["_type", "_revision", "_id", "_same_as"]),
+        (Action.INSERT, True, ["_type", "_revision", "_page"]),
+        (Action.INSERT, False, ["_type", "_revision"]),
+        (Action.GETONE, True, ["_type", "_revision", "_page"]),
+        (Action.GETONE, False, ["_type", "_revision"]),
+    ],
+)
+def test_get_model_reserved_props_model_level_less_or_3(
+    action: Action, include_page: bool, result: list[str], context: Context
+):
+    model = Model()
+    model.level = Level.open
+
+    assert get_model_reserved_props(model, action, include_page) == result
+
+
+@pytest.mark.parametrize(
+    "action, include_page, result",
+    [
+        (Action.GETALL, True, ["_type", "_id", "_revision", "_page"]),
+        (Action.GETALL, False, ["_type", "_id", "_revision"]),
+        (Action.SEARCH, True, ["_type", "_id", "_revision", "_base", "_page"]),
+        (Action.SEARCH, False, ["_type", "_id", "_revision", "_base"]),
+        (Action.CHANGES, True, ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as"]),
+        (Action.CHANGES, False, ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as"]),
+        (Action.MOVE, True, ["_type", "_revision", "_id", "_same_as"]),
+        (Action.MOVE, False, ["_type", "_revision", "_id", "_same_as"]),
+        (Action.INSERT, True, ["_type", "_id", "_revision", "_page"]),
+        (Action.INSERT, False, ["_type", "_id", "_revision"]),
+        (Action.GETONE, True, ["_type", "_id", "_revision", "_page"]),
+        (Action.GETONE, False, ["_type", "_id", "_revision"]),
+    ],
+)
+@pytest.mark.parametrize("model_level", [None, Level.identifiable])
+def test_get_model_reserved_props_model_level_4_or_more(
+    action: Action, include_page: bool, result: list[str], model_level: Level | None, context: Context
+):
+    model = Model()
+    model.type = "model"
+    model.level = model_level
+
+    assert get_model_reserved_props(model, action, include_page) == result

--- a/tests/core/test_enums.py
+++ b/tests/core/test_enums.py
@@ -1,0 +1,52 @@
+import uuid
+
+import pytest
+
+from spinta.components import Context, Model
+from spinta.core.enums import load_level, Level
+from spinta.exceptions import InvalidLevel
+
+
+@pytest.mark.parametrize(
+    "given_value, result",
+    [
+        (Level.absent, Level.absent),
+        (Level.available, Level.available),
+        (Level.structured, Level.structured),
+        (Level.open, Level.open),
+        (Level.identifiable, Level.identifiable),
+        (Level.linked, Level.linked),
+        ("", None),
+        ("0", Level.absent),
+        ("1", Level.available),
+        ("2", Level.structured),
+        ("3", Level.open),
+        ("4", Level.identifiable),
+        ("5", Level.linked),
+        ("6", None),
+        (-1, None),
+        (0, Level.absent),
+        (1, Level.available),
+        (2, Level.structured),
+        (3, Level.open),
+        (4, Level.identifiable),
+        (5, Level.linked),
+        (6, None),
+        (None, None),
+    ],
+)
+def test_load_level_success(context: Context, given_value: Level | int | str | None, result: Level):
+    model = Model()
+    model.eid = str(uuid.uuid4())
+
+    load_level(context, model, given_value)
+    assert model.level == result
+
+
+@pytest.mark.parametrize("given_value", ["foo", "-1"])
+def test_load_level_error(context: Context, given_value: Level | int | str | None):
+    model = Model()
+    model.eid = str(uuid.uuid4())
+
+    with pytest.raises(InvalidLevel):
+        load_level(context, model, given_value)

--- a/tests/datasets/dataframe/backends/xml/components/test_read.py
+++ b/tests/datasets/dataframe/backends/xml/components/test_read.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+from unittest.mock import ANY
+
 import pytest
 from responses import RequestsMock, POST
 
@@ -9,7 +11,6 @@ from spinta.testing.client import create_test_client
 from spinta.testing.data import listdata
 from spinta.testing.manifest import prepare_manifest
 from spinta.testing.utils import get_error_codes, get_error_context
-from unittest.mock import ANY
 
 
 def test_xml_read(rc: RawConfig, tmp_path: Path):
@@ -89,6 +90,112 @@ def test_xml_read_with_attributes(rc: RawConfig, tmp_path: Path):
         ("lv", "Ryga"),
         ("ee", "Talin"),
     ]
+
+
+@pytest.mark.parametrize("level", [0, 1, 2, 3])
+def test_xml_read_no_primary_key_level_0_1_2_3_should_not_return__id(rc: RawConfig, tmp_path: Path, level: int):
+    xml = """
+        <cities>
+            <city>
+                <code>lt</code>
+                <name>Vilnius</name>
+            </city>
+            <city>
+                <code>lv</code>
+                <name>Ryga</name>
+            </city>
+        </cities>
+    """
+    path = tmp_path / "cities.xml"
+    path.write_text(xml)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type     | ref  | source       | access | level
+        example/xml              |          |      |              |        |
+          | xml                  | dask/xml |      | {path}       |        |
+          |   |   | City         |          |      | /cities/city |        | {level}
+          |   |   |   | name     | string   |      | name         | open   |
+          |   |   |   | code     | string   |      | code         | open   |
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/xml/City", ["getall"])
+
+    response = app.get("/example/xml/City")
+    assert response.json() == {
+        "_data": [
+            {
+                "_revision": None,
+                "_type": "example/xml/City",
+                "name": "Vilnius",
+                "code": "lt",
+            },
+            {
+                "_revision": None,
+                "_type": "example/xml/City",
+                "name": "Ryga",
+                "code": "lv",
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize("level", [4, 5])
+def test_xml_read_no_primary_key_level_4_5_should_return_id(rc: RawConfig, tmp_path: Path, level: int):
+    xml = """
+        <cities>
+            <city>
+                <code>lt</code>
+                <name>Vilnius</name>
+            </city>
+            <city>
+                <code>lv</code>
+                <name>Ryga</name>
+            </city>
+        </cities>
+    """
+    path = tmp_path / "cities.xml"
+    path.write_text(xml)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type     | ref  | source       | access | level
+        example/xml              |          |      |              |        |
+          | xml                  | dask/xml |      | {path}       |        |
+          |   |   | City         |          |      | /cities/city |        | {level}
+          |   |   |   | name     | string   |      | name         | open   |
+          |   |   |   | code     | string   |      | code         | open   |
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/xml/City", ["getall"])
+
+    response = app.get("/example/xml/City")
+    assert response.json() == {
+        "_data": [
+            {
+                "_id": ANY,
+                "_revision": None,
+                "_type": "example/xml/City",
+                "name": "Vilnius",
+                "code": "lt",
+            },
+            {
+                "_id": ANY,
+                "_revision": None,
+                "_type": "example/xml/City",
+                "name": "Ryga",
+                "code": "lv",
+            },
+        ],
+    }
 
 
 def test_xml_read_refs_level_3(rc: RawConfig, tmp_path: Path):

--- a/tests/formats/test_ascii.py
+++ b/tests/formats/test_ascii.py
@@ -729,3 +729,157 @@ def test_ascii_changes_corrupt_data(
         f"{city_id}  0   Vilnius  {country_id}  ∅             t_obj_updated\n"
         "------------------------------------  --  -------  ------------------------------------  ------------  -------------\n"
     )
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getall_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:format/ascii")
+
+    assert response.status_code == 200
+    assert response.text.splitlines()[4].split() == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_base", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_base", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_search_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get('example/html/Country/:format/ascii?code="lt"', headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.text.splitlines()[4].split() == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getone_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context, scope=["spinta_set_meta_fields"])
+    app.authmodel("example/html", ["insert", "getall", "getone"])
+
+    row_id = str(uuid.uuid4())
+    pushdata(app, "example/html/Country", {"_id": row_id, "name": "Lietuva", "code": "lt"})
+
+    response = app.get(f"example/html/Country/{row_id}/:format/ascii", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.text.splitlines()[4].split() == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("1", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("2", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("3", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("4", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("5", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_changes_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "changes"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:changes/:format/ascii", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.text.splitlines()[1].split() == columns

--- a/tests/formats/test_csv.py
+++ b/tests/formats/test_csv.py
@@ -612,3 +612,157 @@ def test_csv_changes_corrupt_data(
         ["_id", "id", "name", "country._id", "country.test", "obj.test"],
         [city_id, "0", "Vilnius", country_id, "", "t_obj_updated"],
     ]
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getall_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:format/csv")
+
+    assert response.status_code == 200
+    assert parse_csv(response)[0] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_base", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_base", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_base", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_search_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get('example/html/Country/:format/csv?code="lt"', headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert parse_csv(response)[0] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("1", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("2", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("3", ["_type", "_revision", "_page.next", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_page.next", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getone_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context, scope=["spinta_set_meta_fields"])
+    app.authmodel("example/html", ["insert", "getall", "getone"])
+
+    row_id = str(uuid.uuid4())
+    pushdata(app, "example/html/Country", {"_id": row_id, "name": "Lietuva", "code": "lt"})
+
+    response = app.get(f"example/html/Country/{row_id}/:format/csv", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert parse_csv(response)[0] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("1", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("2", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("3", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("4", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("5", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_changes_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "changes"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:changes/:format/csv", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert parse_csv(response)[0] == columns

--- a/tests/formats/test_html.py
+++ b/tests/formats/test_html.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import json
 import uuid
 from pathlib import Path
 
@@ -17,7 +18,7 @@ from starlette.datastructures import Headers
 from spinta import commands
 from spinta.backends.constants import TableType
 from spinta.backends.postgresql.components import PostgreSQL
-from spinta.core.enums import Action
+from spinta.core.enums import Action, Mode
 from spinta.components import Config
 from spinta.components import Context
 from spinta.components import Namespace
@@ -1328,3 +1329,257 @@ def test_html_changes_corrupt_data(
     }
     assert value["country.test"] == {"color": Color.null.value, "value": ""}
     assert value["obj.test"] == {"value": "t_obj_updated"}
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["name", "code"]),
+        ("1", ["name", "code"]),
+        ("2", ["name", "code"]),
+        ("3", ["name", "code"]),
+        ("4", ["_id", "name", "code"]),
+        ("5", ["_id", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getall_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["name", "code"]),
+        ("1", ["name", "code"]),
+        ("2", ["name", "code"]),
+        ("3", ["name", "code"]),
+        ("4", ["_id", "name", "code"]),
+        ("5", ["_id", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_search_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get('example/html/Country?code="lt"', headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "name", "code"]),
+        ("1", ["_type", "_revision", "name", "code"]),
+        ("2", ["_type", "_revision", "name", "code"]),
+        ("3", ["_type", "_revision", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getone_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context, scope=["spinta_set_meta_fields"])
+    app.authmodel("example/html", ["insert", "getall", "getone"])
+
+    row_id = str(uuid.uuid4())
+    pushdata(app, "example/html/Country", {"_id": row_id, "name": "Lietuva", "code": "lt"})
+
+    response = app.get(f"example/html/Country/{row_id}", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("1", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("2", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("3", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("4", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+        ("5", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "_same_as", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_changes_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "changes"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:changes", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["name", "code"]),
+        ("1", ["name", "code"]),
+        ("2", ["name", "code"]),
+        ("3", ["name", "code"]),
+        ("4", ["_id", "name", "code"]),
+        ("5", ["_id", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_external_json_getall(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    json_data = {
+        "countries": [
+            {
+                "name": "Lietuva",
+                "code": "lt",
+            },
+        ],
+    }
+    path = tmp_path / "countries.json"
+    path.write_text(json.dumps(json_data))
+
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type      | source    | access | level
+        example/html             |           |           |        |
+          | resource             | dask/json | {path}    |        |
+          |   |   | Country      |           | countries |        | {level}
+          |   |   |   | name     | string    | name      | open   |
+          |   |   |   | code     | string    | code      | open   |
+        """,
+        tmp_path=tmp_path,
+        mode=Mode.external,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["getall"])
+
+    response = app.get("example/html/Country", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["name", "code"]),
+        ("1", ["name", "code"]),
+        ("2", ["name", "code"]),
+        ("3", ["name", "code"]),
+        ("4", ["_id", "name", "code"]),
+        ("5", ["_id", "name", "code"]),
+    ],
+)
+def test_return_correct_columns_for_external_json_search(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    json_data = {
+        "countries": [
+            {
+                "name": "Lietuva",
+                "code": "lt",
+            },
+            {
+                "name": "Latvia",
+                "code": "lv",
+            },
+        ],
+    }
+    path = tmp_path / "countries.json"
+    path.write_text(json.dumps(json_data))
+
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type      | source    | access | level
+        example/html             |           |           |        |
+          | resource             | dask/json | {path}    |        |
+          |   |   | Country      |           | countries |        | {level}
+          |   |   |   | name     | string    | name      | open   |
+          |   |   |   | code     | string    | code      | open   |
+        """,
+        tmp_path=tmp_path,
+        mode=Mode.external,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["getall", "search"])
+
+    response = app.get('example/html/Country?code="lt"', headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.context["header"] == columns

--- a/tests/formats/test_json.py
+++ b/tests/formats/test_json.py
@@ -449,3 +449,157 @@ def test_json_changes_corrupt_data(
     assert value["name"] == "Vilnius"
     assert value["country"] == {"_id": country_id}
     assert value["obj"] == {"test": "t_obj_updated"}
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_base", "name", "code"]),
+        ("1", ["_type", "_revision", "_base", "name", "code"]),
+        ("2", ["_type", "_revision", "_base", "name", "code"]),
+        ("3", ["_type", "_revision", "_base", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_base", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_base", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getall_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get("example/html/Country/:format/json?limit(1)")
+
+    assert response.status_code == 200
+    assert list(response.json()["_data"][0].keys()) == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_base", "name", "code"]),
+        ("1", ["_type", "_revision", "_base", "name", "code"]),
+        ("2", ["_type", "_revision", "_base", "name", "code"]),
+        ("3", ["_type", "_revision", "_base", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_base", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_base", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_search_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get('example/html/Country/:format/json?code="lt"')
+
+    assert response.status_code == 200
+    assert list(response.json()["_data"][0].keys()) == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "name", "code"]),
+        ("1", ["_type", "_revision", "name", "code"]),
+        ("2", ["_type", "_revision", "name", "code"]),
+        ("3", ["_type", "_revision", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getone_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context, scope=["spinta_set_meta_fields"])
+    app.authmodel("example/html", ["insert", "getall", "getone"])
+
+    row_id = str(uuid.uuid4())
+    pushdata(app, "example/html/Country", {"_id": row_id, "name": "Lietuva", "code": "lt"})
+
+    response = app.get(f"example/html/Country/{row_id}/:format/json")
+
+    assert response.status_code == 200
+    assert list(response.json().keys()) == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+        ("1", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+        ("2", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+        ("3", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+        ("4", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+        ("5", ["_cid", "_created", "_op", "_id", "_txn", "_revision", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_changes_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "changes"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:changes/-10/:format/json")
+
+    assert response.status_code == 200
+    assert list(response.json()["_data"][0].keys()) == columns

--- a/tests/formats/test_jsonl.py
+++ b/tests/formats/test_jsonl.py
@@ -13,6 +13,7 @@ from spinta import commands
 from spinta.backends.constants import TableType
 from spinta.backends.postgresql.components import PostgreSQL
 from spinta.core.config import RawConfig
+from spinta.core.enums import Mode
 from spinta.testing.client import create_test_client
 from spinta.testing.data import pushdata, encode_page_values_manually
 from spinta.testing.manifest import bootstrap_manifest
@@ -498,3 +499,103 @@ def test_jsonl_changes_corrupt_data(
     assert value["name"] == "Vilnius"
     assert value["country"] == {"_id": country_id}
     assert value["obj"] == {"test": "t_obj_updated"}
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "name", "code"]),
+        ("1", ["_type", "_revision", "name", "code"]),
+        ("2", ["_type", "_revision", "name", "code"]),
+        ("3", ["_type", "_revision", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_external_json_getall(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    json_data = {
+        "countries": [
+            {
+                "name": "Lietuva",
+                "code": "lt",
+            },
+        ],
+    }
+    path = tmp_path / "countries.json"
+    path.write_text(json.dumps(json_data))
+
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type      | source    | access | level
+        example/html             |           |           |        |
+          | resource             | dask/json | {path}    |        |
+          |   |   | Country      |           | countries |        | {level}
+          |   |   |   | name     | string    | name      | open   |
+          |   |   |   | code     | string    | code      | open   |
+        """,
+        tmp_path=tmp_path,
+        mode=Mode.external,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["getall"])
+
+    response = app.get("example/html/Country/:format/jsonl")
+
+    assert response.status_code == 200
+    assert list(json.loads(response.text.splitlines()[0]).keys()) == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_type", "_revision", "_base", "name", "code"]),
+        ("1", ["_type", "_revision", "_base", "name", "code"]),
+        ("2", ["_type", "_revision", "_base", "name", "code"]),
+        ("3", ["_type", "_revision", "_base", "name", "code"]),
+        ("4", ["_type", "_id", "_revision", "_base", "name", "code"]),
+        ("5", ["_type", "_id", "_revision", "_base", "name", "code"]),
+    ],
+)
+def test_return_correct_columns_for_external_json_search(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    json_data = {
+        "countries": [
+            {
+                "name": "Lietuva",
+                "code": "lt",
+            },
+            {
+                "name": "Latvia",
+                "code": "lv",
+            },
+        ],
+    }
+    path = tmp_path / "countries.json"
+    path.write_text(json.dumps(json_data))
+
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type      | source    | access | level
+        example/html             |           |           |        |
+          | resource             | dask/json | {path}    |        |
+          |   |   | Country      |           | countries |        | {level}
+          |   |   |   | name     | string    | name      | open   |
+          |   |   |   | code     | string    | code      | open   |
+        """,
+        tmp_path=tmp_path,
+        mode=Mode.external,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["getall", "search"])
+
+    response = app.get('example/html/Country/:format/jsonl?code="lt"')
+
+    assert response.status_code == 200
+    assert list(json.loads(response.text.splitlines()[0]).keys()) == columns

--- a/tests/formats/test_rdf.py
+++ b/tests/formats/test_rdf.py
@@ -3,6 +3,7 @@ import uuid
 from pathlib import Path
 
 from _pytest.fixtures import FixtureRequest
+from lxml import etree
 
 from spinta import commands
 from spinta.backends.constants import TableType
@@ -1077,3 +1078,181 @@ def test_rdf_changes_corrupt_data(
         f"</rdf:Description>\n"
         f"</rdf:RDF>\n"
     )
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_page", "name", "code"]),
+        ("1", ["_page", "name", "code"]),
+        ("2", ["_page", "name", "code"]),
+        ("3", ["_page", "name", "code"]),
+        ("4", ["_page", "name", "code"]),
+        ("5", ["_page", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getall_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:format/rdf")
+
+    assert response.status_code == 200
+
+    root = etree.fromstring(response.text.encode())
+    description_element = root.find(
+        "rdf:Description",
+        namespaces={"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "default": "https://testserver/"},
+    )
+    assert [etree.QName(child).localname for child in description_element] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_page", "name", "code"]),
+        ("1", ["_page", "name", "code"]),
+        ("2", ["_page", "name", "code"]),
+        ("3", ["_page", "name", "code"]),
+        ("4", ["_page", "name", "code"]),
+        ("5", ["_page", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_search_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "getall", "search"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+    pushdata(app, "example/html/Country", {"name": "Latvija", "code": "lv"})
+
+    response = app.get('example/html/Country/:format/rdf?code="lt"')
+
+    assert response.status_code == 200
+
+    root = etree.fromstring(response.text.encode())
+    description_element = root.find(
+        "rdf:Description",
+        namespaces={"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "default": "https://testserver/"},
+    )
+    assert [etree.QName(child).localname for child in description_element] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["name", "code"]),
+        ("1", ["name", "code"]),
+        ("2", ["name", "code"]),
+        ("3", ["name", "code"]),
+        ("4", ["name", "code"]),
+        ("5", ["name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_getone_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context, scope=["spinta_set_meta_fields"])
+    app.authmodel("example/html", ["insert", "getall", "getone"])
+
+    row_id = str(uuid.uuid4())
+    pushdata(app, "example/html/Country", {"_id": row_id, "name": "Lietuva", "code": "lt"})
+
+    response = app.get(f"example/html/Country/{row_id}/:format/rdf")
+
+    assert response.status_code == 200
+
+    root = etree.fromstring(response.text.encode())
+    description_element = root.find(
+        "rdf:Description",
+        namespaces={"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "default": "https://testserver/"},
+    )
+    assert [etree.QName(child).localname for child in description_element] == columns
+
+
+@pytest.mark.parametrize(
+    "level,columns",
+    [
+        ("0", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+        ("1", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+        ("2", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+        ("3", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+        ("4", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+        ("5", ["_cid", "_created", "_op", "_txn", "name", "code"]),
+    ],
+)
+def test_returns_correct_columns_for_internal_changes_action(
+    tmp_path: Path, rc: RawConfig, postgresql: str, level: str, columns: list[str]
+):
+    context = bootstrap_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type   | access | level
+        example/html             |        |        |
+          | resource             |        |        |
+          |   |   | Country      |        |        | {level}
+          |   |   |   | name     | string | open   |
+          |   |   |   | code     | string | open   |
+        """,
+        tmp_path=tmp_path,
+    )
+
+    app = create_test_client(context)
+    app.authmodel("example/html", ["insert", "changes"])
+
+    pushdata(app, "example/html/Country", {"name": "Lietuva", "code": "lt"})
+
+    response = app.get("example/html/Country/:changes/:format/rdf")
+
+    assert response.status_code == 200
+
+    root = etree.fromstring(response.text.encode())
+    description_element = root.find(
+        "rdf:Description",
+        namespaces={"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "default": "https://testserver/"},
+    )
+    assert [etree.QName(child).localname for child in description_element] == columns


### PR DESCRIPTION
**Summary:**
Model with `level=0` does not return `_id` column in response.

95% of this PR are new tests, because I had to test columns returned with different Spinta actions and formats.

Main business logic change of this PR is in `spinta/backends/helpers.py`: `_id` is only added if `commands.identifiable(model)` check passes.

Other places has small refactorings or fixes for `Level.absent=0`.

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1795