### PR TITLE
[1866] Implement `comment` and `uncomment` commands for `spinta`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,12 @@ Changes
 New Features:
 
 - Adding implicit `link` changes; Implicitly change the `property` of type `ref` that refers a model, that does not exist in the file (`#1872`_).
+- Adding new commands `spinta comment` and `spinta uncomment` (`#1886`_);
+  - `spinta comment` comments the requested parts (argument) of the manifest;
+  - `spinta uncomment` looks through the commented rows that are indicating the manifest was updated and uncomments them.
 
 .. _#1872: https://github.com/atviriduomenys/spinta/issues/1872
+.. _#1886: https://github.com/atviriduomenys/spinta/issues/1886
 
 
 0.2dev22 (2026-04-23)

--- a/spinta/cli/comment.py
+++ b/spinta/cli/comment.py
@@ -1,0 +1,113 @@
+from typer import Argument
+from typer import Context as TyperContext
+from typer import Option
+from typer import echo
+
+from spinta.cli.helpers.enums import CommentPart
+from spinta.cli.helpers.store import load_manifest
+from spinta.components import Context, Property
+from spinta.core.context import configure_context
+from spinta.core.enums import Access
+from spinta.manifests.components import Manifest
+from spinta.manifests.tabular.helpers import datasets_to_tabular
+from spinta.manifests.tabular.helpers import render_tabular_manifest_rows
+from spinta.manifests.tabular.helpers import write_tabular_manifest
+
+
+def comment(
+    ctx: TyperContext,
+    part: CommentPart = Argument(None, help="Part to comment"),
+    author: str | None = Option(None, "--author", help="Comment author"),
+    uri: str | None = Option(
+        None, "--uri", help="URI tag stored on each comment (use with uncomment --uri to restore selectively)"
+    ),
+    description: str | None = Option(None, "--description", help="Additional description stored on each comment"),
+    output: str | None = Option(None, "-o", "--output", help="Output tabular manifest in a specified file"),
+    manifests: list[str] = Argument(None, help="Source manifest files"),
+) -> None:
+    """Comment out specific manifest parts so the manifest can be processed further."""
+    context: Context = ctx.obj
+    context = configure_context(context, manifests)
+
+    comment_manifest(
+        context,
+        author=author,
+        uri=uri,
+        description=description,
+        output=output,
+        manifests=manifests,
+    )
+
+
+def comment_manifest(
+    context: Context,
+    author: str | None = None,
+    uri: str | None = None,
+    description: str | None = None,
+    output: str | None = None,
+    manifests: list[str] | None = None,
+) -> None:
+    verbose = bool(output)
+    context = configure_context(context, manifests)
+    store = load_manifest(
+        context,
+        load_internal=False,
+        verbose=verbose,
+        full_load=True,
+    )
+
+    _update_systemic_comments(context, store.manifest, author=author, uri=uri, description=description)
+    rows = datasets_to_tabular(context, store.manifest, external=False, access=Access.private)
+
+    if output:
+        write_tabular_manifest(context, output, rows)
+    else:
+        manager = context.get("error_manager")
+        handler = manager.handler
+        table = render_tabular_manifest_rows(rows)
+        if handler.get_counts():
+            handler.post_process()
+        else:
+            echo(table)
+
+
+def _update_systemic_comments(
+    context: Context,
+    manifest: Manifest,
+    *,
+    author: str | None = None,
+    uri: str | None = None,
+    description: str | None = None,
+) -> None:
+    """Update author/uri/description on comment type properties."""
+    from spinta import commands
+
+    if all(argument is None for argument in [author, uri, description]):
+        return
+
+    models = commands.get_models(context, manifest)
+    for model in models.values():
+        for prop in model.properties.values():
+            _patch_property_restore_comments(prop, author=author, uri=uri, description=description)
+
+
+def _patch_property_restore_comments(
+    prop: Property,
+    *,
+    author: str | None,
+    uri: str | None,
+    description: str | None,
+) -> None:
+    if not prop.comments:
+        return
+
+    for comment in prop.comments:
+        if not comment.prepare or not comment.prepare.startswith("update"):
+            continue
+
+        if author is not None:
+            comment.author = author
+        if uri is not None:
+            comment.uri = uri
+        if description is not None:
+            comment.comment = description

--- a/spinta/cli/helpers/enums.py
+++ b/spinta/cli/helpers/enums.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class CommentPart(str, Enum):
+    missing_external_refs = "missing-external-refs"

--- a/spinta/cli/main.py
+++ b/spinta/cli/main.py
@@ -17,6 +17,8 @@ from spinta.cli import data
 from spinta.cli import inspect
 from spinta.cli import manifest
 from spinta.cli import migrate
+from spinta.cli.comment import comment
+from spinta.cli.uncomment import uncomment
 from spinta.cli import pii
 from spinta.cli import pull
 from spinta.cli import push
@@ -45,6 +47,8 @@ add(app, "inspect", inspect.inspect, short_help=("Update manifest schema from an
 add(app, "pii", pii.app, short_help="Manage Person Identifying Information")
 
 add(app, "copy", manifest.copy, short_help="Copy only specified metadata from a manifest")
+add(app, "comment", comment, short_help="Comment unsupported functionality in a manifest")
+add(app, "uncomment", uncomment, short_help="Restore commented parts of a manifest")
 add(app, "show", show, short_help="Show manifest as ascii table")
 
 add(app, "bootstrap", migrate.bootstrap, short_help="Initialize backends")

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -1,0 +1,110 @@
+import csv
+import pathlib
+import re
+
+from typer import Argument
+from typer import Context as TyperContext
+from typer import Option
+from typer import echo
+
+from spinta.components import Context
+from spinta.manifests.tabular.components import MANIFEST_COLUMNS
+from spinta.manifests.tabular.components import ManifestRow
+from spinta.manifests.tabular.helpers import render_tabular_manifest_rows
+from spinta.manifests.tabular.helpers import torow
+from spinta.manifests.tabular.helpers import write_tabular_manifest
+
+
+UPDATE_FUNCTION = "update"
+COLUMN_TYPE_COMMENT = "comment"
+
+
+def uncomment(
+    ctx: TyperContext,
+    uri: str | None = Option(None, "--uri", help="Only restore comments that carry this URI tag"),
+    output: str | None = Option(None, "-o", "--output", help="Output tabular manifest in a specified file"),
+    manifests: list[str] = Argument(None, help="Source manifest files"),
+):
+    """Restore commented-out properties."""
+    context: Context = ctx.obj
+    uncomment_manifest(context, uri=uri, output=output, manifests=manifests)
+
+
+def uncomment_manifest(
+    context: Context,
+    uri: str | None = None,
+    output: str | None = None,
+    manifests: list[str] | None = None,
+) -> None:
+    """Read raw CSV rows, remove `update` comments, and write the result."""
+    rows = _read_raw_manifest_rows(manifests or [])
+    result = _uncomment_rows(rows, uri_filter=uri)
+    if output:
+        write_tabular_manifest(context, output, iter(result))
+    else:
+        echo(render_tabular_manifest_rows(iter(result)))
+
+
+def _read_raw_manifest_rows(manifests: list[str]) -> list[ManifestRow]:
+    """Read CSV manifest files as raw dicts, normalising to MANIFEST_COLUMNS keys."""
+    rows = []
+    for path in manifests:
+        with pathlib.Path(path).open(encoding="utf-8-sig") as file:
+            reader = csv.DictReader(file)
+            for raw in reader:
+                rows.append(torow(MANIFEST_COLUMNS, raw))
+    return rows
+
+
+def _parse_update_fields(prepare: str) -> dict[str, str]:
+    """Parse 'update(key1:val1, key2:val2, ...)' into {'key1': 'val1', 'key2': 'val2', ...}.
+
+    Splits on commas only when followed by a word-colon pattern, so values containing
+    commas inside brackets (e.g. ref:example2/City[id, name]) are handled correctly.
+    """
+    match = re.match(rf"{UPDATE_FUNCTION}\((.+)\)\s*$", (prepare or "").strip())
+    if not match:
+        return {}
+    parts = re.split(r",\s*(?=\w+:)", match.group(1))
+    result = {}
+    for part in parts:
+        key, _, value = part.partition(":")
+        result[key.strip()] = value.strip().strip('"')
+    return result
+
+
+def _is_restore_comment(row: ManifestRow) -> bool:
+    prepare = row.get("prepare") or ""
+    return row.get("type") == COLUMN_TYPE_COMMENT and prepare.startswith(UPDATE_FUNCTION)
+
+
+def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[ManifestRow]:
+    """
+    Walk rows in order. When an `update` comment is found (and passes the URI filter),
+    patch the most recent property row in result and drop the comment row.
+    """
+    result: list[ManifestRow] = []
+    last_property_index: int | None = None
+
+    for row in rows:
+        if _is_restore_comment(row):
+            # Restore only rows that match the `uri` if it is given by input;
+            if uri_filter is not None and row.get("uri") != uri_filter:
+                result.append(row)
+                continue
+
+            # Parse the expression and apply field to the last seen row (comments go after the row they change);
+            fields = _parse_update_fields(row.get("prepare", ""))
+            if fields and last_property_index is not None:
+                prop_row: dict = dict(result[last_property_index])
+                for key, value in fields.items():
+                    prop_row[key] = value
+                prop_row["level"] = row.get("level") or ""
+                result[last_property_index] = prop_row
+        else:
+            # If it's not an `update` comment, append to the result as-is;
+            if row.get("property"):
+                last_property_index = len(result)
+            result.append(row)
+
+    return result

--- a/spinta/dimensions/comments/components.py
+++ b/spinta/dimensions/comments/components.py
@@ -21,3 +21,4 @@ class Comment(Component):
     given: CommentGiven
     prepare: str | None = None
     level: int | None = None
+    uri: str | None = None

--- a/spinta/manifests/internal_sql/helpers.py
+++ b/spinta/manifests/internal_sql/helpers.py
@@ -745,6 +745,7 @@ def _comments_to_sql(
                 "source": comment.author,
                 "access": comment.given.access,
                 "level": comment.level,
+                "uri": comment.uri,
                 "title": comment.created,
                 "description": comment.comment,
                 "prepare": _handle_prepare(spyna_parse(comment.prepare)) if comment.prepare else _handle_prepare(NA),

--- a/spinta/manifests/tabular/components.py
+++ b/spinta/manifests/tabular/components.py
@@ -299,6 +299,7 @@ class CommentRow(TypedDict, total=False):
     comment: str
     prepare: str
     level: str
+    uri: str
 
 
 class CommentData(TypedDict, total=False):

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1629,6 +1629,7 @@ class CommentReader(TabularReader):
                 "comment": row[DESCRIPTION],
                 "prepare": row[PREPARE],
                 "level": row[LEVEL],
+                "uri": row[URI],
             }
         )
 
@@ -2264,6 +2265,7 @@ def _comments_to_tabular(
                 "access": comment.given.access,
                 "prepare": comment.prepare,
                 "level": comment.level,
+                "uri": comment.uri,
                 "title": comment.created,
                 "description": comment.comment,
             },

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -112,7 +112,7 @@ def replace_undeclared_ref_with_object(
             created=datetime.now(timezone.utc).isoformat(),
             comment="",
             given=CommentGiven(access=None),
-            prepare=f"update(type:{original_type}, ref:{ref_str})",
+            prepare=f'update(type:"{original_type}", ref:"{ref_str}")',
             level=4,
         )
     )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,7 @@
+import csv
+from pathlib import Path
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with path.open() as f:
+        return list(csv.DictReader(f))

--- a/tests/cli/test_comment.py
+++ b/tests/cli/test_comment.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from pathlib import Path
+
+from spinta.components import Context
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.cli import SpintaCliRunner
+from spinta.testing.manifest import load_manifest
+from spinta.testing.tabular import create_tabular_manifest
+from tests.cli.conftest import _read_csv
+
+
+def test_comment_missing_external_refs(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """comment missing-external-refs downgrades undeclared refs to object (level=2) and adds a restore comment."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | name     | string |                  | private
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "comment",
+            "missing-external-refs",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    manifest = load_manifest(rc, tmp_path / "result.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access  | description
+    example                  |         |      |        |                                        |       |         |
+                             |         |      |        |                                        |       |         |
+      |   |   | City         |         |      |        |                                        |       |         |
+      |   |   |   | name     | string  |      |        |                                        |       | private |
+      |   |   |   | country  | object  |      |        |                                        | 2     | private |
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |         |
+    """
+    )
+
+    # Verify the title column carries an ISO 8601 creation date
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_row = next(row for row in rows if row.get("type") == "comment")
+    assert comment_row["title"], "comment title (creation date) must be set"
+    datetime.fromisoformat(comment_row["title"])  # Datetime needs to conform to ISO 8601
+
+
+def test_comment_all_optional_values_given(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """--author, --uri, and --description are all stored on the comment row, along with an ISO 8601 title date."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "comment",
+            "missing-external-refs",
+            "--author",
+            "john",
+            "--uri",
+            "http://example.com/issue/1",
+            "--description",
+            "Waiting for example2 dataset",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    manifest = load_manifest(rc, tmp_path / "result.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access  | uri                         | description
+    example                  |         |      |        |                                        |       |         |                             |
+                             |         |      |        |                                        |       |         |                             |
+      |   |   | City         |         |      |        |                                        |       |         |                             |
+      |   |   |   | country  | object  |      |        |                                        | 2     | private |                             |
+                             | comment | type | john   | update(type:"ref", ref:"example2/Country") | 4     |         | http://example.com/issue/1  | Waiting for example2 dataset
+    """
+    )
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+    assert len(comment_rows) == 1
+    comment_row = comment_rows[0]
+    assert comment_row["title"], "comment title (creation date) must be set"
+    datetime.fromisoformat(comment_row["title"])  # raises ValueError if not valid ISO 8601
+
+
+def test_comment_idempotent(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Running comment twice on the same file does not create duplicate restore comments."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented2.csv", tmp_path / "commented.csv"],
+    )
+
+    rows1 = _read_csv(tmp_path / "commented.csv")
+    rows2 = _read_csv(tmp_path / "commented2.csv")
+
+    comment_rows1 = [row for row in rows1 if row.get("type") == "comment"]
+    comment_rows2 = [row for row in rows2 if row.get("type") == "comment"]
+
+    assert len(comment_rows1) == 1
+    assert len(comment_rows2) == 1, "second run must not duplicate the restore comment"
+    assert comment_rows1[0]["prepare"] == comment_rows2[0]["prepare"]
+
+
+def test_comment_unknown_part_raises(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """comment with an unsupported `part` argument should exit with an error."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref | access
+    example                  |        |     |
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "comment",
+            "unknown-part",
+            tmp_path / "manifest.csv",
+        ],
+        fail=False,
+    )
+    assert result.exit_code != 0

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1279,6 +1279,6 @@ def test_copy_undeclared_ref_transforms_to_object(context: Context, rc, cli: Spi
       |   |   | City         |         |      |        |                                        |       |
       |   |   |   | name     | string  |      |        |                                        |       | private
       |   |   |   | country  | object  |      |        |                                        | 2     | private
-                             | comment | type | author | update(type:ref, ref:example2/Country) | 4     |
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |
     """
     )

--- a/tests/cli/test_uncomment.py
+++ b/tests/cli/test_uncomment.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+
+from spinta.components import Context
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.cli import SpintaCliRunner
+from spinta.testing.tabular import create_tabular_manifest
+from tests.cli.conftest import _read_csv
+
+
+def test_uncomment_direct_input(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """uncomment works directly on a manifest that already has type=comment restore rows."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access
+    example                  |         |      |        |                                        |       |
+                             |         |      |        |                                        |       |
+      |   |   | City         |         |      |        |                                        |       |
+      |   |   |   | name     | string  |      |        |                                        |       | private
+      |   |   |   | country  | object  |      |        |                                        | 2     | private
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "-o",
+            tmp_path / "restored.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    property_rows = [row for row in rows if row.get("property") == "country"]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(property_rows) == 1
+    property_row = property_rows[0]
+    assert property_row["type"] == "ref"
+    assert property_row["ref"] == "example2/Country"
+    assert property_row["level"] == "4"
+    assert len(comment_rows) == 0, "restore comment should have been removed"
+
+
+def test_comment_uncomment_roundtrip(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Full round-trip: comment downgrades missing refs, uncomment restores them."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref              | access
+    example                  |        |                  |
+                             |        |                  |
+      |   |   | City         |        |                  |
+      |   |   |   | name     | string |                  | private
+      |   |   |   | country  | ref    | example2/Country | private
+    """),
+    )
+
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "commented.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    property_rows = [row for row in rows if row.get("property") == "country"]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(property_rows) == 1
+    property_row = property_rows[0]
+    assert property_row["type"] == "ref"
+    assert property_row["ref"] == "example2/Country"
+    assert property_row["level"] == "4"
+    assert len(comment_rows) == 0, "restore comment should have been removed"
+
+
+def test_uncomment_preserves_non_restore_comments(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Regular comment rows (no restore prepare) are kept; only restore comments are dropped."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access  | description
+    example                  |         |      |        |                                        |       |         |
+                             |         |      |        |                                        |       |         |
+      |   |   | City         |         |      |        |                                        |       |         |
+      |   |   |   | country  | object  |      |        |                                        | 2     | private |
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |         |
+                             | comment |      | alice  |                                        |       |         | needs review
+    """),
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "-o",
+            tmp_path / "restored.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(comment_rows) == 1, "plain comment should be preserved, only restore comment removed"
+    comment_row = comment_rows[0]
+    assert comment_row["source"] == "alice"
+    assert comment_row["description"] == "needs review"
+    assert not comment_row.get("prepare"), "preserved comment should have no prepare"
+
+
+def test_uncomment_uri_filter(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """uncomment --uri only restores comments that carry the matching URI tag, when URI is given."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access  | uri
+    example                  |         |      |        |                                        |       |         |
+                             |         |      |        |                                        |       |         |
+      |   |   | City         |         |      |        |                                        |       |         |
+      |   |   |   | country  | object  |      |        |                                        | 2     | private |
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |         | http://foo
+      |   |   |   | capital  | object  |      |        |                                        | 2     | private |
+                             | comment | type | author | update(type:"ref", ref:"example3/Capital") | 4     |         | http://foo
+    """),
+    )
+
+    # Restore only comments tagged with http://bar (should match nothing -> file unchanged)
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "--uri",
+            "http://bar",
+            "-o",
+            tmp_path / "restored_bar.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows_bar = _read_csv(tmp_path / "restored_bar.csv")
+    comment_rows_bar = [row for row in rows_bar if row.get("type") == "comment"]
+    assert len(comment_rows_bar) == 2, "both comments should remain when URI doesn't match"
+
+    # Restore only comments tagged with http://foo (should restore both props)
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "--uri",
+            "http://foo",
+            "-o",
+            tmp_path / "restored_foo.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows_foo = _read_csv(tmp_path / "restored_foo.csv")
+    comment_rows_foo = [row for row in rows_foo if row.get("type") == "comment"]
+    assert len(comment_rows_foo) == 0, "all comments should be removed when URI matches"
+    property_country = next(row for row in rows_foo if row.get("property") == "country")
+    property_capital = next(row for row in rows_foo if row.get("property") == "capital")
+
+    assert property_country["type"] == "ref"
+    assert property_country["ref"] == "example2/Country"
+    assert property_capital["type"] == "ref"
+    assert property_capital["ref"] == "example3/Capital"

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -77,8 +77,8 @@ def test_undeclared_ref_model_transforms_to_object(manifest_type: str, tmp_path:
     comment = country_property.comments[0]
     assert comment.parent == "type"
     assert comment.level == 4
-    # internal-sql round-trips through spyna which normalises spacing
-    prepare = comment.prepare.replace(" ", "")
+    # internal-sql round-trips through spyna which normalises spacing and quote style
+    prepare = comment.prepare.replace(" ", "").replace('"', "").replace("'", "")
     assert "type:ref" in prepare
     assert "ref:example2/Country" in prepare
 
@@ -111,7 +111,7 @@ def test_undeclared_ref_with_refprops_transforms_to_object(manifest_type: str, t
     comment = country_property.comments[0]
     assert comment.parent == "type"
     assert comment.level == 4
-    prepare = comment.prepare.replace(" ", "")
+    prepare = comment.prepare.replace(" ", "").replace('"', "").replace("'", "")
     assert "type:ref" in prepare
     assert "ref:example2/Country[code]" in prepare
 
@@ -144,7 +144,7 @@ def test_undeclared_backref_model_transforms_to_object(manifest_type: str, tmp_p
     comment = countries_property.comments[0]
     assert comment.parent == "type"
     assert comment.level == 4
-    prepare = comment.prepare.replace(" ", "")
+    prepare = comment.prepare.replace(" ", "").replace('"', "").replace("'", "")
     assert "type:backref" in prepare
     assert "ref:example2/Country" in prepare
 
@@ -177,6 +177,6 @@ def test_undeclared_array_model_transforms_to_object(manifest_type, tmp_path, rc
     comment = countries_property.comments[0]
     assert comment.parent == "type"
     assert comment.level == 4
-    prepare = comment.prepare.replace(" ", "")
+    prepare = comment.prepare.replace(" ", "").replace('"', "").replace("'", "")
     assert "type:array" in prepare
     assert "ref:example2/CityCountry[city,country]" in prepare


### PR DESCRIPTION
Implements `comment` and `uncomment` commands with an extensive test-suite;

Further described in the related task description.