### PR TITLE
Admin command for cooperative backends

### DIFF
--- a/spinta/cli/admin.py
+++ b/spinta/cli/admin.py
@@ -30,6 +30,7 @@ def admin(
         """
         ),
     ),
+    manifests: Optional[List[str]] = Option(None, help=("Source manifest files for scripts that need them")),
     ensure_config_dir: bool = Option(True, "--ensure-config", help=("Ensures that all config files are created.")),
     force: bool = Option(False, "-f", "--force", help=("Skips all checks when running scripts.")),
     destructive: bool = Option(
@@ -54,7 +55,7 @@ def admin(
         "-i",
         "--input",
         help="Path to input file (some scripts might require extra data). If not given, script will read from stdin.",
-    ),
+    ),  # TODO: should always use manifests parameter and not input_path
     output_path: Optional[pathlib.Path] = Option(
         None,
         "-o",
@@ -90,5 +91,6 @@ def admin(
             check_only=check_only,
             input_path=input_path,
             output_path=output_path,
+            manifests=manifests,
             status_cache=status_cache,
         )

--- a/spinta/cli/admin.py
+++ b/spinta/cli/admin.py
@@ -55,7 +55,7 @@ def admin(
         "-i",
         "--input",
         help="Path to input file (some scripts might require extra data). If not given, script will read from stdin.",
-    ),  # TODO: should always use manifests parameter and not input_path
+    ),
     output_path: Optional[pathlib.Path] = Option(
         None,
         "-o",

--- a/spinta/cli/helpers/admin/components.py
+++ b/spinta/cli/helpers/admin/components.py
@@ -17,3 +17,5 @@ class Script(enum.Enum):
     CHANGELOG = "changelog"
     ENUM_LIST = "enum_list"
     CITUS_DISTRIBUTION = "citus_distribution"
+    ADD_LOCAL_IDS = "add_local_ids"
+    REMOVE_LOCAL_IDS = "remove_local_ids"

--- a/spinta/cli/helpers/admin/registry.py
+++ b/spinta/cli/helpers/admin/registry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from spinta.cli.helpers.admin.components import AdminScript, Script, ADMIN_SCRIPT_TYPE
+from spinta.cli.helpers.admin.scripts.add_local_ids import add_local_ids
 from spinta.cli.helpers.admin.scripts.changelog import migrate_changelog_duplicates, cli_requires_changelog_migrations
 from spinta.cli.helpers.admin.scripts.citus_shard import migrate_citus_distributions, cli_requires_citus_distribution
 from spinta.cli.helpers.admin.scripts.deduplicate import migrate_duplicates, cli_requires_deduplicate_migrations
 from spinta.cli.helpers.admin.scripts.enums import gather_invalid_enum_values
+from spinta.cli.helpers.admin.scripts.remove_local_ids import remove_local_ids
 from spinta.cli.helpers.script.components import ScriptTarget, ScriptTag
 from spinta.cli.helpers.script.registry import script_registry
 from spinta.cli.helpers.upgrade.components import Script as UpgradeScript, UPGRADE_SCRIPT_TYPE
@@ -43,3 +45,5 @@ script_registry.register(
         targets={ScriptTarget.BACKEND.value},
     )
 )
+script_registry.register(AdminScript(name=Script.ADD_LOCAL_IDS.value, run=add_local_ids, required=[]))
+script_registry.register(AdminScript(name=Script.REMOVE_LOCAL_IDS.value, run=remove_local_ids, required=[]))

--- a/spinta/cli/helpers/admin/scripts/add_local_ids.py
+++ b/spinta/cli/helpers/admin/scripts/add_local_ids.py
@@ -1,0 +1,80 @@
+import pathlib
+from copy import copy
+from typing import List
+
+from click import echo
+
+from spinta import commands
+from spinta.cli.helpers.manifest import convert_str_to_manifest_path
+from spinta.cli.helpers.message import cli_error
+from spinta.cli.helpers.store import load_manifest
+from spinta.components import Context
+from spinta.core.context import configure_context
+from spinta.manifests.tabular.helpers import write_tabular_manifest
+from spinta.types.datatype import Base32, String
+
+RESERVED_MODEL_PREFIX = "_"
+
+
+def add_explicit_id_properties(context: Context, manifest: str, verbose: bool = True) -> int:
+    count_of_ids = 0
+    for model in commands.get_models(context, manifest).values():
+        if model.model_type().startswith(RESERVED_MODEL_PREFIX):
+            continue
+        if not model.external or model.external.unknown_primary_key:
+            if verbose:
+                echo(f'Model "{model.model_type()}" has no `ref`, skipping.', err=True)
+            continue
+        prop = model.properties.get("_id")
+        if prop is None or prop.explicitly_given:
+            continue
+
+        pkeys = model.external.pkeys
+        composite = len(pkeys) > 1
+        pkey_dtype = pkeys[0].dtype
+        old_backend = prop.dtype.backend
+
+        prop.explicitly_given = True
+        prop.given.explicit = True
+        if composite or isinstance(pkey_dtype, String):
+            new_dtype = Base32()
+            new_dtype.name = "base32"
+            new_dtype.type = "base32"
+            new_dtype.type_args = []
+            new_dtype.unique = False
+            new_dtype.required = False
+            new_dtype.prop = prop
+            new_dtype.backend = old_backend
+        else:
+            new_dtype = copy(pkey_dtype)
+            new_dtype.prop = prop
+            new_dtype.type_args = list(pkey_dtype.type_args or [])
+            new_dtype.backend = old_backend
+        prop.dtype = new_dtype
+        count_of_ids += 1
+    return count_of_ids
+
+
+def add_local_ids(
+    context: Context,
+    manifests: List[str] | None = None,
+    output_path: pathlib.Path | None = None,
+    **kwargs,
+) -> None:
+    if not manifests:
+        cli_error("`add_local_ids` requires at least one source manifest path.")
+
+    manifest_paths = convert_str_to_manifest_path(list(manifests))
+    context = configure_context(context, manifest_paths)
+    store = load_manifest(context, verbose=False, full_load=True)
+    manifest = store.manifest
+
+    count_of_ids = add_explicit_id_properties(context, manifest)
+
+    output = output_path or pathlib.Path(manifests[0])
+    if count_of_ids == 0:
+        echo(f'No `_id` rows to add in "{output}".')
+        return
+
+    write_tabular_manifest(context, str(output), manifest)
+    echo(f'Added {count_of_ids} `_id` row(s) to "{output}".')

--- a/spinta/cli/helpers/admin/scripts/remove_local_ids.py
+++ b/spinta/cli/helpers/admin/scripts/remove_local_ids.py
@@ -1,0 +1,55 @@
+import pathlib
+from typing import List
+
+from click import echo
+
+from spinta import commands
+from spinta.cli.helpers.manifest import convert_str_to_manifest_path
+from spinta.cli.helpers.message import cli_error
+from spinta.cli.helpers.store import load_manifest
+from spinta.components import Context
+from spinta.core.context import configure_context
+from spinta.manifests.tabular.helpers import write_tabular_manifest
+
+
+RESERVED_MODEL_PREFIX = "_"
+
+
+def remove_explicit_id_properties(context: Context, manifest: str) -> int:
+    count_of_ids = 0
+    for model in commands.get_models(context, manifest).values():
+        if model.model_type().startswith(RESERVED_MODEL_PREFIX):
+            continue
+        prop = model.properties.get("_id")
+        if prop is None or not prop.explicitly_given:
+            continue
+
+        prop.explicitly_given = False
+        prop.given.explicit = False
+        count_of_ids += 1
+    return count_of_ids
+
+
+def remove_local_ids(
+    context: Context,
+    manifests: List[str] | None = None,
+    output_path: pathlib.Path | None = None,
+    **kwargs,
+) -> None:
+    if not manifests:
+        cli_error("`remove_local_ids` requires at least one source manifest path.")
+
+    manifest_paths = convert_str_to_manifest_path(list(manifests))
+    context = configure_context(context, manifest_paths)
+    store = load_manifest(context, verbose=False, full_load=True)
+    manifest = store.manifest
+
+    count_of_ids = remove_explicit_id_properties(context, manifest)
+
+    output = output_path or pathlib.Path(manifests[0])
+    if count_of_ids == 0:
+        echo(f'No `_id` rows to remove in "{output}".')
+        return
+
+    write_tabular_manifest(context, str(output), manifest)
+    echo(f'Removed {count_of_ids} `_id` row(s) from "{output}".')

--- a/spinta/cli/inspect.py
+++ b/spinta/cli/inspect.py
@@ -7,6 +7,7 @@ from typer import Option
 from typer import echo
 
 from spinta import commands
+from spinta.cli.helpers.admin.scripts.add_local_ids import add_explicit_id_properties
 from spinta.cli.helpers.manifest import convert_str_to_manifest_path
 from spinta.datasets.inspect.helpers import create_manifest_from_inspect
 from spinta.manifests.tabular.helpers import render_tabular_manifest
@@ -44,6 +45,8 @@ def inspect(
         auth=auth,
         priority=priority,
     )
+
+    add_explicit_id_properties(context, manifest, verbose=False)
 
     if output:
         output_type = output.split(".")[-1]

--- a/tests/cli/admin/test_add_local_ids.py
+++ b/tests/cli/admin/test_add_local_ids.py
@@ -1,0 +1,245 @@
+from pathlib import Path
+
+import pytest
+
+from spinta import commands
+from spinta.cli.helpers.admin.components import Script
+from spinta.cli.helpers.admin.scripts.add_local_ids import (
+    add_explicit_id_properties,
+)
+from spinta.components import Context
+from spinta.core.config import RawConfig
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.cli import SpintaCliRunner
+from spinta.testing.manifest import load_manifest, load_manifest_and_context
+from spinta.testing.tabular import convert_ascii_manifest_to_csv
+from spinta.types.datatype import Base32, String, Integer, UUID
+
+
+@pytest.mark.parametrize(
+    "pkey_type, expected_id_type, expected_required",
+    [
+        ("integer", Integer, False),
+        ("string", Base32, False),
+        ("uuid", UUID, False),
+        ("integer required", Integer, True),
+        ("string required", Base32, False),
+        ("uuid required", UUID, True),
+    ],
+)
+def test_add_local_ids_inserts_id_with_pkey_type(
+    rc: RawConfig, pkey_type: str, expected_id_type: str, expected_required: bool
+):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            f"""
+        d | r | b | m | property | type        | ref  | access
+        ds/local_ids              |             |      |
+          |   |   | Country       |             | code |
+          |   |   |   | code      | {pkey_type} |      | open
+          |   |   |   | name      | string      |      | open
+        """
+        ),
+    )
+
+    count_of_id = add_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 1
+    prop = commands.get_model(context, manifest, "ds/local_ids/Country").properties["_id"]
+    assert prop.explicitly_given is True
+    assert isinstance(prop.dtype, expected_id_type)
+    assert prop.dtype.required is expected_required
+
+
+def test_add_local_ids_inserts_base32_for_composite_pkey(rc: RawConfig):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            """
+        d | r | b | m | property | type    | ref        | access
+        ds/local_ids              |         |            |
+          |   |   | Country       |         | code, year |
+          |   |   |   | code      | string  |            | open
+          |   |   |   | year      | integer |            | open
+        """
+        ),
+    )
+
+    count_of_id = add_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 1
+    prop = commands.get_model(context, manifest, "ds/local_ids/Country").properties["_id"]
+    assert prop.explicitly_given is True
+    assert isinstance(prop.dtype, Base32)
+
+
+def test_add_local_ids_skips_model_without_ref(rc: RawConfig, capsys: pytest.CaptureFixture):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            """
+        d | r | b | m | property | type   | ref | access
+        ds/local_ids              |        |     |
+          |   |   | Country       |        |     |
+          |   |   |   | code      | string |     | open
+        """
+        ),
+    )
+
+    count_of_id = add_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 0
+    err = capsys.readouterr().err
+    assert 'Model "ds/local_ids/Country" has no `ref`, skipping.' in err
+
+
+def test_add_local_ids_skips_model_with_existing_id(rc: RawConfig):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            """
+        d | r | b | m | property | type   | ref  | access
+        ds/local_ids              |        |      |
+          |   |   | Country       |        | code |
+          |   |   |   | _id       | string |      | open
+          |   |   |   | code      | string |      | open
+        """
+        ),
+    )
+
+    count_of_id = add_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 0
+    prop = commands.get_model(context, manifest, "ds/local_ids/Country").properties["_id"]
+    assert prop.explicitly_given is True
+    assert isinstance(prop.dtype, String)
+
+
+def test_add_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRunner):
+    result = cli.invoke(
+        context.get("rc"),
+        ["admin", Script.ADD_LOCAL_IDS.value],
+        fail=False,
+    )
+    assert result.exit_code == 1
+    assert "`add_local_ids` requires at least one source manifest path." in result.stderr
+
+
+def test_add_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "a.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type   | ref  | access
+    ds/a                      |        |      |
+      |   |   | Alpha         |        | code |
+      |   |   |   | code      | string |      | open
+    """)
+        )
+    )
+    (tmp_path / "b.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type | ref  | access
+    ds/b                      |      |      |
+      |   |   | Beta          |      | id   |
+      |   |   |   | id        | uuid |      | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "admin",
+            Script.ADD_LOCAL_IDS.value,
+            "--manifests",
+            str(tmp_path / "a.csv"),
+            "--manifests",
+            str(tmp_path / "b.csv"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Added 2 `_id` row(s)" in result.output
+
+    manifest = load_manifest(rc, tmp_path / "a.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property  | type   | ref  | access
+    ds/a                      |        |      |
+                              |        |      |
+      |   |   | Alpha         |        | code |
+      |   |   |   | _id       | base32 |      |
+      |   |   |   | code      | string |      | open
+    ds/b                      |        |      |
+                              |        |      |
+      |   |   | Beta          |        | id   |
+      |   |   |   | _id       | uuid   |      |
+      |   |   |   | id        | uuid   |      | open
+    """
+    )
+
+
+def test_add_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "manifest.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type | ref | access
+    ds/local_ids              |      |     |
+      |   |   | Country       |      | id  |
+      |   |   |   | id        | uuid |     | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "admin",
+            Script.ADD_LOCAL_IDS.value,
+            "--manifests",
+            str(tmp_path / "manifest.csv"),
+            "-o",
+            str(tmp_path / "output.csv"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Added 1 `_id` row(s)" in result.output
+
+    manifest = load_manifest(rc, tmp_path / "output.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property  | type | ref | access
+    ds/local_ids              |      |     |
+                              |      |     |
+      |   |   | Country       |      | id  |
+      |   |   |   | _id       | uuid |     |
+      |   |   |   | id        | uuid |     | open
+    """
+    )
+
+
+def test_add_local_ids_cli_nothing_to_add(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "manifest.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type   | ref  | access
+    ds/local_ids              |        |      |
+      |   |   | Country       |        | code |
+      |   |   |   | _id       | base32 |      | open
+      |   |   |   | code      | string |      | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        ["admin", Script.ADD_LOCAL_IDS.value, "--manifests", str(tmp_path / "manifest.csv")],
+    )
+
+    assert result.exit_code == 0
+    assert "No `_id` rows to add" in result.output

--- a/tests/cli/admin/test_add_local_ids.py
+++ b/tests/cli/admin/test_add_local_ids.py
@@ -12,7 +12,7 @@ from spinta.core.config import RawConfig
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.manifest import load_manifest, load_manifest_and_context
-from spinta.testing.tabular import convert_ascii_manifest_to_csv
+from spinta.testing.tabular import create_tabular_manifest
 from spinta.types.datatype import Base32, String, Integer, UUID
 
 
@@ -126,26 +126,26 @@ def test_add_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRunner
     assert "`add_local_ids` requires at least one source manifest path." in result.stderr
 
 
-def test_add_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "a.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_add_local_ids_cli_multiple_files_writes_to_first(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "a.csv",
+        striptable("""
     d | r | b | m | property  | type   | ref  | access
     ds/a                      |        |      |
       |   |   | Alpha         |        | code |
       |   |   |   | code      | string |      | open
-    """)
-        )
+    """),
     )
-    (tmp_path / "b.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+    create_tabular_manifest(
+        context,
+        tmp_path / "b.csv",
+        striptable("""
     d | r | b | m | property  | type | ref  | access
     ds/b                      |      |      |
       |   |   | Beta          |      | id   |
       |   |   |   | id        | uuid |      | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(
@@ -182,16 +182,16 @@ def test_add_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli: Sp
     )
 
 
-def test_add_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "manifest.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_add_local_ids_cli_with_output_file(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
     d | r | b | m | property  | type | ref | access
     ds/local_ids              |      |     |
       |   |   | Country       |      | id  |
       |   |   |   | id        | uuid |     | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(
@@ -223,17 +223,17 @@ def test_add_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunner,
     )
 
 
-def test_add_local_ids_cli_nothing_to_add(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "manifest.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_add_local_ids_cli_nothing_to_add(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
     d | r | b | m | property  | type   | ref  | access
     ds/local_ids              |        |      |
       |   |   | Country       |        | code |
       |   |   |   | _id       | base32 |      | open
       |   |   |   | code      | string |      | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(

--- a/tests/cli/admin/test_add_local_ids.py
+++ b/tests/cli/admin/test_add_local_ids.py
@@ -126,7 +126,9 @@ def test_add_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRunner
     assert "`add_local_ids` requires at least one source manifest path." in result.stderr
 
 
-def test_add_local_ids_cli_multiple_files_writes_to_first(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+def test_add_local_ids_cli_multiple_files_writes_to_first(
+    context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path
+):
     create_tabular_manifest(
         context,
         tmp_path / "a.csv",

--- a/tests/cli/admin/test_remove_local_ids.py
+++ b/tests/cli/admin/test_remove_local_ids.py
@@ -12,7 +12,7 @@ from spinta.core.config import RawConfig
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.manifest import load_manifest, load_manifest_and_context
-from spinta.testing.tabular import convert_ascii_manifest_to_csv
+from spinta.testing.tabular import create_tabular_manifest
 
 
 def test_remove_local_ids_removes_explicit_id(rc: RawConfig):
@@ -89,28 +89,28 @@ def test_remove_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRun
     assert "`remove_local_ids` requires at least one source manifest path." in result.stderr
 
 
-def test_remove_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "a.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_remove_local_ids_cli_multiple_files_writes_to_first(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "a.csv",
+        striptable("""
     d | r | b | m | property  | type   | ref  | access
     ds/a                      |        |      |
       |   |   | Alpha         |        | code |
       |   |   |   | _id       | base32 |      |
       |   |   |   | code      | string |      | open
-    """)
-        )
+    """),
     )
-    (tmp_path / "b.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+    create_tabular_manifest(
+        context,
+        tmp_path / "b.csv",
+        striptable("""
     d | r | b | m | property  | type | ref | access
     ds/b                      |      |     |
       |   |   | Beta          |      | id  |
       |   |   |   | _id       | uuid |     |
       |   |   |   | id        | uuid |     | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(
@@ -145,17 +145,17 @@ def test_remove_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli:
     )
 
 
-def test_remove_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "manifest.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_remove_local_ids_cli_with_output_file(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
     d | r | b | m | property  | type   | ref  | access
     ds/local_ids              |        |      |
       |   |   | Country       |        | code |
       |   |   |   | _id       | base32 |      |
       |   |   |   | code      | string |      | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(
@@ -186,17 +186,17 @@ def test_remove_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunn
     )
 
 
-def test_remove_local_ids_cli_nothing_to_remove(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
-    (tmp_path / "manifest.csv").write_bytes(
-        convert_ascii_manifest_to_csv(
-            striptable("""
+def test_remove_local_ids_cli_nothing_to_remove(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
     d | r | b | m | property  | type   | ref  | access
     ds/local_ids              |        |      |
                               |        |      |
       |   |   | Country       |        | code |
       |   |   |   | code      | string |      | open
-    """)
-        )
+    """),
     )
 
     result = cli.invoke(

--- a/tests/cli/admin/test_remove_local_ids.py
+++ b/tests/cli/admin/test_remove_local_ids.py
@@ -89,7 +89,9 @@ def test_remove_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRun
     assert "`remove_local_ids` requires at least one source manifest path." in result.stderr
 
 
-def test_remove_local_ids_cli_multiple_files_writes_to_first(context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+def test_remove_local_ids_cli_multiple_files_writes_to_first(
+    context: Context, rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path
+):
     create_tabular_manifest(
         context,
         tmp_path / "a.csv",

--- a/tests/cli/admin/test_remove_local_ids.py
+++ b/tests/cli/admin/test_remove_local_ids.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+
+import pytest
+
+from spinta import commands
+from spinta.cli.helpers.admin.components import Script
+from spinta.cli.helpers.admin.scripts.remove_local_ids import (
+    remove_explicit_id_properties,
+)
+from spinta.components import Context
+from spinta.core.config import RawConfig
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.cli import SpintaCliRunner
+from spinta.testing.manifest import load_manifest, load_manifest_and_context
+from spinta.testing.tabular import convert_ascii_manifest_to_csv
+
+
+def test_remove_local_ids_removes_explicit_id(rc: RawConfig):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            """
+        d | r | b | m | property  | type   | ref  | access
+        ds/local_ids              |        |      |
+          |   |   | Country       |        | code |
+          |   |   |   | _id       | base32 |      | open
+          |   |   |   | code      | string |      | open
+        """
+        ),
+    )
+
+    count_of_id = remove_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 1
+    prop = commands.get_model(context, manifest, "ds/local_ids/Country").properties["_id"]
+    assert prop.explicitly_given is False
+
+
+def test_remove_local_ids_skips_model_without_explicit_id(rc: RawConfig):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            """
+        d | r | b | m | property  | type   | ref  | access
+        ds/local_ids              |        |      |
+          |   |   | Country       |        | code |
+          |   |   |   | code      | string |      | open
+        """
+        ),
+    )
+
+    count_of_id = remove_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 0
+
+
+@pytest.mark.parametrize(
+    "id_type",
+    ["integer", "base32", "uuid"],
+)
+def test_remove_local_ids_removes_explicit_id_of_any_type(rc: RawConfig, id_type: str):
+    context, manifest = load_manifest_and_context(
+        rc,
+        striptable(
+            f"""
+        d | r | b | m | property  | type      | ref  | access
+        ds/local_ids              |           |      |
+          |   |   | Country       |           | code |
+          |   |   |   | _id       | {id_type} |      |
+          |   |   |   | code      | {id_type} |      | open
+        """
+        ),
+    )
+
+    count_of_id = remove_explicit_id_properties(context, manifest)
+
+    assert count_of_id == 1
+    prop = commands.get_model(context, manifest, "ds/local_ids/Country").properties["_id"]
+    assert prop.explicitly_given is False
+
+
+def test_remove_local_ids_no_manifest_errors(context: Context, cli: SpintaCliRunner):
+    result = cli.invoke(
+        context.get("rc"),
+        ["admin", Script.REMOVE_LOCAL_IDS.value],
+        fail=False,
+    )
+    assert result.exit_code == 1
+    assert "`remove_local_ids` requires at least one source manifest path." in result.stderr
+
+
+def test_remove_local_ids_cli_multiple_files_writes_to_first(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "a.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type   | ref  | access
+    ds/a                      |        |      |
+      |   |   | Alpha         |        | code |
+      |   |   |   | _id       | base32 |      |
+      |   |   |   | code      | string |      | open
+    """)
+        )
+    )
+    (tmp_path / "b.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type | ref | access
+    ds/b                      |      |     |
+      |   |   | Beta          |      | id  |
+      |   |   |   | _id       | uuid |     |
+      |   |   |   | id        | uuid |     | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "admin",
+            Script.REMOVE_LOCAL_IDS.value,
+            "--manifests",
+            str(tmp_path / "a.csv"),
+            "--manifests",
+            str(tmp_path / "b.csv"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Removed 2 `_id` row(s)" in result.output
+
+    manifest = load_manifest(rc, tmp_path / "a.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property  | type   | ref  | access
+    ds/a                      |        |      |
+                              |        |      |
+      |   |   | Alpha         |        | code |
+      |   |   |   | code      | string |      | open
+    ds/b                      |        |      |
+                              |        |      |
+      |   |   | Beta          |        | id   |
+      |   |   |   | id        | uuid   |      | open
+    """
+    )
+
+
+def test_remove_local_ids_cli_with_output_file(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "manifest.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type   | ref  | access
+    ds/local_ids              |        |      |
+      |   |   | Country       |        | code |
+      |   |   |   | _id       | base32 |      |
+      |   |   |   | code      | string |      | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        [
+            "admin",
+            Script.REMOVE_LOCAL_IDS.value,
+            "--manifests",
+            str(tmp_path / "manifest.csv"),
+            "-o",
+            str(tmp_path / "output.csv"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Removed 1 `_id` row(s)" in result.output
+
+    manifest = load_manifest(rc, tmp_path / "output.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | m | property  | type   | ref  | access
+    ds/local_ids              |        |      |
+                              |        |      |
+      |   |   | Country       |        | code |
+      |   |   |   | code      | string |      | open
+    """
+    )
+
+
+def test_remove_local_ids_cli_nothing_to_remove(rc: RawConfig, cli: SpintaCliRunner, tmp_path: Path):
+    (tmp_path / "manifest.csv").write_bytes(
+        convert_ascii_manifest_to_csv(
+            striptable("""
+    d | r | b | m | property  | type   | ref  | access
+    ds/local_ids              |        |      |
+                              |        |      |
+      |   |   | Country       |        | code |
+      |   |   |   | code      | string |      | open
+    """)
+        )
+    )
+
+    result = cli.invoke(
+        rc,
+        ["admin", Script.REMOVE_LOCAL_IDS.value, "--manifests", str(tmp_path / "manifest.csv")],
+    )
+
+    assert result.exit_code == 0
+    assert "No `_id` rows to remove" in result.output

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -126,6 +126,7 @@ def test_inspect(
       |   |   |   | name       | string  |         | NAME       |
                                |         |         |            |
       |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | _id        | integer |         |            |
       |   |   |   | code       | string  |         | CODE       |
       |   |   |   | id         | integer |         | ID         |
       |   |   |   | name       | string  |         | NAME       |
@@ -182,6 +183,7 @@ def test_inspect_from_manifest_table(
       | resource1             | sql     |     | sqlite  |
                               |         |     |         |
       |   |   | Country       |         | id  | COUNTRY |
+      |   |   |   | _id       | integer |     |         |
       |   |   |   | id        | integer |     | ID      |
       |   |   |   | name      | string  |     | NAME    |
     """
@@ -235,6 +237,7 @@ def test_inspect_format(
       |   |   |   | name       | string  |         | NAME       |
                                |         |         |            |
       |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | _id        | integer |         |            |
       |   |   |   | code       | string  |         | CODE       |
       |   |   |   | id         | integer |         | ID         |
       |   |   |   | name       | string  |         | NAME       |
@@ -289,11 +292,13 @@ def test_inspect_cyclic_refs(
       | resource1              | sql     |         | sqlite     |
                                |         |         |            |
       |   |   | City           |         | id      | CITY       |
+      |   |   |   | _id        | integer |         |            |
       |   |   |   | country_id | ref     | Country | COUNTRY_ID |
       |   |   |   | id         | integer |         | ID         |
       |   |   |   | name       | string  |         | NAME       |
                                |         |         |            |
       |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | _id        | integer |         |            |
       |   |   |   | capital    | ref     | City    | CAPITAL    |
       |   |   |   | id         | integer |         | ID         |
       |   |   |   | name       | string  |         | NAME       |
@@ -341,6 +346,7 @@ def test_inspect_self_refs(
       | resource1             | sql     |          | sqlite    |
                               |         |          |           |
       |   |   | Category      |         | id       | CATEGORY  |
+      |   |   |   | _id       | integer |          |           |
       |   |   |   | id        | integer |          | ID        |
       |   |   |   | name      | string  |          | NAME      |
       |   |   |   | parent_id | ref     | Category | PARENT_ID |
@@ -507,6 +513,7 @@ def test_inspect_with_schema(
       | schema               | sql     |     | sqlite | connect(self, schema: null)
                              |         |     |        |
       |   |   | City         |         | id  | CITY   |
+      |   |   |   | _id      | integer |     |        |
       |   |   |   | id       | integer |     | ID     |
       |   |   |   | name     | string  |     | NAME   |
     """,
@@ -574,11 +581,13 @@ def test_inspect_update_existing_manifest(
       | schema               | sql     | sql     |         |         |         |
                              |         |         |         |         |         |
       |   |   | City         |         | id      | CITY    | id>1    |         | City
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         | private |
       |   |   |   | name     | string  |         | NAME    | strip() | open    | City name
       |   |   |   | country  | ref     | Country | COUNTRY |         |         |
                              |         |         |         |         |         |
       |   |   | Country      |         | id      | COUNTRY |         |         |
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         |         |
       |   |   |   | name     | string  |         | NAME    |         |         |
     """,
@@ -650,10 +659,12 @@ def test_inspect_update_existing_ref_manifest_priority(
       | schema               | sql     | sql     |         |         |         |
                              |         |         |         |         |         |
       |   |   | Country      |         | id      | COUNTRY |         |         | Country
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         | private | Primary key
       |   |   |   | name     | string  |         | NAME    |         | open    | Country name
                              |         |         |         |         |         |
       |   |   | City         |         | id      | CITY    | id>1    |         | City
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         | private |
       |   |   |   | name     | string  |         | NAME    | strip() | open    | City name
       |   |   |   | country  | integer |         | COUNTRY |         | open    | Country id
@@ -728,10 +739,12 @@ def test_inspect_update_existing_ref_external_priority(
       | schema               | sql     | sql     |         |         |         |
                              |         |         |         |         |         |
       |   |   | Country      |         | id      | COUNTRY |         |         | Country
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         | private | Primary key
       |   |   |   | name     | string  |         | NAME    |         | open    | Country name
                              |         |         |         |         |         |
       |   |   | City         |         | id      | CITY    | id>1    |         | City
+      |   |   |   | _id      | integer |         |         |         |         |
       |   |   |   | id       | integer |         | ID      |         | private |
       |   |   |   | name     | string  |         | NAME    | strip() | open    | City name
       |   |   |   | country  | ref     | Country | COUNTRY |         | open    | Country id
@@ -788,6 +801,7 @@ def test_inspect_with_empty_config_dir(
       | resource1            | sql     |     | sqlite
                              |         |     |
       |   |   | Country      |         | id  | COUNTRY
+      |   |   |   | _id      | integer |     |
       |   |   |   | id       | integer |     | ID
       |   |   |   | name     | string  |     | NAME
     """
@@ -944,6 +958,7 @@ def test_inspect_existing_duplicate_table_names(
          | schema           | sql     | sql |           |         |         |
                             |         |     |           |         |         |
          |   | Country      |         | id  |           |         |         | Country
+         |   |   | _id      | integer |     |           |         |         |
          |   |   | id       | integer |     |           |         | private | Primary key
          |   |   | name     | string  |     |           |         | open    | Country name
                             |         |     |           |         |         |
@@ -1362,6 +1377,7 @@ def test_inspect_multiple_resources_specific(
          |   |   | continent | ref     | Continent | CONTINENT  |         |         |
                              |         |           |            |         |         |
          |   | Continent     |         | id        | CONTINENT  |         |         |
+         |   |   | _id       | integer |           |            |         |         |
          |   |   | code      | string  |           | CODE       |         |         |
          |   |   | id        | integer |           | ID         |         |         |
          |   |   | name      | string  |           | NAME       |         |         |
@@ -1491,6 +1507,7 @@ def test_inspect_multiple_resources_advanced(
          | schema_1          | sql     |           | sqlite_new |         |         |
                              |         |           |            |         |         |
          |   | Continent     |         | id        | CONTINENT  |         |         |
+         |   |   | _id       | integer |           |            |         |         |
          |   |   | code      | string  |           | CODE       |         |         |
          |   |   | id        | integer |           | ID         |         |         |
          |   |   | name      | string  |           | NAME       |         |         |
@@ -1656,6 +1673,7 @@ def test_inspect_multiple_datasets_advanced_manifest_priority(
          |   |   | continent | ref     | Continent    | CONTINENT |         |         |
                              |         |              |           |         |         |
          |   | Continent     |         | id           | CONTINENT |         |         |
+         |   |   | _id       | integer |              |           |         |         |
          |   |   | code      | string  |              | CODE      |         |         |
          |   |   | id        | integer |              | ID        |         |         |
          |   |   | name      | string  |              | NAME      |         |         |
@@ -1667,6 +1685,7 @@ def test_inspect_multiple_datasets_advanced_manifest_priority(
          |   |   | continent | ref     | NewContinent | CONTINENT |         |         |
                              |         |              |           |         |         |
          |   | NewContinent  |         | new_id       | CONTINENT |         |         |
+         |   |   | _id       | base32  |              |           |         |         |
          |   |   | name      | string  |              |           |         |         |
          |   |   | new_id    | string  |              | ID        |         |         |
          |   |   | code      | string  |              | CODE      |         |         |
@@ -1750,6 +1769,7 @@ def test_inspect_multiple_datasets_advanced_external_priority(
          |   |   | continent | ref     | Continent    | CONTINENT |         |         |
                              |         |              |           |         |         |
          |   | Continent     |         | id           | CONTINENT |         |         |
+         |   |   | _id       | integer |              |           |         |         |
          |   |   | code      | string  |              | CODE      |         |         |
          |   |   | id        | integer |              | ID        |         |         |
          |   |   | name      | string  |              | NAME      |         |         |
@@ -1761,6 +1781,7 @@ def test_inspect_multiple_datasets_advanced_external_priority(
          |   |   | continent | ref     | NewContinent | CONTINENT |         |         |
                              |         |              |           |         |         |
          |   | NewContinent  |         | new_id       | CONTINENT |         |         |
+         |   |   | _id       | integer |              |           |         |         |
          |   |   | name      | string  |              |           |         |         |
          |   |   | new_id    | integer |              | ID        |         |         |
          |   |   | code      | string  |              | CODE      |         |         |
@@ -1841,6 +1862,7 @@ def test_inspect_multiple_datasets_different_resources(
          | schema            | sql     |           | sqlite     |         |         |
                              |         |           |            |         |         |
          |   | Continent     |         | id        | CONTINENT  |         |         |
+         |   |   | _id       | integer |           |            |         |         |
          |   |   | code      | string  |           | CODE       |         |         |
          |   |   | id        | integer |           | ID         |         |         |
          |   |   | name      | string  |           | NAME       |         |         |
@@ -1856,6 +1878,7 @@ def test_inspect_multiple_datasets_different_resources(
          |   |   | name      | string  |           | NAME       |         |         |
                              |         |           |            |         |         |
          |   | Engine        |         | id        | ENGINE     |         |         |
+         |   |   | _id       | integer |           |            |         |         |
          |   |   | code      | string  |           | CODE       |         |         |
          |   |   | id        | integer |           | ID         |         |         |
          |   |   | name      | string  |           | NAME       |         |         |
@@ -1946,6 +1969,7 @@ def test_inspect_multiple_datasets_different_resources_specific(
          | schema           | sql     |        | sqlite     |         |         |
                             |         |        |            |         |         |
          |   | NewContinent |         | id     | CONTINENT  |         |         |
+         |   |   | _id      | integer |        |            |         |         |
          |   |   | code     | string  |        | CODE       |         |         |
          |   |   | id       | integer |        | ID         |         |         |
          |   |   | name     | string  |        | NAME       |         |         |
@@ -1958,6 +1982,7 @@ def test_inspect_multiple_datasets_different_resources_specific(
          |   |   | engine   | ref     | Engine | ENGINE     |         |         |
                             |         |        |            |         |         |
          |   | Engine       |         | id     | ENGINE     |         |         |
+         |   |   | _id      | integer |        |            |         |         |
          |   |   | code     | string  |        | CODE       |         |         |
          |   |   | id       | integer |        | ID         |         |         |
          |   |   | name     | string  |        | NAME       |         |         |
@@ -2013,6 +2038,7 @@ def test_inspect_with_views(rc_new: RawConfig, cli: SpintaCliRunner, tmp_path: P
          | resource1         | sql     |           | sqlite     |         |         |
                              |         |           |            |         |         |
          |   | Continent     |         | id        | CONTINENT  |         |         |
+         |   |   | _id       | integer |           |            |         |         |
          |   |   | code      | string  |           | CODE       |         |         |
          |   |   | id        | integer |           | ID         |         |         |
          |   |   | name      | string  |           | NAME       |         |         |
@@ -2093,6 +2119,7 @@ def test_inspect_with_postgresql_cross_schema_foreign_key(
       | resource1           | sql     |                          | postgresql              |         |         |
                             |         |                          |                         |         |         |
       |   | Country         |         | country_id               | geography.country       |         |         |
+      |   |   | _id         | integer |                          |                         |         |         |
       |   |   | country_id  | integer |                          | country_id              |         |         |
       |   |   | iso_code    | string  |                          | iso_code                |         |         |
       |   |   | name        | string  |                          | name                    |         |         |
@@ -2100,6 +2127,7 @@ def test_inspect_with_postgresql_cross_schema_foreign_key(
       | resource1           | sql     |                          | postgresql              |         |         |
                             |         |                          |                         |         |         |
       |   | City            |         | city_id                  | urban.city              |         |         |
+      |   |   | _id         | integer |                          |                         |         |         |
       |   |   | city_id     | integer |                          | city_id                 |         |         |
       |   |   | country_id  | ref     | /db/geography/Country    | country_id              |         |         |
       |   |   | name        | string  |                          | name                    |         |         |
@@ -2236,6 +2264,7 @@ def test_inspect_json_model_ref_change(rc_new: RawConfig, cli: SpintaCliRunner, 
           | resource                    | dask/json              |      | resource.json
                                         |                        |      |
           |   | Pos                     |                        | code | .
+          |   |   | _id                 | base32                 |      |
           |   |   | name                | string required unique |      | name
           |   |   | code                | string required        |      | code
           |   |   | location_latitude   | number unique          |      | location.latitude
@@ -2325,6 +2354,7 @@ def test_inspect_xml_model_ref_change(rc: RawConfig, cli: SpintaCliRunner, tmp_p
           | resource                    | dask/xml               |         | resource.xml
                                         |                        |         |
           |   | Country                 |                        | code    | /countries/country
+          |   |   | _id                 | base32                 |         |
           |   |   | name                | string required unique |         | @name
           |   |   | code                | string required        |         | @code
           |   |   | location_latitude   | number unique          |         | location/@latitude
@@ -2474,6 +2504,7 @@ def test_inspect_with_postgresql_multi_schema_references(
           | resource1           | sql     |                              | postgresql      |         |         |
                                 |         |                              |                 |         |         |
           |   | Record          |         | id                           | finances.Record |         |         |
+          |   |   | _id         | integer |                              |                 |         |         |
           |   |   | client      | ref     | /inspect_schema/users/Client | client          |         |         |
           |   |   | id          | integer |                              | id              |         |         |
           |   |   | name        | string  |                              | name            |         |         |
@@ -2481,6 +2512,7 @@ def test_inspect_with_postgresql_multi_schema_references(
           | resource1           | sql     |                              | postgresql      |         |         |
                                 |         |                              |                 |         |         |
           |   | Client          |         | id                           | users.Client    |         |         |
+          |   |   | _id         | integer |                              |                 |         |         |
           |   |   | id          | integer |                              | id              |         |         |
           |   |   | name        | string  |                              | name            |         |         |
 """,
@@ -2651,6 +2683,7 @@ def test_inspect_blob_types(
        |   | resource1             | sql     |     | sqlite    |             |         |        |       |       |         |            |        |     |     |       |
        |                           |         |     |           |             |         |        |       |       |         |            |        |     |     |       |
        |   |   |   | Providers     |         | id  | PROVIDERS |             |         |        |       |       | develop | private    |        |     |     |       |
+       |   |   |   |   | _id       | integer |     |           |             |         |        |       |       | develop | private    |        |     |     |       |
        |   |   |   |   | document  | binary  |     | DOCUMENT  |             |         |        |       |       | develop | private    |        |     |     |       |
        |   |   |   |   | icon      | binary  |     | ICON      |             |         |        |       |       | develop | private    |        |     |     |       |
        |   |   |   |   | id        | integer |     | ID        |             |         |        |       |       | develop | private    |        |     |     |       |
@@ -2696,6 +2729,7 @@ def test_inspect_unrecognized_types_are_mapped_to_unknown(
       | resource1              | sql     |         | sqlite     |
                                |         |         |            |
       |   |   | Country        |         | id      | COUNTRY    |
+      |   |   |   | _id        | integer |         |            |
       |   |   |   | code       | string  |         | CODE       |
       |   |   |   | id         | integer |         | ID         |
       |   |   |   | name       | string  |         | NAME       |
@@ -2747,10 +2781,12 @@ def test_inspect_unknown_type_with_relations(
       | resource1               | sql     |          | sqlite      |
                                 |         |          |             |
       |   |   | Category        |         | id       | CATEGORY    |
+      |   |   |   | _id         | unknown |          |             |
       |   |   |   | id          | unknown |          | ID          |
       |   |   |   | name        | string  |          | NAME        |
                                 |         |          |             |
       |   |   | Country         |         | id       | COUNTRY     |
+      |   |   |   | _id         | integer |          |             |
       |   |   |   | category_id | ref     | Category | CATEGORY_ID |
       |   |   |   | id          | integer |          | ID          |
       |   |   |   | name        | string  |          | NAME        |


### PR DESCRIPTION
This PR adds a spinta admin command meant to add explicit _id properties to models, that do not have them. This way, the manifest becomes a cooperative manifest.

This PR also adds a spinta admin command meant to remove explicit _id properties to models, that have them. This way, the manifest stops being a cooperative manifest.

Usage:
spinta admin add_local_ids --manifests <manifest_path1> --manifests <manifest_path2>

spinta admin remove_local_ids --manifest <manifest_path1> --manifests <manifest_path2>

If a model has no ref value, that model is skipped with a message.
If a model already has an explicit _id value, that model is skipped.