### PR TITLE
skip  tables  with exception

### DIFF
--- a/spinta/cli/main.py
+++ b/spinta/cli/main.py
@@ -31,7 +31,7 @@ from spinta.core.context import create_context
 
 log = logging.getLogger(__name__)
 
-app = Typer()
+app = Typer(pretty_exceptions_show_locals=True, pretty_exceptions_short=False, pretty_exceptions_enable=True)
 
 add(app, "config", config.config, short_help="Show current configuration values")
 add(app, "check", config.check, short_help="Check configuration and manifests")

--- a/spinta/manifests/sql/helpers.py
+++ b/spinta/manifests/sql/helpers.py
@@ -1,17 +1,12 @@
 import dataclasses
 import logging
 from operator import itemgetter
-from typing import Any, TypedDict
-from typing import Dict
-from typing import Iterator
-from typing import List
-from typing import NamedTuple
-from typing import Tuple
+from typing import Any, Dict, Iterator, List, NamedTuple, Tuple, TypedDict
 
 import cachetools
 import sqlalchemy as sa
 from geoalchemy2.types import Geometry
-from sqlalchemy.dialects import postgresql, mysql, sqlite, mssql, oracle
+from sqlalchemy.dialects import mssql, mysql, oracle, postgresql, sqlite
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.sqltypes import _Binary
 from sqlalchemy.types import TypeEngine
@@ -20,17 +15,26 @@ from spinta import spyna
 from spinta.components import Context
 from spinta.core.ufuncs import asttoexpr
 from spinta.datasets.backends.sql.backends.oracle.helpers import SDO_GEOMETRY
-from spinta.datasets.backends.sql.ufuncs.components import SqlResource, Engine
+from spinta.datasets.backends.sql.ufuncs.components import Engine, SqlResource
 from spinta.exceptions import UnexpectedFormulaResult
 from spinta.manifests.tabular.constants import DataTypeEnum
 from spinta.utils.imports import full_class_name
-from spinta.utils.naming import Deduplicator
-from spinta.utils.naming import to_dataset_name
-from spinta.utils.naming import to_model_name
-from spinta.utils.naming import to_property_name
-
+from spinta.utils.naming import Deduplicator, to_dataset_name, to_model_name, to_property_name
 
 logger = logging.getLogger(__name__)
+
+
+def _get_columns(insp: Inspector, table: str, schema: str) -> list | None:
+    try:
+        return insp.get_columns(table, schema=schema)
+    except Exception as e:
+        logger.warning(
+            "Skipping table %r in schema %r: failed to retrieve columns (%s).",
+            table,
+            schema,
+            e,
+        )
+        return None
 
 
 def read_schema(context: Context, path: str, prepare: str = None, dataset_name: str = ""):
@@ -157,7 +161,10 @@ def _create_mapping(insp: Inspector, tables: list, schema: str, dataset: str) ->
         model = dedup_model(model)
         dedup_prop = Deduplicator("_{}")
         props = {}
-        for col in insp.get_columns(table, schema=schema):
+        columns = _get_columns(insp, table, schema)
+        if columns is None:
+            continue
+        for col in columns:
             prop = to_property_name(col["name"])
             prop = dedup_prop(prop)
             props[col["name"]] = prop
@@ -199,7 +206,9 @@ def _read_props(
 ]:
     fkeys, cfkeys = _get_fkeys(insp, table, schema, mapping)
 
-    cols = insp.get_columns(table, schema=schema)
+    cols = _get_columns(insp, table, schema)
+    if cols is None:
+        return
     cols = sorted(cols, key=itemgetter("name"))
     for col in cols:
         name = col["name"]

--- a/tests/datasets/sql/test_inspect.py
+++ b/tests/datasets/sql/test_inspect.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
+import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
-from spinta.manifests.sql.helpers import _get_column_type
+from spinta.manifests.sql.helpers import _create_mapping, _get_column_type, _read_props, _SchemaMapping, _TableMapping
 
 
 def test_char_type():
@@ -36,3 +39,102 @@ def test_longblob_type():
     table = "test"
 
     assert _get_column_type(column, table) == "binary"
+
+
+def _make_insp(columns_by_table: dict, foreign_keys: dict = None) -> MagicMock:
+    """Build a minimal Inspector mock.
+
+    columns_by_table: {table_name: list-of-col-dicts | Exception subclass}
+    foreign_keys:     {table_name: list-of-fk-dicts} (default: empty for all)
+    """
+    foreign_keys = foreign_keys or {}
+    insp = MagicMock()
+
+    def get_columns(table, schema=None):
+        result = columns_by_table[table]
+        if isinstance(result, type) and issubclass(result, Exception):
+            raise result("argument of type 'NoneType' is not iterable")
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    insp.get_columns.side_effect = get_columns
+    insp.get_foreign_keys.side_effect = lambda table, schema=None: foreign_keys.get(table, [])
+    return insp
+
+
+# ---------------------------------------------------------------------------
+# _create_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_create_mapping_skips_table_when_get_columns_raises():
+    """A table whose get_columns raises any exception must be omitted from the
+    mapping; other tables must still be present."""
+    insp = _make_insp(
+        {
+            "good_table": [{"name": "id", "type": sa.Integer()}],
+            "bad_table": TypeError,
+        }
+    )
+
+    mapping = _create_mapping(insp, ["good_table", "bad_table"], schema="dbo", dataset="ds")
+
+    assert "good_table" in mapping
+    assert "bad_table" not in mapping
+
+
+def test_create_mapping_all_tables_ok():
+    """Sanity check: when no table raises, all tables appear in the mapping."""
+    insp = _make_insp(
+        {
+            "table_a": [{"name": "col1", "type": sa.Integer()}],
+            "table_b": [{"name": "col1", "type": sa.Text()}],
+        }
+    )
+
+    mapping = _create_mapping(insp, ["table_a", "table_b"], schema="dbo", dataset="ds")
+
+    assert set(mapping.keys()) == {"table_a", "table_b"}
+
+
+# ---------------------------------------------------------------------------
+# _read_props
+# ---------------------------------------------------------------------------
+
+
+def _make_schema_mapping(schema: str, table: str, props: dict) -> dict:
+    """Build the mapping dict that _read_props expects."""
+    table_mapping = _TableMapping(model=f"ds/{table}", schema=schema, props=props)
+    return {schema: _SchemaMapping(schema=schema, dataset="ds", resource="res", tables={table: table_mapping})}
+
+
+def test_read_props_yields_nothing_when_get_columns_raises():
+    """_read_props must return an empty iterator (not crash) when get_columns
+    raises any exception (e.g. unresolvable column type)."""
+    schema = "dbo"
+    table = "bad_table"
+    insp = _make_insp({table: TypeError})
+    mapping = _make_schema_mapping(schema, table, {})
+
+    result = list(_read_props(insp, table, schema, mapping))
+
+    assert result == []
+
+
+def test_read_props_yields_props_for_normal_table():
+    """Sanity check: _read_props yields properties for a well-formed table."""
+    schema = "dbo"
+    table = "good_table"
+    insp = _make_insp(
+        {table: [{"name": "id", "type": sa.Integer(), "comment": ""}]},
+        foreign_keys={table: []},
+    )
+    mapping = _make_schema_mapping(schema, table, {"id": "id"})
+
+    result = list(_read_props(insp, table, schema, mapping))
+
+    assert len(result) == 1
+    prop_name, prop_schema = result[0]
+    assert prop_name == "id"
+    assert prop_schema["type"] == "integer"


### PR DESCRIPTION
Fixes #1791 
`spinta inspect` throws exceptions without any additional information.
This solution skips the table with exception and shows names of schema and table.