### PR TITLE
ft/1805 code cleanup for spinta/manifests/dict/helpers.py

### DIFF
--- a/spinta/__init__.py
+++ b/spinta/__init__.py
@@ -1,3 +1,5 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version(__name__)
+
+HTTP_URL_PREFIXES = ("http://", "https://")

--- a/spinta/backends/postgresql/commands/summary.py
+++ b/spinta/backends/postgresql/commands/summary.py
@@ -6,7 +6,7 @@ from spinta.backends.helpers import get_table_name
 from spinta.backends.postgresql.helpers.name import get_pg_table_name, get_pg_column_name
 from spinta.core.ufuncs import Expr
 from spinta.types.datatype import Integer, Number, Boolean, String, Date, DateTime, Time, Ref
-from spinta import commands
+from spinta import commands, HTTP_URL_PREFIXES
 from spinta.components import Context, Property
 from spinta.components import Model
 from spinta.exceptions import NotFoundError, NotImplementedFeature, InvalidRequestQuery
@@ -322,7 +322,7 @@ def summary(context: Context, dtype: Ref, backend: PostgreSQL, **kwargs):
         prefixes = dtype.model.external.dataset.prefixes
         label = None
         if uri and ":" in uri:
-            if uri.startswith(("http://", "https://")):
+            if uri.startswith(HTTP_URL_PREFIXES):
                 label = uri
             else:
                 split = uri.split(":")

--- a/spinta/manifests/dict/components.py
+++ b/spinta/manifests/dict/components.py
@@ -1,7 +1,8 @@
+import dataclasses
 from enum import Enum
 
-
 from spinta.manifests.components import Manifest
+from spinta.manifests.helpers import TypeDetector
 
 
 class DictFormat(Enum):
@@ -30,3 +31,103 @@ class XmlManifest(DictManifest):
     @staticmethod
     def detect_from_path(path: str) -> bool:
         return path.endswith(".xml")
+
+
+@dataclasses.dataclass
+class _MappedProperties:
+    name: str
+    source: str
+    extra: str
+    type_detector: TypeDetector
+
+
+@dataclasses.dataclass
+class _MappedModels:
+    name: str
+    source: str
+    properties: dict[str, _MappedProperties]
+
+
+@dataclasses.dataclass
+class _MappedDataset:
+    dataset: str
+    resource: str
+    models: dict[str, dict[str, _MappedModels]]
+
+
+@dataclasses.dataclass
+class _MappingMeta:
+    is_blank_node: bool
+    blank_node_name: str
+    blank_node_source: str
+    seperator: str
+    recursive_descent: str
+    remove_array_suffix: bool
+    model_source_prefix: str
+    check_namespace: bool
+    namespace_prefixes: dict[str, list[str]]
+    namespace_seperator: str
+
+    @classmethod
+    def get_for(cls, manifest_type: DictFormat) -> "_MappingMeta":
+        if manifest_type == DictFormat.JSON:
+            mapping_meta = _MappingMeta.for_json()
+        elif manifest_type in (DictFormat.XML, DictFormat.HTML):
+            mapping_meta = _MappingMeta.for_xml()
+        else:
+            mapping_meta = _MappingMeta.default()
+
+        return mapping_meta
+
+    @classmethod
+    def for_json(cls) -> "_MappingMeta":
+        return cls(
+            is_blank_node=False,
+            blank_node_name="model1",
+            blank_node_source=".",
+            seperator=".",
+            recursive_descent=".",
+            model_source_prefix="",
+            namespace_seperator=":",
+            remove_array_suffix=False,
+            check_namespace=False,
+            namespace_prefixes={},
+        )
+
+    @classmethod
+    def for_xml(cls) -> "_MappingMeta":
+        return cls(
+            is_blank_node=False,
+            blank_node_name="model1",
+            blank_node_source=".",
+            seperator="/",
+            recursive_descent="/..",
+            model_source_prefix="/",
+            namespace_seperator=":",
+            remove_array_suffix=True,
+            check_namespace=True,
+            namespace_prefixes={"xmlns": ["xmlns", "@xmlns"]},
+        )
+
+    @classmethod
+    def default(cls) -> "_MappingMeta":
+        return cls(
+            is_blank_node=False,
+            blank_node_name="model1",
+            blank_node_source=".",
+            seperator="",
+            recursive_descent="",
+            model_source_prefix="",
+            namespace_seperator=":",
+            remove_array_suffix=False,
+            check_namespace=False,
+            namespace_prefixes={},
+        )
+
+
+@dataclasses.dataclass
+class _MappingScope:
+    parent_scope: str
+    model_scope: str
+    model_name: str
+    property_name: str

--- a/spinta/manifests/dict/helpers.py
+++ b/spinta/manifests/dict/helpers.py
@@ -1,4 +1,3 @@
-import dataclasses
 import pathlib
 import json
 from copy import deepcopy
@@ -7,111 +6,30 @@ import requests
 import xmltodict
 from typing import Any, Iterator
 
+from spinta import HTTP_URL_PREFIXES
 from spinta.manifests.components import ManifestSchema
-from spinta.manifests.dict.components import DictFormat
+from spinta.manifests.dict.components import (
+    DictFormat,
+    _MappedDataset,
+    _MappingMeta,
+    _MappingScope,
+    _MappedModels,
+    _MappedProperties,
+)
 from spinta.manifests.helpers import TypeDetector
 from spinta.utils.itertools import first_dict_value, first_dict_key
 from spinta.utils.naming import Deduplicator, to_model_name, to_property_name
 
 
-@dataclasses.dataclass
-class _MappedProperties:
-    name: str
-    source: str
-    extra: str
-    type_detector: TypeDetector
-
-
-@dataclasses.dataclass
-class _MappedModels:
-    name: str
-    source: str
-    properties: dict[str, _MappedProperties]
-
-
-@dataclasses.dataclass
-class _MappedDataset:
-    dataset: str
-    resource: str
-    models: dict[str, dict[str, _MappedModels]]
-
-
-@dataclasses.dataclass
-class _MappingMeta:
-    is_blank_node: bool
-    blank_node_name: str
-    blank_node_source: str
-    seperator: str
-    recursive_descent: str
-    remove_array_suffix: bool
-    model_source_prefix: str
-    check_namespace: bool
-    namespace_prefixes: dict[str, list[str]]
-    namespace_seperator: str
-
-    @classmethod
-    def for_json(cls):
-        return cls(
-            is_blank_node=False,
-            blank_node_name="model1",
-            blank_node_source=".",
-            seperator=".",
-            recursive_descent=".",
-            model_source_prefix="",
-            namespace_seperator=":",
-            remove_array_suffix=False,
-            check_namespace=False,
-            namespace_prefixes={},
-        )
-
-    @classmethod
-    def for_xml(cls):
-        return cls(
-            is_blank_node=False,
-            blank_node_name="model1",
-            blank_node_source=".",
-            seperator="/",
-            recursive_descent="/..",
-            model_source_prefix="/",
-            namespace_seperator=":",
-            remove_array_suffix=True,
-            check_namespace=True,
-            namespace_prefixes={"xmlns": ["xmlns", "@xmlns"]},
-        )
-
-    @classmethod
-    def default(cls):
-        return cls(
-            is_blank_node=False,
-            blank_node_name="model1",
-            blank_node_source=".",
-            seperator="",
-            recursive_descent="",
-            model_source_prefix="",
-            namespace_seperator=":",
-            remove_array_suffix=False,
-            check_namespace=False,
-            namespace_prefixes={},
-        )
-
-
-@dataclasses.dataclass
-class _MappingScope:
-    parent_scope: str
-    model_scope: str
-    model_name: str
-    property_name: str
-
-
 def read_schema(manifest_type: DictFormat, path: str, dataset_name: str) -> Iterator[ManifestSchema]:
-    if path.startswith(("http://", "https://")):
+    if path.startswith(HTTP_URL_PREFIXES):
         value = requests.get(path).text
     else:
         with pathlib.Path(path).open(encoding="utf-8-sig") as f:
             value = f.read()
 
     converted = {}
-    mapping_meta = _get_mapping_meta(manifest_type)
+    mapping_meta = _MappingMeta.get_for(manifest_type)
 
     if manifest_type == DictFormat.JSON:
         converted = json.loads(value)
@@ -212,17 +130,6 @@ def read_schema(manifest_type: DictFormat, path: str, dataset_name: str) -> Iter
                     "properties": converted_props,
                 },
             )
-
-
-def _get_mapping_meta(manifest_type: DictFormat) -> _MappingMeta:
-    if manifest_type == DictFormat.JSON:
-        mapping_meta = _MappingMeta.for_json()
-    elif manifest_type in (DictFormat.XML, DictFormat.HTML):
-        mapping_meta = _MappingMeta.for_xml()
-    else:
-        mapping_meta = _MappingMeta.default()
-
-    return mapping_meta
 
 
 def is_single_item_dict(value: dict) -> bool:

--- a/spinta/manifests/helpers.py
+++ b/spinta/manifests/helpers.py
@@ -8,7 +8,7 @@ from typing import Type
 
 import jsonpatch
 
-from spinta import commands
+from spinta import commands, HTTP_URL_PREFIXES
 from spinta.backends.constants import BackendOrigin
 from spinta.backends.helpers import load_backend
 from spinta.components import Model
@@ -324,7 +324,7 @@ def get_manifest_from_type(rc: RawConfig, type_: str) -> Type[Manifest]:
 
 
 def check_manifest_path(manifest: Manifest, path: str) -> None:
-    if not path.startswith(("http://", "https://")) and not pathlib.Path(path).exists():
+    if not path.startswith(HTTP_URL_PREFIXES) and not pathlib.Path(path).exists():
         raise ManifestFileDoesNotExist(manifest, path=path)
 
 
@@ -432,7 +432,7 @@ class TypeDetector:
         self.type = new_type
 
     def _assert_url(self, value: str):
-        if value.startswith(("http://", "https://")):
+        if value.startswith(HTTP_URL_PREFIXES):
             self.type = "url"
         else:
             self.type = ""


### PR DESCRIPTION
**Summary:**
Some refactoring on code that I was investigating for bug. Business logic did not change:
- Call `is_model` method directly, instead of calling it through `_MappingMeta`
- Add early exits for some methods
- Few other small refactorings
- Replace `TypeDict` classes with `dataclass` classes

I suggest reviewing changes in two parts and with "hide whitespaces" enabled:
- I part: first 4 commits (45ab375dd7e5fa078daed5b7ba8fa5ffff9efa8c, 88052356867544056ad67245feaab4c1b0dcbe18, c57a7d11461c9dd83d714549fa44ecb86157a064, 364db4103c921275ba9d8c3b44c8f97600f797d8)
- II part: last 2 commits (0a27b49eac2905fdc5eac80052e59c7b743581ed, 142d89c3c27830815b2dcee75fd915230b9438d3)

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1805