### PR TITLE
[1872] Implicit `link` change for external references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changes
 0.2dev24 (unreleased)
 =====================
 
+New Features:
+
+- Adding implicit `link` changes; Implicitly change the `property` of type `ref` that refers a model, that does not exist in the file (`#1872`_).
+
+.. _#1872: https://github.com/atviriduomenys/spinta/issues/1872
+
 
 0.2dev22 (2026-04-23)
 =====================

--- a/spinta/dimensions/comments/components.py
+++ b/spinta/dimensions/comments/components.py
@@ -19,3 +19,5 @@ class Comment(Component):
     created: str
     comment: str
     given: CommentGiven
+    prepare: str | None = None
+    level: int | None = None

--- a/spinta/dimensions/comments/helpers.py
+++ b/spinta/dimensions/comments/helpers.py
@@ -20,12 +20,14 @@ def load_comments(
             access_given = params.pop("access")
             access = enum_by_name(parent, "access", Access, access_given)
             access = access or Access.private
+            level = int(level) if (level := params.pop("level", None)) else None
             comments.append(
                 Comment(
                     access=access,
                     given=CommentGiven(
                         access=access_given,
                     ),
+                    level=level,
                     **params,
                 )
             )

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -306,10 +306,6 @@ class NodeNotFound(UserError):
     template = "Node {name!r} of type {type!r} not found."
 
 
-class ModelReferenceNotFound(BaseError):
-    template = "Model reference {ref!r} not found."
-
-
 class ModelReferenceKeyNotFound(BaseError):
     template = "Model reference key {ref!r} not found in {model!r}."
 

--- a/spinta/manifests/internal_sql/helpers.py
+++ b/spinta/manifests/internal_sql/helpers.py
@@ -41,7 +41,7 @@ from spinta.manifests.tabular.helpers import (
 from sqlalchemy_utils import UUIDType
 
 from spinta.nodes import get_node
-from spinta.spyna import unparse
+from spinta.spyna import parse as spyna_parse, unparse
 from spinta.types.datatype import ArrayBackRef, Ref, Array, BackRef, Object
 from spinta.types.text.components import Text
 from spinta.utils.data import take
@@ -744,9 +744,10 @@ def _comments_to_sql(
                 "ref": comment.parent,
                 "source": comment.author,
                 "access": comment.given.access,
+                "level": comment.level,
                 "title": comment.created,
                 "description": comment.comment,
-                "prepare": _handle_prepare(NA),
+                "prepare": _handle_prepare(spyna_parse(comment.prepare)) if comment.prepare else _handle_prepare(NA),
             },
         )
 

--- a/spinta/manifests/tabular/components.py
+++ b/spinta/manifests/tabular/components.py
@@ -297,6 +297,8 @@ class CommentRow(TypedDict, total=False):
     # TODO: should be datetime
     created: str
     comment: str
+    prepare: str
+    level: str
 
 
 class CommentData(TypedDict, total=False):

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1627,6 +1627,8 @@ class CommentReader(TabularReader):
                 # TODO: parse datetime
                 "created": row[TITLE],
                 "comment": row[DESCRIPTION],
+                "prepare": row[PREPARE],
+                "level": row[LEVEL],
             }
         )
 
@@ -2260,6 +2262,8 @@ def _comments_to_tabular(
                 "ref": comment.parent,
                 "source": comment.author,
                 "access": comment.given.access,
+                "prepare": comment.prepare,
+                "level": comment.level,
                 "title": comment.created,
                 "description": comment.comment,
             },

--- a/spinta/types/__init__.py
+++ b/spinta/types/__init__.py
@@ -1,0 +1,1 @@
+TYPE_OBJECT = "object"

--- a/spinta/types/array/__init__.py
+++ b/spinta/types/array/__init__.py
@@ -1,0 +1,1 @@
+TYPE_ARRAY = "array"

--- a/spinta/types/array/link.py
+++ b/spinta/types/array/link.py
@@ -5,14 +5,14 @@ from typing import List
 from spinta import commands
 from spinta.components import Context, Model, Property
 from spinta.exceptions import (
-    ModelReferenceNotFound,
     ModelReferenceKeyNotFound,
     InvalidIntermediateTableMappingRefCount,
     UnableToMapIntermediateTable,
     SameModelIntermediateTableMapping,
 )
+from spinta.types.array import TYPE_ARRAY
 from spinta.types.datatype import Array, PartialArray, ArrayBackRef, Ref
-from spinta.types.helpers import set_dtype_backend
+from spinta.types.helpers import set_dtype_backend, replace_undeclared_ref_with_object
 
 
 @commands.link.register(Context, Array)
@@ -31,7 +31,10 @@ def link(context: Context, dtype: Array) -> None:
         dtype.model = dtype.prop.model
     else:
         if not commands.has_model(context, dtype.prop.model.manifest, intermediate_model):
-            raise ModelReferenceNotFound(dtype, ref=intermediate_model)
+            replace_undeclared_ref_with_object(
+                context, dtype.prop, TYPE_ARRAY, intermediate_model, dtype.refprops or []
+            )
+            return
         dtype.model = commands.get_model(context, dtype.prop.model.manifest, intermediate_model)
 
     intermediate_model: Model = dtype.model

--- a/spinta/types/backref/__init__.py
+++ b/spinta/types/backref/__init__.py
@@ -1,0 +1,1 @@
+TYPE_BACKREF = "backref"

--- a/spinta/types/backref/link.py
+++ b/spinta/types/backref/link.py
@@ -1,14 +1,14 @@
 from spinta import commands
 from spinta.components import Context, Model, Property
 from spinta.exceptions import (
-    ModelReferenceNotFound,
     MultipleBackRefReferencesFound,
     NoReferencesFound,
     OneToManyBackRefNotSupported,
 )
 from spinta.manifests.tabular.constants import DataTypeEnum
+from spinta.types.backref import TYPE_BACKREF
 from spinta.types.datatype import BackRef, Ref, Array, Object, Denorm, DataType
-from spinta.types.helpers import set_dtype_backend
+from spinta.types.helpers import set_dtype_backend, replace_undeclared_ref_with_object
 
 
 @commands.find_backref_ref.register(Model, str, object)
@@ -71,7 +71,9 @@ def _link_backref(context: Context, dtype: BackRef):
         dtype.model = dtype.prop.model
     else:
         if not commands.has_model(context, dtype.prop.model.manifest, backref_target_model):
-            raise ModelReferenceNotFound(dtype, ref=backref_target_model)
+            replace_undeclared_ref_with_object(context, dtype.prop, TYPE_BACKREF, backref_target_model)
+            dtype.refprop = None
+            return
         dtype.model = commands.get_model(context, dtype.prop.model.manifest, backref_target_model)
     given_refprop = dtype.refprop
     if dtype.refprop:

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
-
-from typing import TYPE_CHECKING, Iterable
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Iterable, List
 
 from spinta import exceptions
 from spinta.components import Config
 from spinta.components import Context
 from spinta.components import Model
 from spinta.components import Property
+from spinta.core.enums import Access, load_level, Level
+from spinta.dimensions.comments.components import Comment, CommentGiven
 from spinta.exceptions import BackendNotFound
 from spinta.exceptions import InvalidName
+from spinta.types import TYPE_OBJECT
 from spinta.utils.naming import is_valid_model_name, is_valid_property_name
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from spinta.types.datatype import DataType
@@ -38,6 +45,8 @@ RESERVED_PROPERTY_NAMES = {
 
 C_LANG = "C"
 
+SYSTEMIC_COMMENT_AUTHOR = "author"
+
 
 def check_no_extra_keys(dtype: DataType, schema: Iterable, data: Iterable):
     unknown = set(data) - set(schema)
@@ -60,6 +69,53 @@ def set_dtype_backend(dtype: DataType):
             dtype.backend = backends[dtype.backend]
     else:
         dtype.backend = dtype.prop.model.backend
+
+
+def replace_undeclared_ref_with_object(
+    context: Context,
+    prop: Property,
+    original_type: str,
+    original_model: str,
+    refprops: List[str] | None = None,
+) -> None:
+    from spinta.types.datatype import Object
+
+    ref_str = f"{original_model}[{','.join(refprops)}]" if refprops else original_model
+
+    logger.warning(
+        "Model %r referenced by %r property %r was not found in the manifest. Downgrading to object (level 2).",
+        original_model,
+        original_type,
+        prop.place,
+    )
+
+    new_dtype = Object()
+    new_dtype.name = TYPE_OBJECT
+    new_dtype.type = TYPE_OBJECT
+    new_dtype.type_args = []
+    new_dtype.prop = prop
+    new_dtype.properties = {}
+    prop.dtype = new_dtype
+    set_dtype_backend(new_dtype)
+
+    load_level(context, prop, Level.structured)
+
+    if prop.comments is None:
+        prop.comments = []
+
+    prop.comments.append(
+        Comment(
+            id=None,
+            parent="type",
+            author=SYSTEMIC_COMMENT_AUTHOR,
+            access=Access.private,
+            created=datetime.now(timezone.utc).isoformat(),
+            comment="",
+            given=CommentGiven(access=None),
+            prepare=f"update(type:{original_type}, ref:{ref_str})",
+            level=4,
+        )
+    )
 
 
 def check_model_name(context: Context, model: Model):

--- a/spinta/types/ref/__init__.py
+++ b/spinta/types/ref/__init__.py
@@ -1,0 +1,1 @@
+TYPE_REF = "ref"

--- a/spinta/types/ref/link.py
+++ b/spinta/types/ref/link.py
@@ -3,9 +3,10 @@ from typing import List
 from spinta import commands
 from spinta.components import Context, Model
 from spinta.types.datatype import Ref
-from spinta.exceptions import ModelReferenceNotFound, MissingRefModel
+from spinta.exceptions import MissingRefModel
 from spinta.exceptions import ModelReferenceKeyNotFound
-from spinta.types.helpers import set_dtype_backend
+from spinta.types.helpers import set_dtype_backend, replace_undeclared_ref_with_object
+from spinta.types.ref import TYPE_REF
 
 
 @commands.link.register(Context, Ref)
@@ -28,7 +29,8 @@ def link(context: Context, dtype: Ref) -> None:
         if isinstance(rmodel, Model):
             rmodel = rmodel.name
         if not commands.has_model(context, dtype.prop.model.manifest, rmodel):
-            raise ModelReferenceNotFound(dtype, ref=rmodel)
+            replace_undeclared_ref_with_object(context, dtype.prop, TYPE_REF, rmodel, dtype.refprops or [])
+            return
         dtype.model = commands.get_model(context, dtype.prop.model.manifest, rmodel)
 
     if dtype.refprops:

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -702,3 +702,29 @@ def test_spinta_check_no_message_filters_support_sql_backend(
     assert result.exit_code == 0
     # Verify that no Dask-related messages are issued.
     assert "Dask backend does not support" not in result.output
+
+
+def test_check_undeclared_ref_does_not_fail(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """check should succeed when a ref points to an undeclared model,
+    silently downgrading the property to object instead of raising."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | name     | string |                  | private
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "check",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1238,3 +1238,47 @@ def test_copy_property_with_underscore_wrong(context: Context, rc, cli: SpintaCl
     assert result.exit_code != 0
     assert isinstance(result.exception, InvalidName)
     assert "_test" in str(result.exception)
+
+
+def test_copy_undeclared_ref_transforms_to_object(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """When a ref points to an undeclared model, copy should output the property
+    as object (level=2) and append a restore comment row."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | name     | string |                  | private
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    cli.invoke(
+        rc,
+        [
+            "copy",
+            "--no-source",
+            "--access",
+            "private",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+
+    manifest = load_manifest(rc, tmp_path / "result.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access
+    example                  |         |      |        |                                        |       |
+                             |         |      |        |                                        |       |
+      |   |   | City         |         |      |        |                                        |       |
+      |   |   |   | name     | string  |      |        |                                        |       | private
+      |   |   |   | country  | object  |      |        |                                        | 2     | private
+                             | comment | type | author | update(type:ref, ref:example2/Country) | 4     |
+    """
+    )

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,0 +1,126 @@
+import sqlalchemy as sa
+from fsspec.implementations.memory import MemoryFileSystem
+from pathlib import Path
+
+import pytest
+
+from spinta.components import Context
+from spinta.core.config import RawConfig
+from spinta.core.enums import Mode
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.client import create_client, create_test_client
+from spinta.testing.data import listdata
+from spinta.testing.datasets import Sqlite
+from spinta.testing.manifest import prepare_manifest
+from spinta.testing.tabular import create_tabular_manifest
+
+
+@pytest.fixture
+def fs():
+    fs = MemoryFileSystem()
+    yield fs
+    MemoryFileSystem.store.clear()
+
+
+def test_undeclared_ref_run_does_not_fail_csv(rc: RawConfig, fs: MemoryFileSystem):
+    """spinta run should not fail (manifest loads, app starts, data is served)
+    when a ref points to a model not declared in the manifest."""
+    fs.pipe("cities.csv", b"name,country_id\nVilnius,lt\nRiga,lv\n")
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+        d | r | b | m | property | type     | ref              | source                 | access
+        example                  |          |                  |                        |
+          | csv                  | dask/csv |                  | memory://cities.csv    |
+          |   |   | City         |          |                  |                        |
+          |   |   |   | name     | string   |                  | name                   | open
+          |   |   |   | country  | ref      | example2/Country | country_id             | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall"])
+
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_ref_run_does_not_fail_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """spinta run should not fail with a SQL data source when a ref points
+    to a model not declared in the manifest."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | source     | access
+    example                  |        |                  |            |
+      | resource             | sql    |                  |            |
+      |   |   | City         |        |                  | CITY       |
+      |   |   |   | name     | string |                  | NAME       | open
+      |   |   |   | country  | ref    | example2/Country | COUNTRY_ID | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_ID", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_ID": "lt"},
+            {"NAME": "Riga", "COUNTRY_ID": "lv"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall"])
+
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_ref_run_does_not_fail_xml(rc: RawConfig, tmp_path: Path):
+    """spinta run should not fail with an XML data source when a ref points
+    to a model not declared in the manifest."""
+    path = tmp_path / "cities.xml"
+    path.write_text("""
+        <cities>
+            <city>
+                <name>Vilnius</name>
+                <country_id>lt</country_id>
+            </city>
+            <city>
+                <name>Riga</name>
+                <country_id>lv</country_id>
+            </city>
+        </cities>
+    """)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property | type     | ref              | source       | access
+        example                  |          |                  |              |
+          | xml                  | dask/xml |                  | {path}       |
+          |   |   | City         |          |                  | /cities/city |
+          |   |   |   | name     | string   |                  | name         | open
+          |   |   |   | country  | ref      | example2/Country | country_id   | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall"])
+
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
 
+from spinta.core.config import RawConfig
 from spinta.exceptions import MissingRefModel
-from spinta.testing.manifest import load_manifest
+from spinta.testing.manifest import load_manifest, load_manifest_get_context
+from spinta.types.datatype import Object
 
 
 @pytest.mark.manifests("internal_sql", "csv")
@@ -43,3 +47,136 @@ def test_raises_missing_ref_model(manifest_type, tmp_path, rc):
     property_type: ref
 """
     )
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_undeclared_ref_model_transforms_to_object(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    """When a ref points to a model not declared in the manifest, the property
+    is silently downgraded to object and a restore comment is appended."""
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref              | source | access  | level
+    example                  |        |                  |        |         |
+                             |        |                  |        |         |
+      |   |   | City         |        |                  |        |         |
+      |   |   |   | name     | string |                  |        | private |
+      |   |   |   | country  | ref    | example2/Country | A      | private |
+    """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    store = context.get("store")
+    city = store.manifest.get_objects()["model"]["example/City"]
+    country_property = city.properties["country"]
+
+    assert isinstance(country_property.dtype, Object)
+    assert country_property.level.value == 2
+    assert len(country_property.comments) == 1
+
+    comment = country_property.comments[0]
+    assert comment.parent == "type"
+    assert comment.level == 4
+    # internal-sql round-trips through spyna which normalises spacing
+    prepare = comment.prepare.replace(" ", "")
+    assert "type:ref" in prepare
+    assert "ref:example2/Country" in prepare
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_undeclared_ref_with_refprops_transforms_to_object(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    """When a ref with explicit bracket refprops points to an undeclared model,
+    the restore expression includes the bracket syntax: ref:Model[prop]."""
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref                    | access
+    example                  |        |                        |
+                             |        |                        |
+      |   |   | City         |        |                        |
+      |   |   |   | name     | string |                        | private
+      |   |   |   | country  | ref    | example2/Country[code] | private
+    """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    store = context.get("store")
+    city = store.manifest.get_objects()["model"]["example/City"]
+    country_property = city.properties["country"]
+
+    assert isinstance(country_property.dtype, Object)
+    assert country_property.level.value == 2
+    assert len(country_property.comments) == 1
+
+    comment = country_property.comments[0]
+    assert comment.parent == "type"
+    assert comment.level == 4
+    prepare = comment.prepare.replace(" ", "")
+    assert "type:ref" in prepare
+    assert "ref:example2/Country[code]" in prepare
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_undeclared_backref_model_transforms_to_object(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    """When a backref points to an undeclared model, the property is downgraded
+    to object and a restore comment with type:backref is appended."""
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property    | type    | ref              | access
+    example                     |         |                  |
+                                |         |                  |
+      |   |   | City            |         |                  |
+      |   |   |   | name        | string  |                  | private
+      |   |   |   | countries   | backref | example2/Country | private
+    """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    store = context.get("store")
+    city = store.manifest.get_objects()["model"]["example/City"]
+    countries_property = city.properties["countries"]
+
+    assert isinstance(countries_property.dtype, Object)
+    assert countries_property.level.value == 2
+    assert len(countries_property.comments) == 1
+
+    comment = countries_property.comments[0]
+    assert comment.parent == "type"
+    assert comment.level == 4
+    prepare = comment.prepare.replace(" ", "")
+    assert "type:backref" in prepare
+    assert "ref:example2/Country" in prepare
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_undeclared_array_model_transforms_to_object(manifest_type, tmp_path, rc):
+    """When an array property references an undeclared intermediate table model,
+    the property is downgraded to object and a restore comment with type:array is appended."""
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property  | type   | ref                               | access
+    example                   |        |                                   |
+                              |        |                                   |
+      |   |   | City          |        |                                   |
+      |   |   |   | name      | string |                                   | private
+      |   |   |   | countries | array  | example2/CityCountry[city,country]| private
+    """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    store = context.get("store")
+    city = store.manifest.get_objects()["model"]["example/City"]
+    countries_property = city.properties["countries"]
+
+    assert isinstance(countries_property.dtype, Object)
+    assert countries_property.level.value == 2
+    assert len(countries_property.comments) == 1
+
+    comment = countries_property.comments[0]
+    assert comment.parent == "type"
+    assert comment.level == 4
+    prepare = comment.prepare.replace(" ", "")
+    assert "type:array" in prepare
+    assert "ref:example2/CityCountry[city,country]" in prepare


### PR DESCRIPTION
Implicitly handle undeclared `ref`/`backref`/`array` targets during manifest `link` part.

Previously if a property, having one of the types defined above, pointed to a model not declared in the manifest, spinta raised `ModelReferenceNotFound` and refused to load. This made it impossible to work with partial manifests where only some models are described.

This use case is required due to the requirements proposed by @riteris13, who has difficulties when models are defined through different manifest files.

#### What changes:

During the `link` phase, when the target model is not found, the property is implicitly downgraded instead of raising:
- `dtype` is replaced with `object` (level 2);
- a comment row is appended with a spyna restore expression (`update(type:ref, ref:example2/Country)`) so the original intent is preserved and can be restored in the future.

**To support comment round-tripping**, `Comment` gained `prepare` and `level` fields, with read/write support added for both the tabular and internal-sql manifest backends.
                                                                                               
Tests cover:
- `spinta check`, `spinta copy`, and `spinta run` (`CSV`, `SQLite`, `XML` data sources) don't fail with undeclared `refs`;
- All three `dtype` paths (`ref`, `backref`, `array`) transform correctly, including the bracket `refprops` syntax (`ref:example2/Country[code]`)