### PR TITLE
1699 Implement `cast()` for string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,9 +23,11 @@ Improvements:
 
 - Changed `postgresql` `backend` table storage logic. Now each table is stored in their own schemas (which are created
   using dataset names) (`#598`_).
+- `cast()` prepare function now supports conversions from string to `string`, `integer`, `number`,
+  `boolean`, `date`, `time` and `datetime` fields for all backends. (`#1699`_).
 
 .. _#598: https://github.com/atviriduomenys/spinta/issues/598
-.. _#1848: https://github.com/atviriduomenys/spinta/issues/1848
+.. _#1699: https://github.com/atviriduomenys/spinta/issues/1699
 
 0.2dev20 (2026-03-27)
 =====================

--- a/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
@@ -15,7 +15,12 @@ from spinta.datasets.backends.dataframe.ufuncs.query.components import (
 )
 from spinta.datasets.components import Param
 from spinta.datasets.utils import iterparams
-from spinta.exceptions import PropertyNotFound, SourceCannotBeList, SourceOrPrepareNotAllowed
+from spinta.exceptions import (
+    PropertyNotFound,
+    SourceCannotBeList,
+    SourceOrPrepareNotAllowed,
+    InvalidArgumentInExpression,
+)
 from spinta.types.datatype import DataType, PrimaryKey, Ref
 from spinta.types.text.components import Text
 from spinta.ufuncs.components import ForeignProperty
@@ -522,3 +527,13 @@ def getattr_(env: DaskDataFrameQueryBuilder, obj: Bind, attr: Bind) -> Any:
 @ufunc.resolver(DaskDataFrameQueryBuilder, Bind, Bind, Bind, name="getattr")
 def getattr_(env: DaskDataFrameQueryBuilder, source: Bind, obj: Bind, attr: Bind) -> Any:
     raise SourceOrPrepareNotAllowed(source=str(source))
+
+
+@ufunc.resolver(DaskDataFrameQueryBuilder, Expr)
+def cast(env: DaskDataFrameQueryBuilder, expr: Expr) -> Expr:
+    args, kwargs = expr.resolve(env)
+    if args or kwargs:
+        arguments = args + list(kwargs.values())
+        raise InvalidArgumentInExpression(arguments=arguments, expr="cast")
+
+    return Expr("cast")

--- a/spinta/datasets/backends/sql/ufuncs/query/ufuncs.py
+++ b/spinta/datasets/backends/sql/ufuncs/query/ufuncs.py
@@ -853,12 +853,6 @@ def file(env: SqlQueryBuilder, expr: Expr) -> Expr:
 
 
 @overload
-@ufunc.resolver(SqlQueryBuilder)
-def cast(env: SqlQueryBuilder) -> Expr:
-    return Expr("cast")
-
-
-@overload
 @ufunc.resolver(SqlQueryBuilder, Bind, Bind)
 def point(env: SqlQueryBuilder, x: Bind, y: Bind) -> Expr:
     return Expr(

--- a/spinta/datasets/backends/sql/ufuncs/result/ufuncs.py
+++ b/spinta/datasets/backends/sql/ufuncs/result/ufuncs.py
@@ -1,46 +1,9 @@
 import base64
-from decimal import Decimal
-from typing import Any, overload, Optional
 
 from spinta.core.ufuncs import ufunc, Expr
 from spinta.datasets.backends.sql.ufuncs.components import FileSelected
 from spinta.datasets.backends.sql.ufuncs.result.components import SqlResultBuilder
-from spinta.exceptions import UnableToCast
-from spinta.types.datatype import Integer, String
 from spinta.types.file.components import FileData
-
-
-@overload
-@ufunc.resolver(SqlResultBuilder)
-def cast(env: SqlResultBuilder) -> Any:
-    return env.call("cast", env.prop.dtype, env.this)
-
-
-@overload
-@ufunc.resolver(SqlResultBuilder, String, int)
-def cast(env: SqlResultBuilder, dtype: String, value: int) -> str:
-    return str(value)
-
-
-@overload
-@ufunc.resolver(SqlResultBuilder, String, type(None))
-def cast(env: SqlResultBuilder, dtype: String, value: Optional[Any]) -> str:
-    return ""
-
-
-@overload
-@ufunc.resolver(SqlResultBuilder, Integer, Decimal)
-def cast(env: SqlResultBuilder, dtype: Integer, value: Decimal) -> int:
-    return env.call("cast", dtype, float(value))
-
-
-@overload
-@ufunc.resolver(SqlResultBuilder, Integer, float)
-def cast(env: SqlResultBuilder, dtype: Integer, value: float) -> int:
-    if value % 1 > 0:
-        raise UnableToCast(dtype, value=value, type=dtype.name)
-    else:
-        return int(value)
 
 
 @ufunc.resolver(SqlResultBuilder, Expr)

--- a/spinta/ufuncs/querybuilder/ufuncs.py
+++ b/spinta/ufuncs/querybuilder/ufuncs.py
@@ -513,3 +513,12 @@ def swap(env: QueryBuilder, expr: Expr):
 def split(env: QueryBuilder, expr: Expr):
     args, kwargs = expr.resolve(env)
     return Expr("split", *args, **kwargs)
+
+
+@ufunc.resolver(QueryBuilder, Expr)
+def cast(env: QueryBuilder, expr: Expr) -> Expr:
+    args, kwargs = expr.resolve(env)
+    if args or kwargs:
+        arguments = args + list(kwargs.values())
+        raise InvalidArgumentInExpression(arguments=arguments, expr="cast")
+    return Expr("cast")

--- a/spinta/ufuncs/resultbuilder/ufuncs.py
+++ b/spinta/ufuncs/resultbuilder/ufuncs.py
@@ -1,14 +1,20 @@
+import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
 import binascii
 
 from spinta.core.ufuncs import ufunc, Expr
-from spinta.exceptions import InvalidBase64String, NotImplementedFeature
-from spinta.types.datatype import String, Binary
+from spinta.exceptions import InvalidBase64String, NotImplementedFeature, UnableToCast
+from spinta.types.datatype import String, Binary, Integer, Date, Time, DateTime, Number, Boolean, DataType
 from spinta.types.geometry.components import Geometry
 from spinta.ufuncs.querybuilder.components import Selected
 from spinta.ufuncs.resultbuilder.components import ResultBuilder
 
 import shapely
 from shapely.geometry.base import BaseGeometry
+
+from spinta.utils.config import asbool
 
 
 @ufunc.resolver(ResultBuilder)
@@ -98,3 +104,104 @@ def base64(env: ResultBuilder, dtype: Binary) -> bytes:
         return env.call("base64", env.this)
     except (binascii.Error, ValueError):
         raise InvalidBase64String(env.prop.model, property=env.prop.name, value=env.this)
+
+
+@ufunc.resolver(ResultBuilder)
+def cast(env: ResultBuilder) -> Any:
+    return env.call("cast", env.prop.dtype, env.this)
+
+
+@ufunc.resolver(ResultBuilder, Expr)
+def cast(env: ResultBuilder, expr: Expr) -> Any:
+    return env.call("cast", env.prop.dtype, env.this)
+
+
+@ufunc.resolver(ResultBuilder, String, int)
+def cast(env: ResultBuilder, dtype: String, value: int) -> str:
+    return str(value)
+
+
+@ufunc.resolver(ResultBuilder, String, type(None))
+def cast(env: ResultBuilder, dtype: String, value: None) -> str:
+    return ""
+
+
+@ufunc.resolver(ResultBuilder, Integer, Decimal)
+def cast(env: ResultBuilder, dtype: Integer, value: Decimal) -> int:
+    return env.call("cast", dtype, float(value))
+
+
+@ufunc.resolver(ResultBuilder, Integer, float)
+def cast(env: ResultBuilder, dtype: Integer, value: float) -> int:
+    if value % 1 > 0:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+    else:
+        return int(value)
+
+
+@ufunc.resolver(ResultBuilder, String, str)
+def cast(env: ResultBuilder, dtype: String, value: str) -> str:
+    return value
+
+
+@ufunc.resolver(ResultBuilder, Integer, str)
+def cast(env: ResultBuilder, dtype: Integer, value: str) -> int:
+    if value.removeprefix("-").isdigit() or value.removeprefix("+").isdigit():
+        return int(value)
+    else:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, Number, str)
+def cast(env: ResultBuilder, dtype: Number, value: str) -> float:
+    try:
+        return float(Decimal(value))
+    except InvalidOperation:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, Boolean, str)
+def cast(env: ResultBuilder, dtype: Boolean, value: str) -> bool:
+    try:
+        return asbool(value)
+    except ValueError:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, Date, str)
+def cast(env: ResultBuilder, dtype: Date, value: str) -> datetime.date:
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError:
+        pass
+
+    try:
+        return datetime.datetime.fromisoformat(value).date()
+    except ValueError:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, Time, str)
+def cast(env: ResultBuilder, dtype: Time, value: str) -> datetime.time:
+    try:
+        return datetime.time.fromisoformat(value)
+    except ValueError:
+        pass
+
+    try:
+        return datetime.datetime.fromisoformat(value).time()
+    except ValueError:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, DateTime, str)
+def cast(env: ResultBuilder, dtype: DateTime, value: str) -> datetime.datetime:
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except ValueError:
+        raise UnableToCast(dtype, value=value, type=dtype.name)
+
+
+@ufunc.resolver(ResultBuilder, DataType, object)
+def cast(env: ResultBuilder, dtype: DataType, value: Any) -> None:
+    raise NotImplementedFeature(dtype, feature=f'Prepare method "cast()" for data type {dtype.name}')

--- a/tests/datasets/dataframe/backends/xml/components/test_read.py
+++ b/tests/datasets/dataframe/backends/xml/components/test_read.py
@@ -1303,3 +1303,126 @@ def test_composite_prepare_links_tables(rc: RawConfig, tmp_path: Path):
             "asset_type_attribute": {"_id": legal_data[0]["_id"]},
         }
     ]
+
+
+def test_read_with_prepare_cast(rc: RawConfig, tmp_path: Path):
+    xml = """
+        <cities>
+            <city>
+                <string_field>abc</string_field>
+                <integer_field>1</integer_field>
+                <number_field>1.2</number_field>
+                <boolean_field>true</boolean_field>
+                <date_field>2025-05-05</date_field>
+                <time_field>12:05</time_field>
+                <datetime_field>2025-05-05T12:05</datetime_field>
+            </city>
+        </cities>
+    """
+    path = tmp_path / "cities.xml"
+    path.write_text(xml)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property       | type     | ref          | source         | prepare
+        example/xml                    |          |              |                |
+          | xml                        | dask/xml |              | {path}         |
+          |   |   | City               |          | string_field | /cities/city   |
+          |   |   |   | string_field   | string   |              | string_field   | cast()
+          |   |   |   | integer_field  | integer  |              | integer_field  | cast()
+          |   |   |   | number_field   | number   |              | number_field   | cast()
+          |   |   |   | boolean_field  | boolean  |              | boolean_field  | cast()
+          |   |   |   | date_field     | date     |              | date_field     | cast()
+          |   |   |   | time_field     | time     |              | time_field     | cast()
+          |   |   |   | datetime_field | datetime |              | datetime_field | cast()
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/xml/City", ["getall"])
+
+    response = app.get("/example/xml/City")
+    assert response.json()["_data"] == [
+        {
+            "_type": "example/xml/City",
+            "_id": ANY,
+            "_revision": None,
+            "string_field": "abc",
+            "integer_field": 1,
+            "number_field": 1.2,
+            "boolean_field": True,
+            "date_field": "2025-05-05",
+            "time_field": "12:05:00",
+            "datetime_field": "2025-05-05T12:05:00",
+        },
+    ]
+
+
+def test_read_with_invalid_prepare_cast(rc: RawConfig, tmp_path: Path):
+    xml = """
+        <cities>
+            <city>
+                <geometry_field>SRID=4326;POINT(15 15)</geometry_field>
+            </city>
+        </cities>
+    """
+    path = tmp_path / "cities.xml"
+    path.write_text(xml)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property       | type     | source         | prepare
+        example/xml                    |          |                |
+          | xml                        | dask/xml | {path}         |
+          |   |   | City               |          | /cities/city   |
+          |   |   |   | geometry_field | geometry | geometry_field | cast()
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/xml/City", ["getall"])
+
+    response = app.get("/example/xml/City")
+    assert response.status_code == 500
+
+    response_error = response.json()["errors"][0]
+    assert response_error["code"] == "NotImplementedFeature"
+    assert response_error["message"] == 'Prepare method "cast()" for data type geometry is not implemented yet.'
+
+
+def test_read_prepare_cast_with_argument(rc: RawConfig, tmp_path: Path):
+    xml = """
+        <cities>
+            <city>
+                <string_field>1234</string_field>
+            </city>
+        </cities>
+    """
+    path = tmp_path / "cities.xml"
+    path.write_text(xml)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property     | type     | source       | prepare
+        example/xml                  |          |              |
+          | xml                      | dask/xml | {path}       |
+          |   |   | City             |          | /cities/city |
+          |   |   |   | string_field | string   | string_field | cast("integer")
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/xml/City", ["getall"])
+
+    response = app.get("/example/xml/City")
+    assert response.status_code == 500
+
+    response_error = response.json()["errors"][0]
+    assert response_error["code"] == "InvalidArgumentInExpression"
+    assert response_error["message"] == "Invalid ['integer'] arguments given to cast expression."

--- a/tests/datasets/test_sql.py
+++ b/tests/datasets/test_sql.py
@@ -3357,6 +3357,42 @@ def test_cast_integer_error(
     assert error(resp) == "UnableToCast"
 
 
+def test_cast_with_arguments_error(
+    context,
+    postgresql,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    responses,
+    tmp_path,
+    sqlite: Sqlite,
+):
+    dataset = "example/func/cast/integer/error"
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        f"""
+        d | r | b | m | property | type    | ref | source | prepare
+        {dataset}                |         |     |        |
+          | resource             | sql     | sql |        |
+          |   |   | Data         |         | id  | DATA   |
+          |   |   |   | id       | integer |     | ID     | cast("string")
+        """,
+    )
+
+    # Configure local server with SQL backend
+    sqlite.init({"DATA": [sa.Column("ID", sa.Integer)]})
+    sqlite.write("DATA", [{"ID": 123}])
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel(dataset, ["getall"])
+
+    resp = app.get(f"/{dataset}/Data")
+    assert error(resp, "code", "message") == {
+        "code": "InvalidArgumentInExpression",
+        "message": "Invalid ['string'] arguments given to cast expression.",
+    }
+
+
 def test_point(
     context,
     postgresql,

--- a/tests/ufuncs/resultsbuilder/test_ufuncs.py
+++ b/tests/ufuncs/resultsbuilder/test_ufuncs.py
@@ -1,9 +1,12 @@
+from datetime import date, time, datetime
+from decimal import Decimal
+
 import pytest
 
 from spinta import commands
 from spinta.core.config import RawConfig
 from spinta.core.ufuncs import asttoexpr
-from spinta.exceptions import InvalidBase64String
+from spinta.exceptions import InvalidBase64String, UnableToCast, NotImplementedFeature
 from spinta.spyna import parse
 from spinta.testing.manifest import load_manifest_and_context
 from spinta.ufuncs.resultbuilder.components import ResultBuilder
@@ -54,3 +57,442 @@ class TestBase64:
         assert e.value.message == (
             'Value of property "value" cannot be decoded because "test" is not valid base64 string.'
         )
+
+
+class TestCast:
+    def test_cast_string_to_string(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | string  | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this="abc",
+            prop=model.properties["value"],
+            data={"value": "abc"},
+            params={},
+        )
+
+        assert env.call("cast") == "abc"
+        assert env.call("cast", asttoexpr(parse("cast()"))) == "abc"
+
+    def test_cast_int_to_string(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | string  | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=123,
+            prop=model.properties["value"],
+            data={"value": 123},
+            params={},
+        )
+
+        assert env.call("cast") == "123"
+        assert env.call("cast", asttoexpr(parse("cast()"))) == "123"
+
+    def test_cast_none_to_string(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | string  | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=None,
+            prop=model.properties["value"],
+            data={"value": None},
+            params={},
+        )
+
+        assert env.call("cast") == ""
+        assert env.call("cast", asttoexpr(parse("cast()"))) == ""
+
+    def test_cast_decimal_to_integer(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | integer | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=Decimal("10.00"),
+            prop=model.properties["value"],
+            data={"value": Decimal("10.00")},
+            params={},
+        )
+
+        assert env.call("cast") == 10
+        assert env.call("cast", asttoexpr(parse("cast()"))) == 10
+
+    def test_cast_float_to_integer(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | integer | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=12.0,
+            prop=model.properties["value"],
+            data={"value": 12.0},
+            params={},
+        )
+
+        assert env.call("cast") == 12
+        assert env.call("cast", asttoexpr(parse("cast()"))) == 12
+
+    @pytest.mark.parametrize("value, result", [("123", 123), ("+123", 123), ("-123", -123)])
+    def test_cast_string_to_integer(self, rc: RawConfig, value: str, result: int):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | integer | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") == result
+        assert env.call("cast", asttoexpr(parse("cast()"))) == result
+
+    @pytest.mark.parametrize("value", ["abc", "10.10", "-10,12"])
+    def test_cast_invalid_string_to_integer(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | integer | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to integer type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to integer type."
+
+    @pytest.mark.parametrize("value, result", [("123", 123), ("+123", 123), ("-123", -123), ("1.12", 1.12)])
+    def test_cast_string_to_number(self, rc: RawConfig, value: str, result: float):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type   | prepare
+            example                  |        |
+              |   |   | Data         |        |
+              |   |   |   | value    | number | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") == result
+        assert env.call("cast", asttoexpr(parse("cast()"))) == result
+
+    @pytest.mark.parametrize("value", ["abc", "123,1", "1.234.56", "1,234.56"])
+    def test_cast_invalid_string_to_number(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type   | prepare
+            example                  |        |
+              |   |   | Data         |        |
+              |   |   |   | value    | number | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to number type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to number type."
+
+    @pytest.mark.parametrize(
+        "value, result",
+        [
+            ("true", True),
+            ("1", True),
+            ("on", True),
+            ("yes", True),
+            ("false", False),
+            ("0", False),
+            ("off", False),
+            ("no", False),
+        ],
+    )
+    def test_cast_string_to_boolean(self, rc: RawConfig, value: str, result: bool):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | boolean | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") is result
+        assert env.call("cast", asttoexpr(parse("cast()"))) is result
+
+    @pytest.mark.parametrize("value", ["abc", "123"])
+    def test_cast_invalid_string_to_boolean(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type    | prepare
+            example                  |         |
+              |   |   | Data         |         |
+              |   |   |   | value    | boolean | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to boolean type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to boolean type."
+
+    @pytest.mark.parametrize("value", ["2025-05-05", "2025-05-05T13:50:13.401332"])
+    def test_cast_string_to_date(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type | prepare
+            example                  |      |
+              |   |   | Data         |      |
+              |   |   |   | value    | date | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") == date(2025, 5, 5)
+        assert env.call("cast", asttoexpr(parse("cast()"))) == date(2025, 5, 5)
+
+    @pytest.mark.parametrize("value", ["2025-00-00", "abc", "12:00"])
+    def test_cast_invalid_string_to_date(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type | prepare
+            example                  |      |
+              |   |   | Data         |      |
+              |   |   |   | value    | date | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to date type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to date type."
+
+    @pytest.mark.parametrize("value", ["12:05", "2025-05-05T12:05:00.000000"])
+    def test_cast_string_to_time(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type | prepare
+            example                  |      |
+              |   |   | Data         |      |
+              |   |   |   | value    | time | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") == time(12, 5)
+        assert env.call("cast", asttoexpr(parse("cast()"))) == time(12, 5)
+
+    @pytest.mark.parametrize("value", ["25:25", "abc"])
+    def test_cast_invalid_string_to_time(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type | prepare
+            example                  |      |
+              |   |   | Data         |      |
+              |   |   |   | value    | time | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to time type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to time type."
+
+    @pytest.mark.parametrize("value", ["2025-05-05T12:05:00.000000", "2025-05-05 12:05"])
+    def test_cast_string_to_datetime(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type     | prepare
+            example                  |          |
+              |   |   | Data         |          |
+              |   |   |   | value    | datetime | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        assert env.call("cast") == datetime(2025, 5, 5, 12, 5)
+        assert env.call("cast", asttoexpr(parse("cast()"))) == datetime(2025, 5, 5, 12, 5)
+
+    @pytest.mark.parametrize("value", ["2025-13-13T12:05:00.00000", "12:05"])
+    def test_cast_invalid_string_to_datetime(self, rc: RawConfig, value: str):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type     | prepare
+            example                  |          |
+              |   |   | Data         |          |
+              |   |   |   | value    | datetime | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=value,
+            prop=model.properties["value"],
+            data={"value": value},
+            params={},
+        )
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast")
+        assert err_info.value.message == f"Unable to cast {value} to datetime type."
+
+        with pytest.raises(UnableToCast) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == f"Unable to cast {value} to datetime type."
+
+    def test_cast_with_not_implemented_types(self, rc: RawConfig):
+        context, manifest = load_manifest_and_context(
+            rc,
+            """
+            d | r | b | m | property | type     | prepare
+            example                  |          |
+              |   |   | Data         |          |
+              |   |   |   | value    | datetime | cast()
+            """,
+        )
+        model = commands.get_model(context, manifest, "example/Data")
+        env = ResultBuilder(context).init(
+            this=date(2025, 5, 5),
+            prop=model.properties["value"],
+            data={"value": date(2025, 5, 5)},
+            params={},
+        )
+
+        with pytest.raises(NotImplementedFeature) as err_info:
+            env.call("cast")
+        assert err_info.value.message == 'Prepare method "cast()" for data type datetime is not implemented yet.'
+
+        with pytest.raises(NotImplementedFeature) as err_info:
+            env.call("cast", asttoexpr(parse("cast()")))
+        assert err_info.value.message == 'Prepare method "cast()" for data type datetime is not implemented yet.'


### PR DESCRIPTION
**Summary:**
- Move some existing `cast()` methods from `SqlResultBuilder` to `ResultBuilder`
- Implement new `cast()` methods for casting string to: string, integer, boolean, number, date, time, datetime
- Implement `cast()` that raises exception for every other datatype - value type combo

**Ticket:**
 https://github.com/atviriduomenys/spinta/issues/1699