### PR TITLE
improve mermaid creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@ Changes
 0.2dev24 (unreleased)
 =====================
 
+Improvements:
+
+- Updated Mermaid generation logic using the `spinta copy` command (`#1888`_): 
+  - added support for `-d` (`--dataset`) argument that can be used to specify the main dataset for Mermaid generation.
+  - updated code to correctly display visibility, relationships, cardinality.
+  - added custom diagram styling.
+  - added namespaces.
+  - added dot-notated properties.
+
+
 New Features:
 
 - Adding implicit `link` changes; Implicitly change the `property` of type `ref` that refers a model, that does not exist in the file (`#1872`_).

--- a/docs/en/reference/cli.rst
+++ b/docs/en/reference/cli.rst
@@ -70,3 +70,91 @@ Example
     }
   ]
 }
+
+.. _cli_copy:
+
+copy
+====
+
+The ``copy`` CLI command reads a manifest file and depending on arguments either returns manifest in tabular format or writes into file.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   spinta copy <manifest-files-to-load> -o <path-to-output-file> -d <dataset-name>
+
+Arguments
+---------
+
+- ``<manifest-files-to-load>``
+  One or more manifest files that will be loaded.
+
+- ``<path-to-output-file>``
+  OPTIONAL. Output file name. If specified, manifest will be written to this file. If file extension is `.mmd`, UML diagram will be generated in Mermaid syntax.
+
+- ``<dataset-name>``
+  The name of the dataset. This is used only for Mermaid diagram. Specified dataset will not be wrapped in Mermaid class diagram `namespace <https://mermaid.js.org/syntax/classDiagram.html#define-namespace>`_
+
+Example
+-------
+
+**Input Manifest file (`manifest.csv`)**:
+
++----+-----------------+----------+------+---------+----------+---------+---------+
+| id | dataset         | resource | base | model   | property | type    | ref     |
++====+=================+==========+======+=========+==========+=========+=========+
+|    | example/dataset |          |      |         |          |         |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 | resource |      |         |          |         |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      | City    |          |         |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      |         | id       | integer |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      |         | name     | string  |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      |         | city     | ref     | Country |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      | Country |          |         |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      |         | id       | integer |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+|    |                 |          |      |         | name     | string  |         |
++----+-----------------+----------+------+---------+----------+---------+---------+
+
+
+**Command**:
+
+.. code-block:: bash
+
+   spinta copy manifest.csv -o manifest.mmd -d example/dataset
+
+**Output (manifest.mmd)**:
+
+.. code-block:: mermaid
+
+  ---
+  config:
+    theme: base
+    themeVariables:
+      mainBkg: '#ffffff00'
+      clusterBkg: '#ffffde'
+  ---
+
+  classDiagram
+  class `example/dataset/City`["City"]:::Entity {
+  «optional»
+  id : integer [0..1]
+  name : string [0..1]
+  }
+  class `example/dataset/Country`["Country"]:::Entity {
+  «optional»
+  id : integer [0..1]
+  name : string [0..1]
+  }
+
+  `example/dataset/City` --> "[0..1]" `example/dataset/Country` : city<br/>«optional»
+  classDef Concept stroke:#8FB58F,fill:#F0FDF0,color:#000000;
+  classDef Entity stroke:#9D8787,fill:#F5E8DF,color:#000000;

--- a/spinta/cli/manifest.py
+++ b/spinta/cli/manifest.py
@@ -37,7 +37,7 @@ def copy(
     access: str = Option("private", help=("Copy properties with at least specified access")),
     format_names: bool = Option(False, help=("Reformat model and property names.")),
     output: Optional[str] = Option(None, "-o", "--output", help=("Output tabular manifest in a specified file")),
-    dataset: str = Option(None, "-d", "--dataset", help=("Main dataset name")),
+    dataset: Optional[str] = Option(None, "-d", "--dataset", help=("Main dataset name")),
     columns: Optional[str] = Option(None, "-c", "--columns", help=("Comma separated list of columns")),
     order_by: Optional[str] = Option(
         None, help=("Order by a specified column (currently only access column is supported)")

--- a/spinta/cli/manifest.py
+++ b/spinta/cli/manifest.py
@@ -37,6 +37,7 @@ def copy(
     access: str = Option("private", help=("Copy properties with at least specified access")),
     format_names: bool = Option(False, help=("Reformat model and property names.")),
     output: Optional[str] = Option(None, "-o", "--output", help=("Output tabular manifest in a specified file")),
+    dataset: str = Option(None, "-d", "--dataset", help=("Main dataset name")),
     columns: Optional[str] = Option(None, "-c", "--columns", help=("Comma separated list of columns")),
     order_by: Optional[str] = Option(
         None, help=("Order by a specified column (currently only access column is supported)")
@@ -57,6 +58,7 @@ def copy(
         order_by=order_by,
         rename_duplicates=rename_duplicates,
         manifests=manifests,
+        dataset=dataset,
     )
 
 
@@ -71,6 +73,7 @@ def copy_manifest(
     rename_duplicates: bool = False,
     manifests: List[str] = None,
     output_type: Optional[str] = None,
+    dataset: str | None = None,
 ):
     """Copy models from CSV manifest files into another CSV manifest file"""
     access = get_enum_by_name(Access, access)
@@ -113,7 +116,7 @@ def copy_manifest(
         )
     if output:
         if output_type == "mermaid":
-            write_mermaid_manifest(context, output, rows)
+            write_mermaid_manifest(context, output, rows, main_dataset=dataset)
         elif internal:
             write_internal_sql_manifest(context, output, rows)
         else:

--- a/spinta/cli/manifest.py
+++ b/spinta/cli/manifest.py
@@ -116,7 +116,7 @@ def copy_manifest(
         )
     if output:
         if output_type == "mermaid":
-            write_mermaid_manifest(context, output, rows, main_dataset=dataset)
+            write_mermaid_manifest(context, rows, dataset, output)
         elif internal:
             write_internal_sql_manifest(context, output, rows)
         else:

--- a/spinta/cli/manifest.py
+++ b/spinta/cli/manifest.py
@@ -1,6 +1,5 @@
 from typing import Iterator, Union
 from typing import List
-from typing import Optional
 
 from typer import Argument
 from typer import Context as TyperContext
@@ -36,10 +35,10 @@ def copy(
     #       https://github.com/tiangolo/typer/issues/151
     access: str = Option("private", help=("Copy properties with at least specified access")),
     format_names: bool = Option(False, help=("Reformat model and property names.")),
-    output: Optional[str] = Option(None, "-o", "--output", help=("Output tabular manifest in a specified file")),
-    dataset: Optional[str] = Option(None, "-d", "--dataset", help=("Main dataset name")),
-    columns: Optional[str] = Option(None, "-c", "--columns", help=("Comma separated list of columns")),
-    order_by: Optional[str] = Option(
+    output: str | None = Option(None, "-o", "--output", help=("Output tabular manifest in a specified file")),
+    dataset: str | None = Option(None, "-d", "--dataset", help=("Main dataset name")),
+    columns: str | None = Option(None, "-c", "--columns", help=("Comma separated list of columns")),
+    order_by: str | None = Option(
         None, help=("Order by a specified column (currently only access column is supported)")
     ),
     rename_duplicates: bool = Option(False, help=("Rename duplicate model names by adding number suffix")),
@@ -67,12 +66,12 @@ def copy_manifest(
     source: bool = True,
     access: str = "private",
     format_names: bool = False,
-    output: Optional[str] = None,
-    columns: Optional[str] = None,
-    order_by: Optional[str] = None,
+    output: str | None = None,
+    columns: str | None = None,
+    order_by: str | None = None,
     rename_duplicates: bool = False,
     manifests: List[str] = None,
-    output_type: Optional[str] = None,
+    output_type: str | None = None,
     dataset: str | None = None,
 ):
     """Copy models from CSV manifest files into another CSV manifest file"""

--- a/spinta/manifests/mermaid/helpers.py
+++ b/spinta/manifests/mermaid/helpers.py
@@ -82,8 +82,10 @@ class MermaidNameSpace:
             self.classes[name] = MermaidClass(name=name, **kwargs)
         return self.classes[name]
 
-    def process_property(self, model: Model, prop: Property, update: bool = True) -> None:
-        mermaid_class = self.get_or_create_class(name=model.name, label=model.basename)
+    def process_property(
+        self, model: Model, prop: Property, update: bool = True, mermaid_class: MermaidClass | None = None
+    ) -> None:
+        mermaid_class = mermaid_class or self.get_or_create_class(name=model.name, label=model.basename)
         if prop.enum:
             enum_class = self.get_or_create_class(
                 name=f"{model.name}{to_model_name(prop.name)}",
@@ -305,6 +307,7 @@ def write_mermaid_manifest(
         dataset_name = model.external.dataset.name
         namespace_name = dataset_name if dataset_name != main_dataset else None
         namespace = mermaid.get_namespace(namespace_name)
+        mermaid_class = namespace.get_or_create_class(name=model.name, label=model.basename)
 
         if model.base:
             label = ", ".join(pk.name for pk in model.base.pk)
@@ -318,7 +321,7 @@ def write_mermaid_manifest(
             )
 
         for model_property in model.get_given_properties().values():
-            namespace.process_property(model, model_property)
+            namespace.process_property(model, model_property, mermaid_class)
 
     if not output:
         return str(mermaid)

--- a/spinta/manifests/mermaid/helpers.py
+++ b/spinta/manifests/mermaid/helpers.py
@@ -31,12 +31,12 @@ class MermaidClassDiagram:
     relationships: list[MermaidRelationship]
     definitions: set[MermaidClassDef]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.namespaces = {}
         self.relationships = []
         self.definitions = set()
 
-    def __str__(self):
+    def __str__(self) -> str:
         text = f"{MERMAID_CONFIG}\n"
         text += "classDiagram\n"
 
@@ -67,11 +67,11 @@ class MermaidNameSpace:
     name: str | None
     classes: list[MermaidClass]
 
-    def __init__(self, name: str | None = None):
+    def __init__(self, name: str | None = None) -> None:
         self.name = name
         self.classes = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         text = f"namespace `{self.name}` {{\n" if self.name else ""
         for mermaid_class in self.classes:
             text += f"{str(mermaid_class)}\n"
@@ -87,7 +87,7 @@ class MermaidClassDef:
     name: str
     styles: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"classDef {self.name} {self.styles};"
 
     def __eq__(self, other: object) -> bool:
@@ -102,8 +102,9 @@ class MermaidClass:
     label: str
     definition: MermaidClassDef
     properties: list[MermaidProperty]
+    is_enum: bool
 
-    def __init__(self, name: str, label: str, definition: MermaidClassDef, is_enum: bool = False):
+    def __init__(self, name: str, label: str, definition: MermaidClassDef, is_enum: bool = False) -> None:
         self.name = name
         self.label = label
         self.definition = definition
@@ -113,7 +114,7 @@ class MermaidClass:
     def add_property(self, prop: MermaidProperty) -> None:
         self.properties.append(prop)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_text = f'class `{self.name}`["{self.label}"]:::{self.definition.name}'
 
         if not self.properties:
@@ -147,7 +148,7 @@ class MermaidClass:
 @dataclass
 class MermaidProperty:
     name: str
-    visibility: Visibility | str = None
+    visibility: Visibility | None = None
     type: str | None = None
     cardinality: bool | None = None
     multiplicity: str | None = None
@@ -159,7 +160,7 @@ class MermaidProperty:
         Visibility.private: "-",
     }
 
-    def __str__(self):
+    def __str__(self) -> str:
         property_string = self.name
 
         if self.visibility is not None:
@@ -196,7 +197,7 @@ class MermaidRelationship:
     multiplicity: str = ""
     label: str = ""
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.direction == RelationshipDirection.FORWARD:
             if self.type == RelationshipType.ASSOCIATION:
                 arrow = "-->"
@@ -229,7 +230,9 @@ class MermaidRelationship:
         return relationship_text
 
 
-def write_mermaid_manifest(context: Context, output: str, manifest: InlineManifest, main_dataset: str | None = None):
+def write_mermaid_manifest(
+    context: Context, output: str, manifest: InlineManifest, main_dataset: str | None = None
+) -> None:
     mermaid = MermaidClassDiagram()
     concept_definition = MermaidClassDef(name=CONCEPT_NAME, styles=CONCEPT_STYLES)
     entity_definition = MermaidClassDef(name=ENTITY_NAME, styles=ENTITY_STYLES)

--- a/spinta/manifests/mermaid/helpers.py
+++ b/spinta/manifests/mermaid/helpers.py
@@ -4,51 +4,109 @@ import enum
 from dataclasses import dataclass
 
 from spinta.components import Context
-from spinta.core.enums import Access
+from spinta.core.enums import Visibility
 from spinta.manifests.yaml.components import InlineManifest
 from spinta.types.datatype import Ref, BackRef, ArrayBackRef, Inherit, PartialArray
 from spinta.utils.naming import to_model_name
 
 
-class MermaidClassDiagram:
-    title: str | None
-    classes: list[MermaidClass]
-    relationships: list[MermaidRelationship]
+CONCEPT_STYLES = "stroke:#8FB58F,fill:#F0FDF0,color:#000000"
+ENTITY_STYLES = "stroke:#9D8787,fill:#F5E8DF,color:#000000"
 
-    def __init__(self, title: str = None):
-        self.title = title
-        self.classes = []
+CONCEPT_NAME = "Concept"
+ENTITY_NAME = "Entity"
+
+MERMAID_CONFIG = """---
+config:
+  theme: base
+  themeVariables:
+    mainBkg: '#ffffff00' 
+    clusterBkg: '#ffffde'
+---
+"""
+
+
+class MermaidClassDiagram:
+    namespaces: dict[str | None, MermaidNameSpace]
+    relationships: list[MermaidRelationship]
+    definitions: set[MermaidClassDef]
+
+    def __init__(self):
+        self.namespaces = {}
         self.relationships = []
+        self.definitions = set()
 
     def __str__(self):
-        text = ""
-
-        if self.title:
-            text += f"---\n{self.title}\n---\n"
-
+        text = f"{MERMAID_CONFIG}\n"
         text += "classDiagram\n"
 
-        for clas in self.classes:
-            text += f"{str(clas)}\n"
+        for namespace in self.namespaces.values():
+            text += f"{str(namespace)}\n"
 
         for relationship in self.relationships:
             text += f"{str(relationship)}\n"
 
+        for definition in sorted(self.definitions, key=lambda d: d.name):
+            text += f"{str(definition)}\n"
+
         return text
 
-    def add_class(self, clas: MermaidClass) -> None:
-        self.classes.append(clas)
+    def add_namespace(self, name: str | None) -> MermaidNameSpace:
+        if name not in self.namespaces:
+            self.namespaces[name] = MermaidNameSpace(name)
+        return self.namespaces[name]
 
     def add_relationship(self, relationship: MermaidRelationship) -> None:
         self.relationships.append(relationship)
 
+    def collect_definitions(self) -> None:
+        self.definitions = {cls.definition for namespace in self.namespaces.values() for cls in namespace.classes}
+
+
+class MermaidNameSpace:
+    name: str | None
+    classes: list[MermaidClass]
+
+    def __init__(self, name: str | None = None):
+        self.name = name
+        self.classes = []
+
+    def __str__(self):
+        text = f"namespace `{self.name}` {{\n" if self.name else ""
+        for mermaid_class in self.classes:
+            text += f"{str(mermaid_class)}\n"
+        text += "}" if self.name else ""
+        return text
+
+    def add_class(self, mermaid_class: MermaidClass) -> None:
+        self.classes.append(mermaid_class)
+
+
+@dataclass(eq=False)
+class MermaidClassDef:
+    name: str
+    styles: str
+
+    def __str__(self):
+        return f"classDef {self.name} {self.styles};"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, MermaidClassDef) and self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
 
 class MermaidClass:
     name: str
+    label: str
+    definition: MermaidClassDef
     properties: list[MermaidProperty]
 
-    def __init__(self, name: str, is_enum=False):
+    def __init__(self, name: str, label: str, definition: MermaidClassDef, is_enum: bool = False):
         self.name = name
+        self.label = label
+        self.definition = definition
         self.properties = []
         self.is_enum = is_enum
 
@@ -56,31 +114,57 @@ class MermaidClass:
         self.properties.append(prop)
 
     def __str__(self):
-        class_text = f"class {self.name} {{\n"
+        class_text = f'class `{self.name}`["{self.label}"]:::{self.definition.name}'
+
+        if not self.properties:
+            return class_text
+
+        class_text += " {\n"
+
         if self.is_enum:
             class_text = f"{class_text}<<enumeration>>\n"
-        properties_text = "".join(f"{str(prop)}\n" for prop in self.properties)
-        class_text += properties_text
+
+        if mandatory_properties := self.mandatory_properties:
+            class_text += "«mandatory»\n"
+            class_text += "".join(f"{str(prop)}\n" for prop in mandatory_properties)
+
+        if optional_properties := self.optional_properties:
+            class_text += "«optional»\n"
+            class_text += "".join(f"{str(prop)}\n" for prop in optional_properties)
+
         class_text += "}"
         return class_text
+
+    @property
+    def optional_properties(self) -> list[MermaidProperty]:
+        return [prop for prop in self.properties if not prop.cardinality]
+
+    @property
+    def mandatory_properties(self) -> list[MermaidProperty]:
+        return [prop for prop in self.properties if prop.cardinality]
 
 
 @dataclass
 class MermaidProperty:
     name: str
-    access: Access | None = None
+    visibility: Visibility | str = None
     type: str | None = None
     cardinality: bool | None = None
     multiplicity: str | None = None
 
-    ACCESS_MAPPING = {Access.open: "+", Access.public: "#", Access.protected: "~", Access.private: "-"}
+    VISIBILITY_MAPPING = {
+        Visibility.public: "+",
+        Visibility.package: "~",
+        Visibility.protected: "#",
+        Visibility.private: "-",
+    }
 
     def __str__(self):
         property_string = self.name
 
-        if self.access is not None:
-            access = self.ACCESS_MAPPING[self.access]
-            property_string = f"{access} {property_string}"
+        if self.visibility is not None:
+            visibility = self.VISIBILITY_MAPPING[self.visibility]
+            property_string = f"{visibility} {property_string}"
 
         if self.type is not None:
             property_string = f"{property_string} : {self.type}"
@@ -116,144 +200,147 @@ class MermaidRelationship:
         if self.direction == RelationshipDirection.FORWARD:
             if self.type == RelationshipType.ASSOCIATION:
                 arrow = "-->"
-            if self.type == RelationshipType.DEPENDENCY:
+            elif self.type == RelationshipType.DEPENDENCY:
                 arrow = "..>"
-            if self.type == RelationshipType.INHERITANCE:
+            elif self.type == RelationshipType.INHERITANCE:
                 arrow = "--|>"
+            else:
+                raise ValueError("Unknown relationship type.")
         else:
             if self.type == RelationshipType.ASSOCIATION:
                 arrow = "<--"
-            if self.type == RelationshipType.DEPENDENCY:
+            elif self.type == RelationshipType.DEPENDENCY:
                 arrow = "<.."
-            if self.type == RelationshipType.INHERITANCE:
+            elif self.type == RelationshipType.INHERITANCE:
                 arrow = "<|--"
+            else:
+                raise ValueError("Unknown relationship type.")
 
         if self.cardinality or self.multiplicity:
             cardinality_multiplicity = f' "[{int(self.cardinality)}..{self.multiplicity}]"'
         else:
             cardinality_multiplicity = ""
 
-        relationship_text = f"{self.node1} {arrow}{cardinality_multiplicity} {self.node2}"
+        relationship_text = f"`{self.node1}` {arrow}{cardinality_multiplicity} `{self.node2}`"
         if self.label:
             relationship_text += f" : {self.label}"
+            relationship_text += "<br/>«mandatory»" if self.cardinality else "<br/>«optional»"
 
         return relationship_text
 
 
-def write_mermaid_manifest(context: Context, output: str, manifest: InlineManifest):
-    mermaids = []
+def write_mermaid_manifest(context: Context, output: str, manifest: InlineManifest, main_dataset: str | None = None):
+    mermaid = MermaidClassDiagram()
+    concept_definition = MermaidClassDef(name=CONCEPT_NAME, styles=CONCEPT_STYLES)
+    entity_definition = MermaidClassDef(name=ENTITY_NAME, styles=ENTITY_STYLES)
 
-    for dataset_name, dataset in manifest.get_objects()["dataset"].items():
-        mermaid = MermaidClassDiagram(title=dataset_name)
+    models = manifest.get_objects()["model"]
+    for model in models.values():
+        dataset_name = model.external.dataset.name
+        namespace_name = dataset_name if dataset_name != main_dataset else None
+        namespace = mermaid.add_namespace(namespace_name)
 
-        models = manifest.get_objects()["model"]
-        for model in models.values():
-            model_dataset_name = model.external.dataset.name
-            if model_dataset_name == dataset_name:
-                mermaid_class = MermaidClass(name=model.basename)
-                for model_property in model.get_given_properties().values():
-                    if model_property.enum:
-                        enum_class = MermaidClass(
-                            name=f"{model.basename}{to_model_name(model_property.name)}", is_enum=True
-                        )
-                        for enum_property in model_property.enum:
-                            enum_property = MermaidProperty(name=enum_property.strip('"'))
-                            enum_class.add_property(enum_property)
-                        mermaid.add_class(enum_class)
+        mermaid_class = MermaidClass(name=model.name, label=model.basename, definition=entity_definition)
+        for model_property in model.get_given_properties().values():
+            if model_property.enum:
+                enum_class = MermaidClass(
+                    name=f"{model.name}{to_model_name(model_property.name)}",
+                    label=to_model_name(model_property.name),
+                    definition=concept_definition,
+                    is_enum=True,
+                )
+                for enum_property in model_property.enum:
+                    mermaid_property = MermaidProperty(name=enum_property.strip('"'))
+                    enum_class.add_property(mermaid_property)
+                namespace.add_class(enum_class)
+                mermaid.add_relationship(
+                    MermaidRelationship(
+                        node1=mermaid_class.name,
+                        node2=enum_class.name,
+                        cardinality=True,
+                        multiplicity="1",
+                        type=RelationshipType.DEPENDENCY,
+                        label=model_property.name,
+                    )
+                )
+
+            elif isinstance(model_property.dtype, Ref) or isinstance(model_property.dtype, BackRef):
+                multiplicity = "1"
+                mermaid.add_relationship(
+                    MermaidRelationship(
+                        node1=mermaid_class.name,
+                        node2=model_property.dtype.model.name,
+                        cardinality=model_property.dtype.required,
+                        multiplicity=multiplicity,
+                        type=RelationshipType.ASSOCIATION,
+                        label=model_property.name,
+                    )
+                )
+
+            # If it's a property that already is in a `base` model, we don't add it
+            elif isinstance(model_property.dtype, Inherit):
+                continue
+
+            elif isinstance(model_property.dtype, PartialArray) or isinstance(model_property.dtype, ArrayBackRef):
+                multiplicity = "*"
+
+                if hasattr(model_property.dtype, "items"):
+                    if hasattr(model_property.dtype.items.dtype, "model"):
                         mermaid.add_relationship(
                             MermaidRelationship(
                                 node1=mermaid_class.name,
-                                node2=enum_class.name,
-                                cardinality=True,
-                                multiplicity="1",
-                                type=RelationshipType.DEPENDENCY,
-                                label=model_property.name,
-                            )
-                        )
-
-                    elif isinstance(model_property.dtype, Ref) or isinstance(model_property.dtype, BackRef):
-                        multiplicity = "1"
-                        mermaid.add_relationship(
-                            MermaidRelationship(
-                                node1=mermaid_class.name,
-                                node2=model_property.dtype.model.basename,
-                                cardinality=model_property.dtype.required,
+                                node2=model_property.dtype.items.dtype.model.name,
+                                cardinality=model_property.dtype.items.dtype.required,
                                 multiplicity=multiplicity,
                                 type=RelationshipType.ASSOCIATION,
                                 label=model_property.name,
                             )
                         )
-
-                    # If it's a property that already is in a `base` model, we don't add it
-                    elif isinstance(model_property.dtype, Inherit):
-                        continue
-
-                    elif isinstance(model_property.dtype, PartialArray) or isinstance(
-                        model_property.dtype, ArrayBackRef
-                    ):
-                        multiplicity = "*"
-
-                        if hasattr(model_property.dtype, "items"):
-                            if hasattr(model_property.dtype.items.dtype, "model"):
-                                mermaid.add_relationship(
-                                    MermaidRelationship(
-                                        node1=mermaid_class.name,
-                                        node2=model_property.dtype.items.dtype.model.basename,
-                                        cardinality=model_property.dtype.items.dtype.required,
-                                        multiplicity=multiplicity,
-                                        type=RelationshipType.ASSOCIATION,
-                                        label=model_property.name,
-                                    )
-                                )
-                            else:
-                                mermaid_property = MermaidProperty(
-                                    name=model_property.name,
-                                    access=model_property.access,
-                                    type=model_property.dtype.items.dtype.name,
-                                    cardinality=model_property.dtype.items.dtype.required,
-                                    multiplicity=multiplicity,
-                                )
-                                mermaid_class.add_property(mermaid_property)
-                        else:
-                            mermaid_property = MermaidProperty(
-                                name=model_property.name,
-                                access=model_property.access,
-                                type=model_property.dtype.name,
-                                cardinality=model_property.dtype.required,
-                                multiplicity=multiplicity,
-                            )
-                            mermaid_class.add_property(mermaid_property)
-
                     else:
-                        multiplicity = "1"
-
                         mermaid_property = MermaidProperty(
                             name=model_property.name,
-                            access=model_property.access,
-                            type=model_property.dtype.name,
-                            cardinality=model_property.dtype.required,
+                            visibility=model_property.dtype.items.visibility,
+                            type=model_property.dtype.items.dtype.name,
+                            cardinality=model_property.dtype.items.dtype.required,
                             multiplicity=multiplicity,
                         )
                         mermaid_class.add_property(mermaid_property)
-
-                mermaid.add_class(mermaid_class)
-
-                if model.base:
-                    labels = []
-                    for pk_property in model.base.pk:
-                        labels.append(pk_property.name)
-                    label = ", ".join(labels)
-                    mermaid.add_relationship(
-                        MermaidRelationship(
-                            node1=mermaid_class.name,
-                            node2=model.base.basename,
-                            type=RelationshipType.INHERITANCE,
-                            label=label,
-                        )
+                else:
+                    mermaid_property = MermaidProperty(
+                        name=model_property.name,
+                        visibility=model_property.visibility,
+                        type=model_property.dtype.name,
+                        cardinality=model_property.dtype.required,
+                        multiplicity=multiplicity,
                     )
+                    mermaid_class.add_property(mermaid_property)
 
-        mermaids.append(mermaid)
+            else:
+                multiplicity = "1"
+
+                mermaid_property = MermaidProperty(
+                    name=model_property.name,
+                    visibility=model_property.visibility,
+                    type=model_property.dtype.name,
+                    cardinality=model_property.dtype.required,
+                    multiplicity=multiplicity,
+                )
+                mermaid_class.add_property(mermaid_property)
+
+        namespace.add_class(mermaid_class)
+
+        if model.base:
+            label = ", ".join(pk.name for pk in model.base.pk)
+            mermaid.add_relationship(
+                MermaidRelationship(
+                    node1=mermaid_class.name,
+                    node2=model.base.parent.name,
+                    type=RelationshipType.INHERITANCE,
+                    label=label,
+                )
+            )
+
+    mermaid.collect_definitions()
 
     with open(output, "w") as file:
-        for mermaid in mermaids:
-            file.write(str(mermaid))
+        file.write(str(mermaid))

--- a/spinta/manifests/mermaid/helpers.py
+++ b/spinta/manifests/mermaid/helpers.py
@@ -3,116 +3,177 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass
 
-from spinta.components import Context
+from spinta.components import Context, Property, Model
 from spinta.core.enums import Visibility
 from spinta.manifests.yaml.components import InlineManifest
-from spinta.types.datatype import Ref, BackRef, ArrayBackRef, Inherit, PartialArray
+from spinta.types.datatype import Ref, BackRef, ArrayBackRef, Inherit, Array
 from spinta.utils.naming import to_model_name
 
-
-CONCEPT_STYLES = "stroke:#8FB58F,fill:#F0FDF0,color:#000000"
-ENTITY_STYLES = "stroke:#9D8787,fill:#F5E8DF,color:#000000"
-
-CONCEPT_NAME = "Concept"
-ENTITY_NAME = "Entity"
 
 MERMAID_CONFIG = """---
 config:
   theme: base
   themeVariables:
-    mainBkg: '#ffffff00' 
+    mainBkg: '#ffffff00'
     clusterBkg: '#ffffde'
 ---
 """
 
 
+class MermaidClassDef(enum.Enum):
+    Concept = "stroke:#8FB58F,fill:#F0FDF0,color:#000000"
+    Entity = "stroke:#9D8787,fill:#F5E8DF,color:#000000"
+
+    def __str__(self) -> str:
+        return f"classDef {self.name} {self.value};"
+
+
 class MermaidClassDiagram:
     namespaces: dict[str | None, MermaidNameSpace]
-    relationships: list[MermaidRelationship]
-    definitions: set[MermaidClassDef]
+    relationships: set[MermaidRelationship]
 
     def __init__(self) -> None:
         self.namespaces = {}
-        self.relationships = []
-        self.definitions = set()
+        self.relationships = set()
 
     def __str__(self) -> str:
         text = f"{MERMAID_CONFIG}\n"
         text += "classDiagram\n"
 
         for namespace in self.namespaces.values():
-            text += f"{str(namespace)}\n"
+            text += f"{namespace}\n"
 
-        for relationship in self.relationships:
+        for relationship in sorted(self.relationships, key=lambda r: (r.node1, r.node2)):
             text += f"{str(relationship)}\n"
 
-        for definition in sorted(self.definitions, key=lambda d: d.name):
-            text += f"{str(definition)}\n"
+        for definition in MermaidClassDef:
+            text += f"{definition}\n"
 
         return text
 
-    def add_namespace(self, name: str | None) -> MermaidNameSpace:
+    def get_namespace(self, name: str | None) -> MermaidNameSpace:
         if name not in self.namespaces:
-            self.namespaces[name] = MermaidNameSpace(name)
+            self.namespaces[name] = MermaidNameSpace(self, name)
         return self.namespaces[name]
 
     def add_relationship(self, relationship: MermaidRelationship) -> None:
-        self.relationships.append(relationship)
-
-    def collect_definitions(self) -> None:
-        self.definitions = {cls.definition for namespace in self.namespaces.values() for cls in namespace.classes}
+        self.relationships.add(relationship)
 
 
 class MermaidNameSpace:
+    mermaid: MermaidClassDiagram
     name: str | None
-    classes: list[MermaidClass]
+    classes: dict[str, MermaidClass]
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(self, mermaid: MermaidClassDiagram, name: str | None = None) -> None:
         self.name = name
-        self.classes = []
+        self.mermaid = mermaid
+        self.classes = {}
 
     def __str__(self) -> str:
         text = f"namespace `{self.name}` {{\n" if self.name else ""
-        for mermaid_class in self.classes:
-            text += f"{str(mermaid_class)}\n"
+        for mermaid_class in self.classes.values():
+            text += f"{mermaid_class}\n"
         text += "}" if self.name else ""
         return text
 
-    def add_class(self, mermaid_class: MermaidClass) -> None:
-        self.classes.append(mermaid_class)
+    def get_or_create_class(self, name: str, **kwargs) -> MermaidClass:
+        if name not in self.classes:
+            self.classes[name] = MermaidClass(name=name, **kwargs)
+        return self.classes[name]
 
+    def process_property(self, model: Model, prop: Property, update: bool = True) -> None:
+        mermaid_class = self.get_or_create_class(name=model.name, label=model.basename)
+        if prop.enum:
+            enum_class = self.get_or_create_class(
+                name=f"{model.name}{to_model_name(prop.name)}",
+                label=to_model_name(prop.name),
+                definition=MermaidClassDef.Concept,
+                is_enum=True,
+            )
 
-@dataclass(eq=False)
-class MermaidClassDef:
-    name: str
-    styles: str
+            self.mermaid.add_relationship(
+                MermaidRelationship(
+                    node1=model.name,
+                    node2=enum_class.name,
+                    required=prop.dtype.required,
+                    type=RelationshipType.DEPENDENCY,
+                    label=prop.name,
+                )
+            )
 
-    def __str__(self) -> str:
-        return f"classDef {self.name} {self.styles};"
+            for enum_property in prop.enum:
+                mermaid_property = MermaidProperty(name=enum_property.strip('"'))
+                enum_class.add_property(mermaid_property, update)
+        elif isinstance(prop.dtype, (Array, ArrayBackRef)):
+            if prop.dtype.items and isinstance(prop.dtype.items.dtype, (Ref, BackRef)):
+                self.mermaid.add_relationship(
+                    MermaidRelationship(
+                        node1=model.name,
+                        node2=prop.dtype.items.dtype.model.name,
+                        required=prop.dtype.required,
+                        many=True,
+                        type=RelationshipType.ASSOCIATION,
+                        label=prop.name,
+                    )
+                )
+                for nested_prop in prop.dtype.items.dtype.properties.values():
+                    self.process_property(prop.dtype.items.dtype.model, nested_prop, update=False)
+            else:
+                type_ = prop.dtype.items.dtype.name if prop.dtype.items else "?"
+                visibility = prop.dtype.items.visibility if prop.dtype.items else prop.visibility
+                mermaid_class.add_property(
+                    MermaidProperty(
+                        name=prop.name, visibility=visibility, type=type_, required=prop.dtype.required, many=True
+                    ),
+                    update,
+                )
 
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, MermaidClassDef) and self.name == other.name
+        elif isinstance(prop.dtype, (Ref, BackRef)):
+            self.mermaid.add_relationship(
+                MermaidRelationship(
+                    node1=model.name,
+                    node2=prop.dtype.model.name,
+                    required=prop.dtype.required,
+                    type=RelationshipType.ASSOCIATION,
+                    label=prop.name,
+                )
+            )
+            for nested_prop in prop.dtype.properties.values():
+                self.process_property(prop.dtype.model, nested_prop, update=False)
 
-    def __hash__(self) -> int:
-        return hash(self.name)
+        # If it's a property that already is in a `base` model, we don't add it
+        elif isinstance(prop.dtype, Inherit):
+            return
+
+        else:
+            mermaid_class.add_property(
+                MermaidProperty(
+                    name=prop.name, visibility=prop.visibility, type=prop.dtype.name, required=prop.dtype.required
+                ),
+                update,
+            )
 
 
 class MermaidClass:
     name: str
     label: str
     definition: MermaidClassDef
-    properties: list[MermaidProperty]
+    properties: dict[str, MermaidProperty]
     is_enum: bool
 
-    def __init__(self, name: str, label: str, definition: MermaidClassDef, is_enum: bool = False) -> None:
+    def __init__(
+        self, name: str, label: str, definition: MermaidClassDef = MermaidClassDef.Entity, is_enum: bool = False
+    ) -> None:
         self.name = name
         self.label = label
         self.definition = definition
-        self.properties = []
+        self.properties = {}
         self.is_enum = is_enum
 
-    def add_property(self, prop: MermaidProperty) -> None:
-        self.properties.append(prop)
+    def add_property(self, prop: MermaidProperty, update: bool = False) -> None:
+        if update or prop.name not in self.properties:
+            self.properties[prop.name] = prop
 
     def __str__(self) -> str:
         class_text = f'class `{self.name}`["{self.label}"]:::{self.definition.name}'
@@ -130,7 +191,7 @@ class MermaidClass:
             class_text += "".join(f"{str(prop)}\n" for prop in mandatory_properties)
 
         if optional_properties := self.optional_properties:
-            class_text += "«optional»\n"
+            class_text += "«optional»\n" if not self.is_enum else ""
             class_text += "".join(f"{str(prop)}\n" for prop in optional_properties)
 
         class_text += "}"
@@ -138,11 +199,11 @@ class MermaidClass:
 
     @property
     def optional_properties(self) -> list[MermaidProperty]:
-        return [prop for prop in self.properties if not prop.cardinality]
+        return [prop for prop in self.properties.values() if not prop.required]
 
     @property
     def mandatory_properties(self) -> list[MermaidProperty]:
-        return [prop for prop in self.properties if prop.cardinality]
+        return [prop for prop in self.properties.values() if prop.required]
 
 
 @dataclass
@@ -150,8 +211,8 @@ class MermaidProperty:
     name: str
     visibility: Visibility | None = None
     type: str | None = None
-    cardinality: bool | None = None
-    multiplicity: str | None = None
+    required: bool | None = None
+    many: bool = False
 
     VISIBILITY_MAPPING = {
         Visibility.public: "+",
@@ -161,17 +222,19 @@ class MermaidProperty:
     }
 
     def __str__(self) -> str:
-        property_string = self.name
+        property_string = ""
 
         if self.visibility is not None:
             visibility = self.VISIBILITY_MAPPING[self.visibility]
-            property_string = f"{visibility} {property_string}"
+            property_string += f"{visibility} "
+
+        property_string += self.name
 
         if self.type is not None:
             property_string = f"{property_string} : {self.type}"
 
-        if self.cardinality or self.multiplicity:
-            property_string = f"{property_string} [{int(self.cardinality) if self.cardinality is not None else ''}..{self.multiplicity if self.multiplicity is not None else ''}]"
+        if self.required is not None:
+            property_string = f"{property_string} [{int(self.required)}..{'*' if self.many else 1}]"
 
         return property_string
 
@@ -189,45 +252,39 @@ class RelationshipType(enum.Enum):
 
 @dataclass
 class MermaidRelationship:
+    _ARROWS = {
+        (RelationshipDirection.FORWARD, RelationshipType.ASSOCIATION): "-->",
+        (RelationshipDirection.FORWARD, RelationshipType.DEPENDENCY): "..>",
+        (RelationshipDirection.FORWARD, RelationshipType.INHERITANCE): "--|>",
+        (RelationshipDirection.BACKWARD, RelationshipType.ASSOCIATION): "<--",
+        (RelationshipDirection.BACKWARD, RelationshipType.DEPENDENCY): "<..",
+        (RelationshipDirection.BACKWARD, RelationshipType.INHERITANCE): "<|--",
+    }
     node1: str
     node2: str
     type: RelationshipType
     direction: RelationshipDirection = RelationshipDirection.FORWARD
-    cardinality: bool = False
-    multiplicity: str = ""
+    required: bool | None = None
+    many: bool = False
     label: str = ""
 
     def __str__(self) -> str:
-        if self.direction == RelationshipDirection.FORWARD:
-            if self.type == RelationshipType.ASSOCIATION:
-                arrow = "-->"
-            elif self.type == RelationshipType.DEPENDENCY:
-                arrow = "..>"
-            elif self.type == RelationshipType.INHERITANCE:
-                arrow = "--|>"
-            else:
-                raise ValueError("Unknown relationship type.")
-        else:
-            if self.type == RelationshipType.ASSOCIATION:
-                arrow = "<--"
-            elif self.type == RelationshipType.DEPENDENCY:
-                arrow = "<.."
-            elif self.type == RelationshipType.INHERITANCE:
-                arrow = "<|--"
-            else:
-                raise ValueError("Unknown relationship type.")
+        arrow = self._ARROWS[(self.direction, self.type)]
 
-        if self.cardinality or self.multiplicity:
-            cardinality_multiplicity = f' "[{int(self.cardinality)}..{self.multiplicity}]"'
+        if self.required is not None:
+            cardinality = f' "[{int(self.required)}..{"*" if self.many else 1}]"'
         else:
-            cardinality_multiplicity = ""
+            cardinality = ""
 
-        relationship_text = f"`{self.node1}` {arrow}{cardinality_multiplicity} `{self.node2}`"
+        relationship_text = f"`{self.node1}` {arrow}{cardinality} `{self.node2}`"
         if self.label:
             relationship_text += f" : {self.label}"
-            relationship_text += "<br/>«mandatory»" if self.cardinality else "<br/>«optional»"
+            relationship_text += "<br/>«mandatory»" if self.required else "<br/>«optional»"
 
         return relationship_text
+
+    def __hash__(self):
+        return hash((self.node1, self.node2))
 
 
 def write_mermaid_manifest(
@@ -242,116 +299,26 @@ def write_mermaid_manifest(
     Otherwise returns the diagram as a string.
     """
     mermaid = MermaidClassDiagram()
-    concept_definition = MermaidClassDef(name=CONCEPT_NAME, styles=CONCEPT_STYLES)
-    entity_definition = MermaidClassDef(name=ENTITY_NAME, styles=ENTITY_STYLES)
 
-    models = manifest.get_objects()["model"]
+    models: dict[str, Model] = manifest.get_objects()["model"]
     for model in models.values():
         dataset_name = model.external.dataset.name
         namespace_name = dataset_name if dataset_name != main_dataset else None
-        namespace = mermaid.add_namespace(namespace_name)
-
-        mermaid_class = MermaidClass(name=model.name, label=model.basename, definition=entity_definition)
-        for model_property in model.get_given_properties().values():
-            if model_property.enum:
-                enum_class = MermaidClass(
-                    name=f"{model.name}{to_model_name(model_property.name)}",
-                    label=to_model_name(model_property.name),
-                    definition=concept_definition,
-                    is_enum=True,
-                )
-                for enum_property in model_property.enum:
-                    mermaid_property = MermaidProperty(name=enum_property.strip('"'))
-                    enum_class.add_property(mermaid_property)
-                namespace.add_class(enum_class)
-                mermaid.add_relationship(
-                    MermaidRelationship(
-                        node1=mermaid_class.name,
-                        node2=enum_class.name,
-                        cardinality=True,
-                        multiplicity="1",
-                        type=RelationshipType.DEPENDENCY,
-                        label=model_property.name,
-                    )
-                )
-
-            elif isinstance(model_property.dtype, Ref) or isinstance(model_property.dtype, BackRef):
-                multiplicity = "1"
-                mermaid.add_relationship(
-                    MermaidRelationship(
-                        node1=mermaid_class.name,
-                        node2=model_property.dtype.model.name,
-                        cardinality=model_property.dtype.required,
-                        multiplicity=multiplicity,
-                        type=RelationshipType.ASSOCIATION,
-                        label=model_property.name,
-                    )
-                )
-
-            # If it's a property that already is in a `base` model, we don't add it
-            elif isinstance(model_property.dtype, Inherit):
-                continue
-
-            elif isinstance(model_property.dtype, PartialArray) or isinstance(model_property.dtype, ArrayBackRef):
-                multiplicity = "*"
-
-                if hasattr(model_property.dtype, "items"):
-                    if hasattr(model_property.dtype.items.dtype, "model"):
-                        mermaid.add_relationship(
-                            MermaidRelationship(
-                                node1=mermaid_class.name,
-                                node2=model_property.dtype.items.dtype.model.name,
-                                cardinality=model_property.dtype.items.dtype.required,
-                                multiplicity=multiplicity,
-                                type=RelationshipType.ASSOCIATION,
-                                label=model_property.name,
-                            )
-                        )
-                    else:
-                        mermaid_property = MermaidProperty(
-                            name=model_property.name,
-                            visibility=model_property.dtype.items.visibility,
-                            type=model_property.dtype.items.dtype.name,
-                            cardinality=model_property.dtype.items.dtype.required,
-                            multiplicity=multiplicity,
-                        )
-                        mermaid_class.add_property(mermaid_property)
-                else:
-                    mermaid_property = MermaidProperty(
-                        name=model_property.name,
-                        visibility=model_property.visibility,
-                        type=model_property.dtype.name,
-                        cardinality=model_property.dtype.required,
-                        multiplicity=multiplicity,
-                    )
-                    mermaid_class.add_property(mermaid_property)
-
-            else:
-                multiplicity = "1"
-
-                mermaid_property = MermaidProperty(
-                    name=model_property.name,
-                    visibility=model_property.visibility,
-                    type=model_property.dtype.name,
-                    cardinality=model_property.dtype.required,
-                    multiplicity=multiplicity,
-                )
-                mermaid_class.add_property(mermaid_property)
-
-        namespace.add_class(mermaid_class)
+        namespace = mermaid.get_namespace(namespace_name)
 
         if model.base:
             label = ", ".join(pk.name for pk in model.base.pk)
             mermaid.add_relationship(
                 MermaidRelationship(
-                    node1=mermaid_class.name,
+                    node1=model.name,
                     node2=model.base.parent.name,
                     type=RelationshipType.INHERITANCE,
                     label=label,
                 )
             )
 
-    mermaid.collect_definitions()
+        for model_property in model.get_given_properties().values():
+            namespace.process_property(model, model_property)
 
     if not output:
         return str(mermaid)

--- a/spinta/manifests/mermaid/helpers.py
+++ b/spinta/manifests/mermaid/helpers.py
@@ -231,8 +231,16 @@ class MermaidRelationship:
 
 
 def write_mermaid_manifest(
-    context: Context, output: str, manifest: InlineManifest, main_dataset: str | None = None
-) -> None:
+    context: Context,
+    manifest: InlineManifest,
+    main_dataset: str | None = None,
+    output: str | None = None,
+) -> str | None:
+    """Generate a Mermaid class diagram from the given manifest.
+
+    If `output` is specified, writes the diagram to that file and returns None.
+    Otherwise returns the diagram as a string.
+    """
     mermaid = MermaidClassDiagram()
     concept_definition = MermaidClassDef(name=CONCEPT_NAME, styles=CONCEPT_STYLES)
     entity_definition = MermaidClassDef(name=ENTITY_NAME, styles=ENTITY_STYLES)
@@ -344,6 +352,9 @@ def write_mermaid_manifest(
             )
 
     mermaid.collect_definitions()
+
+    if not output:
+        return str(mermaid)
 
     with open(output, "w") as file:
         file.write(str(mermaid))

--- a/tests/manifests/mermaid/test_mermaid.py
+++ b/tests/manifests/mermaid/test_mermaid.py
@@ -4,7 +4,7 @@ from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.tabular import create_tabular_manifest
 from spinta.cli.manifest import _read_and_return_manifest
 from spinta.manifests.mermaid.helpers import write_mermaid_manifest
-from spinta.manifests.mermaid.helpers import MERMAID_CONFIG, ENTITY_STYLES, CONCEPT_STYLES
+from spinta.manifests.mermaid.helpers import MERMAID_CONFIG, MermaidClassDef
 
 
 def test_copy_mmd(context: Context, rc, cli: SpintaCliRunner, tmp_path):
@@ -49,7 +49,8 @@ class `datasets/gov/example/Country`["Country"]:::Entity {{
 + name : string [0..1]
 }}
 }}
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -100,7 +101,8 @@ class `datasets/gov/example/Country`["Country"]:::Entity {{
 - population : integer [0..1]
 }}
 }}
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -147,7 +149,8 @@ class `datasets/gov/example/Country`["Country"]:::Entity {{
 + name : string [0..*]
 }}
 }}
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -191,23 +194,22 @@ def test_copy_mmd_enum(context: Context, rc, cli: SpintaCliRunner, tmp_path):
             == f"""{MERMAID_CONFIG}
 classDiagram
 namespace `datasets/gov/example` {{
-class `datasets/gov/example/CountryContinent`["Continent"]:::Concept {{
-<<enumeration>>
-«optional»
-Africa
-Asia
-Europe
-}}
 class `datasets/gov/example/Country`["Country"]:::Entity {{
 «mandatory»
 + id : integer [1..1]
 «optional»
 + name : string [0..1]
 }}
+class `datasets/gov/example/CountryContinent`["Continent"]:::Concept {{
+<<enumeration>>
+Africa
+Asia
+Europe
 }}
-`datasets/gov/example/Country` ..> "[1..1]" `datasets/gov/example/CountryContinent` : continent<br/>«mandatory»
-classDef Concept {CONCEPT_STYLES};
-classDef Entity {ENTITY_STYLES};
+}}
+`datasets/gov/example/Country` ..> "[0..1]" `datasets/gov/example/CountryContinent` : continent<br/>«optional»
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -265,7 +267,8 @@ name : string [0..1]
 }}
 }}
 `datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -323,7 +326,8 @@ name : string [0..1]
 }}
 }}
 `datasets/gov/example/City` --> "[1..1]" `datasets/gov/example/Country` : country<br/>«mandatory»
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -381,9 +385,10 @@ id : integer [1..1]
 name : string [0..1]
 }}
 }}
-`datasets/gov/example/Country` --> "[0..*]" `datasets/gov/example/City` : cities<br/>«optional»
 `datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
-classDef Entity {ENTITY_STYLES};
+`datasets/gov/example/Country` --> "[0..*]" `datasets/gov/example/City` : cities<br/>«optional»
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -441,9 +446,10 @@ id : integer [1..1]
 name : string [0..1]
 }}
 }}
-`datasets/gov/example/Country` --> "[0..1]" `datasets/gov/example/City` : capital<br/>«optional»
 `datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
-classDef Entity {ENTITY_STYLES};
+`datasets/gov/example/Country` --> "[0..1]" `datasets/gov/example/City` : capital<br/>«optional»
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -460,7 +466,7 @@ def test_copy_mmd_backref_required(context: Context, rc, cli: SpintaCliRunner, t
           |   |   | Country      |                  |           | salis       |         |
           |   |   |   | name     | string           |           | pavadinimas |         | public
           |   |   |   | id       | integer required |           | id          |         | public
-          |   |   |   | cities[] | backref required | City      |             |         | 
+          |   |   |   | cities   | backref required | City      |             |         | 
           |   |   | City         |                  |           | salis       |         |
           |   |   |   | name     | string           |           | pavadinimas |         | public
           |   |   |   | country  | ref              | Country   |             |         | 
@@ -501,9 +507,10 @@ class `datasets/gov/example/City`["City"]:::Entity {{
 + name : string [0..1]
 }}
 }}
-`datasets/gov/example/Country` --> "[1..*]" `datasets/gov/example/City` : cities<br/>«mandatory»
 `datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
-classDef Entity {ENTITY_STYLES};
+`datasets/gov/example/Country` --> "[1..1]" `datasets/gov/example/City` : cities<br/>«mandatory»
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -559,7 +566,8 @@ class `datasets/gov/example/City`["City"]:::Entity {{
 }}
 }}
 `datasets/gov/example/City` --|> `datasets/gov/example/Settlement`
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -615,7 +623,8 @@ class `datasets/gov/example/City`["City"]:::Entity {{
 }}
 }}
 `datasets/gov/example/City` --|> `datasets/gov/example/Settlement` : id<br/>«optional»
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -675,7 +684,8 @@ class `datasets/gov/example2/Country`["Country"]:::Entity {{
 + id : string [0..1]
 }}
 }}
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
         )
 
@@ -721,6 +731,63 @@ class `datasets/gov/example2/Country`["Country"]:::Entity {{
 + id : string [0..1]
 }}
 }}
-classDef Entity {ENTITY_STYLES};
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
+"""
+    )
+
+
+def test_write_mermaid_manifest_nested_properties(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+        d | r | b | m | property                      | type             | ref       | source      
+            datasets/gov/example                        |                  |           |             
+            | data                                      | sql              |           |             
+            |   |   | Country                           |                  |           | salis       
+            |   |   |   | name                          | string           |           | pavadinimas 
+            |   |   |   | id                            | integer required |           | id     
+            |   |   |   | continent                     | ref              | Continent |     
+            |   |   | City                              |                  |           | salis       
+            |   |   |   | id                            | integer required |           | id     
+            |   |   |   | name                          | string           |           | pavadinimas 
+            |   |   |   | country                       | ref              | Country   |
+            |   |   |   | country.size                  | integer          |           |   
+            |   |   |   | country.continent.population  | integer          |           |                  
+            |   |   | Continent                         |                  |           | salis       
+            |   |   |   | name                          | string           |           | pavadinimas    
+            """),
+    )
+    manifest = _read_and_return_manifest(context, [str(tmp_path / "manifest.csv")])
+    mermaid = write_mermaid_manifest(context, manifest, "datasets/gov/example")
+
+    assert (
+        mermaid
+        == f"""{MERMAID_CONFIG}
+classDiagram
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+size : integer [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/Continent`["Continent"]:::Entity {{
+«optional»
+population : integer [0..1]
+name : string [0..1]
+}}
+
+`datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
+`datasets/gov/example/Country` --> "[0..1]" `datasets/gov/example/Continent` : continent<br/>«optional»
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
 """
     )

--- a/tests/manifests/mermaid/test_mermaid.py
+++ b/tests/manifests/mermaid/test_mermaid.py
@@ -2,6 +2,7 @@ from spinta.components import Context
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.tabular import create_tabular_manifest
+from spinta.manifests.mermaid.helpers import MERMAID_CONFIG, ENTITY_STYLES, CONCEPT_STYLES
 
 
 def test_copy_mmd(context: Context, rc, cli: SpintaCliRunner, tmp_path):
@@ -9,13 +10,13 @@ def test_copy_mmd(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type            | ref       | source      | prepare | access
-        datasets/gov/example     |                 |           |             |         |
-          | data                 | sql             |           |             |         |
-                                 |                 |           |             |         |
-          |   |   | Country      |                 |           | salis       |         |
-          |   |   |   | name     | string          |           | pavadinimas |         | open
-          |   |   |   | id       | integer required|           | id          |         | open
+        d | r | b | m | property | type            | ref       | source       | visibility
+        datasets/gov/example     |                 |           |              | 
+          | data                 | sql             |           |              |
+                                 |                 |           |              |
+          |   |   | Country      |                 |           | salis        | 
+          |   |   |   | name     | string          |           | pavadinimas  | public
+          |   |   |   | id       | integer required|           | id           | public
         """),
     )
 
@@ -36,32 +37,35 @@ def test_copy_mmd(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
+«optional»
++ name : string [0..1]
+}}
+}}
+classDef Entity {ENTITY_STYLES};
 """
         )
 
 
-def test_copy_mmd_access(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+def test_copy_mmd_visibility(context: Context, rc, cli: SpintaCliRunner, tmp_path):
     create_tabular_manifest(
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property   | type            | ref       | source      | prepare | access
+        d | r | b | m | property   | type            | ref       | source      | prepare | visibility
         datasets/gov/example       |                 |           |             |         |
           | data                   | sql             |           |             |         |
                                    |                 |           |             |         |
           |   |   | Country        |                 |           | salis       |         |
-          |   |   |   | name       | string          |           | pavadinimas |         | open
-          |   |   |   | id         | integer required|           | id          |         | private
+          |   |   |   | name       | string          |           | pavadinimas |         | public
+          |   |   |   | id         | integer required|           | id          |         | package
           |   |   |   | continent  | string          |           | pavadinimas |         | protected
-          |   |   |   | population | integer         |           | id          |         | public
+          |   |   |   | population | integer         |           | id          |         | private
         """),
     )
 
@@ -82,16 +86,19 @@ def test_copy_mmd_access(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+~ id : integer [1..1]
+«optional»
 + name : string [0..1]
-- id : integer [1..1]
-~ continent : string [0..1]
-# population : integer [0..1]
-}
+# continent : string [0..1]
+- population : integer [0..1]
+}}
+}}
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -101,13 +108,13 @@ def test_copy_mmd_array(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type            | ref | source      | prepare | access
-        datasets/gov/example     |                 |     |             |         |
-          | data                 | sql             |     |             |         |
-                                 |                 |     |             |         |
-          |   |   | Country      |                 |     | salis       |         |
-          |   |   |   | name[]   | string          |     | pavadinimas |         | open
-          |   |   |   | id       | integer required|     | id          |         | open
+        d | r | b | m | property | type            | ref | source      | visibility
+        datasets/gov/example     |                 |     |             |
+          | data                 | sql             |     |             |
+                                 |                 |     |             |
+          |   |   | Country      |                 |     | salis       |
+          |   |   |   | name[]   | string          |     | pavadinimas | public
+          |   |   |   | id       | integer required|     | id          | public
         """),
     )
 
@@ -128,14 +135,17 @@ def test_copy_mmd_array(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..*]
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
+«optional»
++ name : string [0..*]
+}}
+}}
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -145,14 +155,14 @@ def test_copy_mmd_enum(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property  | type             | ref | source      | prepare  | access
+        d | r | b | m | property  | type             | ref | source      | prepare  | visibility
         datasets/gov/example      |                  |     |             |          |
           | data                  | sql              |     |             |          |
                                   |                  |     |             |          |
           |   |   | Country       |                  |     | salis       |          |
-          |   |   |   | name      | string           |     | pavadinimas |          | open
-          |   |   |   | id        | integer required |     | id          |          | open
-          |   |   |   | continent | string           |     |             |          | open
+          |   |   |   | name      | string           |     | pavadinimas |          | public
+          |   |   |   | id        | integer required |     | id          |          | public
+          |   |   |   | continent | string           |     |             |          |
           |   |   |   |           | enum             |     |             | "Africa" |
           |   |   |   |           |                  |     |             | "Asia"   |
           |   |   |   |           |                  |     |             | "Europe" |
@@ -176,21 +186,26 @@ def test_copy_mmd_enum(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class CountryContinent {
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/CountryContinent`["Continent"]:::Concept {{
 <<enumeration>>
+«optional»
 Africa
 Asia
 Europe
-}
-class Country {
-+ name : string [0..1]
+}}
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
-Country ..> "[1..1]" CountryContinent : continent
+«optional»
++ name : string [0..1]
+}}
+}}
+`datasets/gov/example/Country` ..> "[1..1]" `datasets/gov/example/CountryContinent` : continent<br/>«mandatory»
+classDef Concept {CONCEPT_STYLES};
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -200,17 +215,17 @@ def test_copy_mmd_ref(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref       | source      | prepare | access
-        datasets/gov/example     |                  |           |             |         |
-          | data                 | sql              |           |             |         |
-                                 |                  |           |             |         |
-          |   |   | Country      |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
-          |   |   | City         |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | country  | ref              | Country   |             |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
+        d | r | b | m | property | type             | ref       | source      
+        datasets/gov/example     |                  |           |             
+          | data                 | sql              |           |             
+                                 |                  |           |             
+          |   |   | Country      |                  |           | salis       
+          |   |   |   | name     | string           |           | pavadinimas 
+          |   |   |   | id       | integer required |           | id          
+          |   |   | City         |                  |           | salis       
+          |   |   |   | name     | string           |           | pavadinimas 
+          |   |   |   | country  | ref              | Country   |             
+          |   |   |   | id       | integer required |           | id          
         """),
     )
 
@@ -231,19 +246,24 @@ def test_copy_mmd_ref(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-class City {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-City --> "[0..1]" Country : country
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+}}
+`datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -253,17 +273,17 @@ def test_copy_mmd_ref_required(context: Context, rc, cli: SpintaCliRunner, tmp_p
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref     | source      | prepare | access
-        datasets/gov/example     |                  |         |             |         |
-          | data                 | sql              |         |             |         |
-                                 |                  |         |             |         |
-          |   |   | Country      |                  |         | salis       |         |
-          |   |   |   | name     | string           |         | pavadinimas |         | open
-          |   |   |   | id       | integer required |         | id          |         | open
-          |   |   | City         |                  |         | salis       |         |
-          |   |   |   | name     | string           |         | pavadinimas |         | open
-          |   |   |   | country  | ref required     | Country |             |         | open
-          |   |   |   | id       | integer required |         | id          |         | open
+        d | r | b | m | property | type             | ref     | source      
+        datasets/gov/example     |                  |         |             
+          | data                 | sql              |         |             
+                                 |                  |         |             
+          |   |   | Country      |                  |         | salis       
+          |   |   |   | name     | string           |         | pavadinimas 
+          |   |   |   | id       | integer required |         | id          
+          |   |   | City         |                  |         | salis       
+          |   |   |   | name     | string           |         | pavadinimas 
+          |   |   |   | country  | ref required     | Country |             
+          |   |   |   | id       | integer required |         | id          
         """),
     )
 
@@ -284,19 +304,24 @@ def test_copy_mmd_ref_required(context: Context, rc, cli: SpintaCliRunner, tmp_p
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-class City {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-City --> "[1..1]" Country : country
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+}}
+`datasets/gov/example/City` --> "[1..1]" `datasets/gov/example/Country` : country<br/>«mandatory»
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -306,18 +331,18 @@ def test_copy_mmd_backref(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref     | source      | prepare | access
-        datasets/gov/example     |                  |         |             |         |
-          | data                 | sql              |         |             |         |
-                                 |                  |         |             |         |
-          |   |   | Country      |                  |         | salis       |         |
-          |   |   |   | name     | string           |         | pavadinimas |         | open
-          |   |   |   | id       | integer required |         | id          |         | open
-          |   |   |   | cities[] | backref          | City    |             |         | open
-          |   |   | City         |                  |         | salis       |         |
-          |   |   |   | name     | string           |         | pavadinimas |         | open
-          |   |   |   | country  | ref              | Country |             |         | open
-          |   |   |   | id       | integer required |         | id          |         | open
+        d | r | b | m | property | type             | ref     | source      
+        datasets/gov/example     |                  |         |             
+          | data                 | sql              |         |             
+                                 |                  |         |             
+          |   |   | Country      |                  |         | salis       
+          |   |   |   | name     | string           |         | pavadinimas 
+          |   |   |   | id       | integer required |         | id          
+          |   |   |   | cities[] | backref          | City    |             
+          |   |   | City         |                  |         | salis       
+          |   |   |   | name     | string           |         | pavadinimas 
+          |   |   |   | country  | ref              | Country |             
+          |   |   |   | id       | integer required |         | id          
         """),
     )
 
@@ -338,20 +363,25 @@ def test_copy_mmd_backref(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-class City {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-Country --> "[0..*]" City : cities
-City --> "[0..1]" Country : country
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+}}
+`datasets/gov/example/Country` --> "[0..*]" `datasets/gov/example/City` : cities<br/>«optional»
+`datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -361,18 +391,18 @@ def test_copy_mmd_backref_not_array(context: Context, rc, cli: SpintaCliRunner, 
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref       | source      | prepare | access
-        datasets/gov/example     |                  |           |             |         |
-          | data                 | sql              |           |             |         |
-                                 |                  |           |             |         |
-          |   |   | Country      |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
-          |   |   |   | capital  | backref          | City      |             |         | open
-          |   |   | City         |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | country  | ref              | Country   |             |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
+        d | r | b | m | property | type             | ref       | source      
+        datasets/gov/example     |                  |           |             
+          | data                 | sql              |           |             
+                                 |                  |           |             
+          |   |   | Country      |                  |           | salis       
+          |   |   |   | name     | string           |           | pavadinimas 
+          |   |   |   | id       | integer required |           | id          
+          |   |   |   | capital  | backref          | City      |             
+          |   |   | City         |                  |           | salis       
+          |   |   |   | name     | string           |           | pavadinimas 
+          |   |   |   | country  | ref              | Country   |             
+          |   |   |   | id       | integer required |           | id          
         """),
     )
 
@@ -393,20 +423,25 @@ def test_copy_mmd_backref_not_array(context: Context, rc, cli: SpintaCliRunner, 
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-class City {
-+ name : string [0..1]
-+ id : integer [1..1]
-}
-Country --> "[0..1]" City : capital
-City --> "[0..1]" Country : country
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
+id : integer [1..1]
+«optional»
+name : string [0..1]
+}}
+}}
+`datasets/gov/example/Country` --> "[0..1]" `datasets/gov/example/City` : capital<br/>«optional»
+`datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -416,18 +451,18 @@ def test_copy_mmd_backref_required(context: Context, rc, cli: SpintaCliRunner, t
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref       | source      | prepare | access
+        d | r | b | m | property | type             | ref       | source      | prepare | visibility
         datasets/gov/example     |                  |           |             |         |
           | data                 | sql              |           |             |         |
                                  |                  |           |             |         |
           |   |   | Country      |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
-          |   |   |   | cities[] | backref required | City      |             |         | open
+          |   |   |   | name     | string           |           | pavadinimas |         | public
+          |   |   |   | id       | integer required |           | id          |         | public
+          |   |   |   | cities[] | backref required | City      |             |         | 
           |   |   | City         |                  |           | salis       |         |
-          |   |   |   | name     | string           |           | pavadinimas |         | open
-          |   |   |   | country  | ref              | Country   |             |         | open
-          |   |   |   | id       | integer required |           | id          |         | open
+          |   |   |   | name     | string           |           | pavadinimas |         | public
+          |   |   |   | country  | ref              | Country   |             |         | 
+          |   |   |   | id       | integer required |           | id          |         | public
         """),
     )
 
@@ -448,20 +483,25 @@ def test_copy_mmd_backref_required(context: Context, rc, cli: SpintaCliRunner, t
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Country {
-+ name : string [0..1]
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
-class City {
+«optional»
 + name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
-Country --> "[1..*]" City : cities
-City --> "[0..1]" Country : country
+«optional»
++ name : string [0..1]
+}}
+}}
+`datasets/gov/example/Country` --> "[1..*]" `datasets/gov/example/City` : cities<br/>«mandatory»
+`datasets/gov/example/City` --> "[0..1]" `datasets/gov/example/Country` : country<br/>«optional»
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -471,17 +511,17 @@ def test_copy_mmd_base(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref       | source      | prepare | access
+        d | r | b | m | property | type             | ref       | source      | prepare | visibility
         datasets/gov/example     |                  |           |             |         |
           | data                 | sql              |           |             |         |
           |   |   | Settlement   |                  |           |             |         |
-          |   |   |   | name     | string           |           |             |         | open
-          |   |   |   | id       | integer required |           |             |         | open
+          |   |   |   | name     | string           |           |             |         | public
+          |   |   |   | id       | integer required |           |             |         | public
           |   | Settlement       |                  |           |             |         |
           |   |   | City         |                  |           | miestas     |         |
-          |   |   |   | name     |                  |           | pavadinimas |         | open
-          |   |   |   | id       |                  |           | id          |         | open                   
-          |   |   |   | council  | string           |           | taryba      |         | open
+          |   |   |   | name     |                  |           | pavadinimas |         | public
+          |   |   |   | id       |                  |           | id          |         | public                   
+          |   |   |   | council  | string           |           | taryba      |         | public
         """),
     )
 
@@ -502,18 +542,22 @@ def test_copy_mmd_base(context: Context, rc, cli: SpintaCliRunner, tmp_path):
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Settlement {
-+ name : string [0..1]
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Settlement`["Settlement"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
-class City {
+«optional»
++ name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«optional»
 + council : string [0..1]
-}
-City --|> Settlement
+}}
+}}
+`datasets/gov/example/City` --|> `datasets/gov/example/Settlement`
+classDef Entity {ENTITY_STYLES};
 """
         )
 
@@ -523,17 +567,17 @@ def test_copy_mmd_base_ref(context: Context, rc, cli: SpintaCliRunner, tmp_path)
         context,
         tmp_path / "manifest.csv",
         striptable("""
-        d | r | b | m | property | type             | ref       | source      | prepare | access
+        d | r | b | m | property | type             | ref       | source      | prepare | visibility
         datasets/gov/example     |                  |           |             |         |
           | data                 | sql              |           |             |         |
           |   |   | Settlement   |                  | id        |             |         |
-          |   |   |   | name     | string           |           |             |         | open
-          |   |   |   | id       | integer required |           |             |         | open
+          |   |   |   | name     | string           |           |             |         | public
+          |   |   |   | id       | integer required |           |             |         | public
           |   | Settlement       |                  | id        |             |         |
           |   |   | City         |                  |           | miestas     |         |
-          |   |   |   | name     |                  |           | pavadinimas |         | open
-          |   |   |   | id       |                  |           | id          |         | open                   
-          |   |   |   | council  | string           |           | taryba      |         | open
+          |   |   |   | name     |                  |           | pavadinimas |         | public
+          |   |   |   | id       |                  |           | id          |         | public                   
+          |   |   |   | council  | string           |           | taryba      |         | public
         """),
     )
 
@@ -554,17 +598,81 @@ def test_copy_mmd_base_ref(context: Context, rc, cli: SpintaCliRunner, tmp_path)
         contents = file.read()
         assert (
             contents
-            == """---
-datasets/gov/example
----
+            == f"""{MERMAID_CONFIG}
 classDiagram
-class Settlement {
-+ name : string [0..1]
+namespace `datasets/gov/example` {{
+class `datasets/gov/example/Settlement`["Settlement"]:::Entity {{
+«mandatory»
 + id : integer [1..1]
-}
-class City {
+«optional»
++ name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity {{
+«optional»
 + council : string [0..1]
-}
-City --|> Settlement : id
+}}
+}}
+`datasets/gov/example/City` --|> `datasets/gov/example/Settlement` : id<br/>«optional»
+classDef Entity {ENTITY_STYLES};
+"""
+        )
+
+
+def test_copy_with_two_datasets_and_main_specified(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+        d | r | b | m | property | type             | ref       | source      | prepare | visibility
+        datasets/gov/example     |                  |           |             |         |
+          | data                 | sql              |           |             |         |
+          |   |   | City         |                  |           | miestas     |         |
+          |   |   |   | name     | string           |           | pavadinimas |         | public
+          |   |   |   | id       | string           |           | id          |         | public                   
+          |   |   |   | council  | string           |           | taryba      |         | public
+        datasets/gov/example2    |                  |           |             |         |
+          | data                 | sql              |           |             |         |
+          |   |   | Country      |                  |           | miestas     |         |
+          |   |   |   | name     | string           |           | pavadinimas |         | public
+          |   |   |   | id       | string           |           | id          |         | public                   
+        """),
+    )
+
+    cli.invoke(
+        rc,
+        [
+            "copy",
+            "--no-source",
+            "--access",
+            "open",
+            "-d",
+            "datasets/gov/example",
+            "-o",
+            tmp_path / "result.mmd",
+            tmp_path / "manifest.csv",
+        ],
+    )
+
+    with open(tmp_path / "result.mmd", "r") as file:
+        contents = file.read()
+        assert (
+            contents
+            == f"""{MERMAID_CONFIG}
+classDiagram
+class `datasets/gov/example/City`["City"]:::Entity {{
+«optional»
++ name : string [0..1]
++ id : string [0..1]
++ council : string [0..1]
+}}
+
+namespace `datasets/gov/example2` {{
+class `datasets/gov/example2/Country`["Country"]:::Entity {{
+«optional»
++ name : string [0..1]
++ id : string [0..1]
+}}
+}}
+classDef Entity {ENTITY_STYLES};
 """
         )

--- a/tests/manifests/mermaid/test_mermaid.py
+++ b/tests/manifests/mermaid/test_mermaid.py
@@ -2,6 +2,8 @@ from spinta.components import Context
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.tabular import create_tabular_manifest
+from spinta.cli.manifest import _read_and_return_manifest
+from spinta.manifests.mermaid.helpers import write_mermaid_manifest
 from spinta.manifests.mermaid.helpers import MERMAID_CONFIG, ENTITY_STYLES, CONCEPT_STYLES
 
 
@@ -676,3 +678,49 @@ class `datasets/gov/example2/Country`["Country"]:::Entity {{
 classDef Entity {ENTITY_STYLES};
 """
         )
+
+
+def test_write_mermaid_manifest_output_as_string(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+        d | r | b | m | property | type             | ref       | source      | prepare | visibility
+        datasets/gov/example     |                  |           |             |         |
+          | data                 | sql              |           |             |         |
+          |   |   | City         |                  |           | miestas     |         |
+          |   |   |   | name     | string required  |           | pavadinimas |         | public
+          |   |   |   | id       | string           |           | id          |         | public                   
+          |   |   |   | council  | string           |           | taryba      |         | public
+        datasets/gov/example2    |                  |           |             |         |
+          | data                 | sql              |           |             |         |
+          |   |   | Country      |                  |           | miestas     |         |
+          |   |   |   | name     | string           |           | pavadinimas |         | public
+          |   |   |   | id       | string           |           | id          |         | public                   
+        """),
+    )
+    manifest = _read_and_return_manifest(context, [str(tmp_path / "manifest.csv")])
+    mermaid = write_mermaid_manifest(context, manifest, "datasets/gov/example")
+
+    assert (
+        mermaid
+        == f"""{MERMAID_CONFIG}
+classDiagram
+class `datasets/gov/example/City`["City"]:::Entity {{
+«mandatory»
++ name : string [1..1]
+«optional»
++ id : string [0..1]
++ council : string [0..1]
+}}
+
+namespace `datasets/gov/example2` {{
+class `datasets/gov/example2/Country`["Country"]:::Entity {{
+«optional»
++ name : string [0..1]
++ id : string [0..1]
+}}
+}}
+classDef Entity {ENTITY_STYLES};
+"""
+    )

--- a/tests/manifests/mermaid/test_mermaid.py
+++ b/tests/manifests/mermaid/test_mermaid.py
@@ -791,3 +791,35 @@ classDef Concept {MermaidClassDef.Concept.value};
 classDef Entity {MermaidClassDef.Entity.value};
 """
     )
+
+
+def test_write_mermaid_manifest_model_without_properties(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+        d | r | b | m | property                      | type             | ref       | source      
+          datasets/gov/example                        |                  |           |             
+          | data                                      |                  |           |             
+          |   |   | Country                           |                  |           | salis       
+          |   |   |   | name                          | string           |           | pavadinimas 
+          |   |   | City                              |                  |           | salis       
+        """),
+    )
+    manifest = _read_and_return_manifest(context, [str(tmp_path / "manifest.csv")])
+    mermaid = write_mermaid_manifest(context, manifest, "datasets/gov/example")
+
+    assert (
+        mermaid
+        == f"""{MERMAID_CONFIG}
+classDiagram
+class `datasets/gov/example/Country`["Country"]:::Entity {{
+«optional»
+name : string [0..1]
+}}
+class `datasets/gov/example/City`["City"]:::Entity
+
+classDef Concept {MermaidClassDef.Concept.value};
+classDef Entity {MermaidClassDef.Entity.value};
+"""
+    )


### PR DESCRIPTION
Updated mermaid creationg logic:

- Added new `-d` argument for spinta copy to pass dataset name that is considered `main`, which is needed for mermaid diagram.
- Added diagram styling based on mermaid documentation.
- Introduced `namespaces`, a special mermaid wrapper, to group classes. In UML it is used to visualy group external (non main) datasets' models.
- Added stereotypes for class properties grouping and relationships. Displays wether property or relation is <<mandatory>> or <<optional>>.
- Updated visibility to actually use `node.visibility` (instead of `node.access`)
- Updated `output` to be optional argument. Based on this diagram can be returned as a string instead of written to file. This will be used when generating diagrams for katalogas.
- Added recursive logic to include dot notated properties to diagram
- Other small code improvements.