### PR TITLE
1922: Adding ScopeLoader to update Env and pass it to ufuncs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,25 @@ Changes
 0.2dev25 (unreleased)
 =====================
 
+Improvements:
+
+- Added validation in `scope` dimension (`#1922`_):
+
+  - Added `ScopeLoader` class which loads on link and validates each scope's
+    `prepare` expression. It walks `bind` and `getattr` expressions,
+    resolves them against the manifest, and ensures every referenced property
+    actually exists.
+  - Bind/getattr resolution is implemented via `ufunc.resolver` overloads so
+    new expression shapes can be added without touching the loader.
+  - Invalid `prepare` expressions raise a clear `ModelNotFound` `PropertyNotFound`
+error pointing at the offending scope.
+
 Bug fixes:
 
 - Fixed a bug where nested backrefs where causing an error (`#1608`_).
 
 .. _#1608: https://github.com/atviriduomenys/spinta/issues/1608
+.. _#1922: https://github.com/atviriduomenys/spinta/issues/1922
 
 0.2dev24 (2026-05-08)
 =====================

--- a/spinta/dimensions/scope/components.py
+++ b/spinta/dimensions/scope/components.py
@@ -1,11 +1,8 @@
-from spinta.components import ExtraMetaData
+from spinta.components import ExtraMetaData, Model
 from spinta.core.enums import Access, Visibility, Status
 from spinta.core.ufuncs import Expr, Env
 from spinta.manifests.components import Manifest
-
-
-class ScopeLoader(Env):
-    manifest: Manifest
+from spinta.ufuncs.propertyresolver.components import PropertyResolver
 
 
 class ScopeGiven:
@@ -49,3 +46,17 @@ class Scope(ExtraMetaData):
 
     def __init__(self):
         self.given = ScopeGiven()
+
+
+class ScopeLoader(Env):
+    manifest: Manifest
+    model: Model
+    property_resolver: PropertyResolver | None
+
+    def resolve_property(self, *args, **kwargs):
+        resolver = self._scope.get("property_resolver")
+        if resolver is None:
+            resolver = PropertyResolver(self.context)
+            resolver = resolver.init(model=self.model, ufunc_types=False)
+            self.update(property_resolver=resolver)
+        return resolver.resolve_property(*args, **kwargs)

--- a/spinta/dimensions/scope/components.py
+++ b/spinta/dimensions/scope/components.py
@@ -1,6 +1,11 @@
 from spinta.components import ExtraMetaData
 from spinta.core.enums import Access, Visibility, Status
-from spinta.core.ufuncs import Expr
+from spinta.core.ufuncs import Expr, Env
+from spinta.manifests.components import Manifest
+
+
+class ScopeLoader(Env):
+    manifest: Manifest
 
 
 class ScopeGiven:

--- a/spinta/dimensions/scope/components.py
+++ b/spinta/dimensions/scope/components.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from spinta.components import ExtraMetaData, Model
 from spinta.core.enums import Access, Visibility, Status
 from spinta.core.ufuncs import Expr, Env
@@ -53,7 +55,7 @@ class ScopeLoader(Env):
     model: Model
     property_resolver: PropertyResolver | None
 
-    def resolve_property(self, *args, **kwargs):
+    def resolve_property(self, *args, **kwargs) -> Any:
         resolver = self._scope.get("property_resolver")
         if resolver is None:
             resolver = PropertyResolver(self.context)

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from spinta import commands
 from spinta.components import Context, Model
 from spinta.core.access import load_access_param
 from spinta.core.enums import load_level, load_status, load_visibility
@@ -7,14 +8,6 @@ from spinta.core.ufuncs import Expr
 from spinta.dimensions.scope.components import Scope, ScopeLoader
 from spinta.manifests.components import Manifest
 from spinta.nodes import load_node
-
-
-def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) -> None:
-    if not scopes:
-        return
-    loader = ScopeLoader(context)
-    loader.update(manifest=manifest)
-    loader.resolve(Expr("resolve_scope", list(scopes.values())))
 
 
 def _load_scope(
@@ -47,3 +40,17 @@ def load_scopes(
     if not scopes:
         return {}
     return {name: _load_scope(context, parents, name, data) for name, data in scopes.items()}
+
+
+def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) -> None:
+    if not scopes:
+        return
+    loader = ScopeLoader(context)
+    loader.update(manifest=manifest)
+    loader.resolve(Expr("resolve_scope", list(scopes.values())))
+
+
+def finalize_scope_link(context: Context, manifest: Manifest) -> None:
+    for model in commands.get_models(context, manifest).values():
+        if model.scopes:
+            link_scopes(context, manifest, model.scopes)

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -3,11 +3,10 @@ from typing import cast
 from spinta.components import Context, Model
 from spinta.core.access import load_access_param
 from spinta.core.enums import load_level, load_status, load_visibility
-from spinta.core.ufuncs import asttoexpr, Expr
+from spinta.core.ufuncs import Expr
 from spinta.dimensions.scope.components import Scope, ScopeLoader
 from spinta.manifests.components import Manifest
 from spinta.nodes import load_node
-from spinta.ufuncs.loadbuilder.components import LoadBuilder
 
 
 def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) -> None:
@@ -16,17 +15,6 @@ def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) 
     loader = ScopeLoader(context)
     loader.update(manifest=manifest)
     loader.resolve(Expr("resolve_scope", list(scopes.values())))
-
-
-def load_prepare(context: Context, scope: Scope, prepare: dict) -> None:
-    expr = asttoexpr(prepare)
-    builder = LoadBuilder(context)
-    builder.update(this=scope)
-
-    if isinstance(expr, Expr):
-        scope.prepare = builder.resolve(expr) or expr
-    else:
-        scope.prepare = expr
 
 
 def _load_scope(
@@ -47,7 +35,6 @@ def _load_scope(
     load_status(scope, data.get("status"))
     load_visibility(scope, data.get("visibility"))
     load_access_param(scope, data.get("access"), parents)
-    load_prepare(context, scope, data.get("prepare"))
 
     return scope
 

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -3,8 +3,30 @@ from typing import cast
 from spinta.components import Context, Model
 from spinta.core.access import load_access_param
 from spinta.core.enums import load_level, load_status, load_visibility
-from spinta.dimensions.scope.components import Scope
+from spinta.core.ufuncs import asttoexpr, Expr
+from spinta.dimensions.scope.components import Scope, ScopeLoader
+from spinta.manifests.components import Manifest
 from spinta.nodes import load_node
+from spinta.ufuncs.loadbuilder.components import LoadBuilder
+
+
+def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) -> None:
+    if not scopes:
+        return
+    loader = ScopeLoader(context)
+    loader.update(manifest=manifest)
+    loader.resolve(Expr("resolve_scope", list(scopes.values())))
+
+
+def load_prepare(context: Context, scope: Scope, prepare: dict) -> None:
+    expr = asttoexpr(prepare)
+    builder = LoadBuilder(context)
+    builder.update(this=scope)
+
+    if isinstance(expr, Expr):
+        scope.prepare = builder.resolve(expr) or expr
+    else:
+        scope.prepare = expr
 
 
 def _load_scope(
@@ -25,6 +47,7 @@ def _load_scope(
     load_status(scope, data.get("status"))
     load_visibility(scope, data.get("visibility"))
     load_access_param(scope, data.get("access"), parents)
+    load_prepare(context, scope, data.get("prepare"))
 
     return scope
 

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -42,15 +42,15 @@ def load_scopes(
     return {name: _load_scope(context, parents, name, data) for name, data in scopes.items()}
 
 
-def link_scopes(context: Context, manifest: Manifest, scopes: dict[str, Scope]) -> None:
+def link_scopes(context: Context, model: Model, scopes: dict[str, Scope]) -> None:
     if not scopes:
         return
     loader = ScopeLoader(context)
-    loader.update(manifest=manifest)
+    loader.update(model=model)
     loader.resolve(Expr("resolve_scope", list(scopes.values())))
 
 
 def finalize_scope_link(context: Context, manifest: Manifest) -> None:
     for model in commands.get_models(context, manifest).values():
         if model.scopes:
-            link_scopes(context, manifest, model.scopes)
+            link_scopes(context, model, model.scopes)

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -1,5 +1,5 @@
 from spinta.components import Model
-from spinta.core.ufuncs import ufunc, Expr, Bind
+from spinta.core.ufuncs import ufunc, Expr, Bind, asttoexpr
 from spinta.dimensions.scope.components import ScopeLoader, Scope
 from spinta.exceptions import PropertyNotFound
 
@@ -12,9 +12,12 @@ def resolve_scope(env: ScopeLoader, scopes: list):
 
 @ufunc.resolver(ScopeLoader, Scope)
 def resolve_scope(env: ScopeLoader, scope: Scope):
-    if scope.prepare is None:
+    prepare = scope.prepare
+    if not prepare:
         return
-    env.call("validate_prepare", scope.model, scope.prepare)
+    if isinstance(prepare, dict):
+        prepare = asttoexpr(prepare)
+    env.call("validate_prepare", scope.model, prepare)
 
 
 @ufunc.resolver(ScopeLoader, Model, Expr)

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -19,13 +19,13 @@ def getattr_(env: ScopeLoader, obj: GetAttr, attr: Bind) -> GetAttr:
 
 
 @ufunc.resolver(ScopeLoader, list)
-def resolve_scope(env: ScopeLoader, scopes: list):
+def resolve_scope(env: ScopeLoader, scopes: list) -> None:
     for scope in scopes:
         env.call("resolve_scope", scope)
 
 
 @ufunc.resolver(ScopeLoader, Scope)
-def resolve_scope(env: ScopeLoader, scope: Scope):
+def resolve_scope(env: ScopeLoader, scope: Scope) -> None:
     prepare = scope.prepare
     if not prepare:
         return
@@ -35,7 +35,7 @@ def resolve_scope(env: ScopeLoader, scope: Scope):
 
 
 @ufunc.resolver(ScopeLoader, Expr)
-def validate_prepare(env: ScopeLoader, expr: Expr):
+def validate_prepare(env: ScopeLoader, expr: Expr) -> None:
     if expr.name in ("bind", "getattr"):
         result = env.resolve(expr)
         env.resolve_property(result)
@@ -47,5 +47,5 @@ def validate_prepare(env: ScopeLoader, expr: Expr):
 
 
 @ufunc.resolver(ScopeLoader, object)
-def validate_prepare(env: ScopeLoader, value: object):
+def validate_prepare(env: ScopeLoader, value: object) -> None:
     return

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -2,11 +2,6 @@ from spinta.core.ufuncs import ufunc, Expr, Bind, GetAttr, asttoexpr
 from spinta.dimensions.scope.components import ScopeLoader, Scope
 
 
-@ufunc.resolver(ScopeLoader, str, name="bind")
-def bind_(env: ScopeLoader, name: str) -> Bind:
-    return Bind(name)
-
-
 @ufunc.resolver(ScopeLoader, Bind, Bind, name="getattr")
 def getattr_(env: ScopeLoader, field: Bind, attr: Bind) -> GetAttr:
     return GetAttr(field.name, attr)
@@ -34,7 +29,6 @@ def resolve_scope(env: ScopeLoader, scope: Scope):
     prepare = scope.prepare
     if not prepare:
         return
-    env.update(model=scope.model, property_resolver=None)
     if isinstance(prepare, dict):
         prepare = asttoexpr(prepare)
     env.call("validate_prepare", prepare)

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -23,6 +23,10 @@ def validate_prepare(env: ScopeLoader, model: Model, expr: Expr):
         if expr.args:
             env.call("validate_prepare", model, expr.args[0])
         return
+    if expr.name == "bind":
+        if expr.args and isinstance(expr.args[0], str):
+            env.call("validate_prepare", model, Bind(expr.args[0]))
+        return
     for arg in expr.args:
         env.call("validate_prepare", model, arg)
     for value in expr.kwargs.values():

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -1,0 +1,40 @@
+from spinta.components import Model
+from spinta.core.ufuncs import ufunc, Expr, Bind
+from spinta.dimensions.scope.components import ScopeLoader, Scope
+from spinta.exceptions import PropertyNotFound
+
+
+@ufunc.resolver(ScopeLoader, list)
+def resolve_scope(env: ScopeLoader, scopes: list):
+    for scope in scopes:
+        env.call("resolve_scope", scope)
+
+
+@ufunc.resolver(ScopeLoader, Scope)
+def resolve_scope(env: ScopeLoader, scope: Scope):
+    if scope.prepare is None:
+        return
+    env.call("validate_prepare", scope.model, scope.prepare)
+
+
+@ufunc.resolver(ScopeLoader, Model, Expr)
+def validate_prepare(env: ScopeLoader, model: Model, expr: Expr):
+    if expr.name == "getattr":
+        if expr.args:
+            env.call("validate_prepare", model, expr.args[0])
+        return
+    for arg in expr.args:
+        env.call("validate_prepare", model, arg)
+    for value in expr.kwargs.values():
+        env.call("validate_prepare", model, value)
+
+
+@ufunc.resolver(ScopeLoader, Model, Bind)
+def validate_prepare(env: ScopeLoader, model: Model, bind: Bind):
+    if bind.name not in model.properties:
+        raise PropertyNotFound(model, property=bind.name)
+
+
+@ufunc.resolver(ScopeLoader, Model, object)
+def validate_prepare(env: ScopeLoader, model: Model, value: object):
+    return

--- a/spinta/dimensions/scope/ufuncs.py
+++ b/spinta/dimensions/scope/ufuncs.py
@@ -1,7 +1,26 @@
-from spinta.components import Model
-from spinta.core.ufuncs import ufunc, Expr, Bind, asttoexpr
+from spinta.core.ufuncs import ufunc, Expr, Bind, GetAttr, asttoexpr
 from spinta.dimensions.scope.components import ScopeLoader, Scope
-from spinta.exceptions import PropertyNotFound
+
+
+@ufunc.resolver(ScopeLoader, str, name="bind")
+def bind_(env: ScopeLoader, name: str) -> Bind:
+    return Bind(name)
+
+
+@ufunc.resolver(ScopeLoader, Bind, Bind, name="getattr")
+def getattr_(env: ScopeLoader, field: Bind, attr: Bind) -> GetAttr:
+    return GetAttr(field.name, attr)
+
+
+@ufunc.resolver(ScopeLoader, Bind, GetAttr, name="getattr")
+def getattr_(env: ScopeLoader, obj: Bind, attr: GetAttr) -> GetAttr:
+    return GetAttr(obj.name, attr)
+
+
+@ufunc.resolver(ScopeLoader, GetAttr, Bind, name="getattr")
+def getattr_(env: ScopeLoader, obj: GetAttr, attr: Bind) -> GetAttr:
+    leaf = env.call("getattr", obj.name, attr)
+    return GetAttr(obj.obj, leaf)
 
 
 @ufunc.resolver(ScopeLoader, list)
@@ -15,33 +34,24 @@ def resolve_scope(env: ScopeLoader, scope: Scope):
     prepare = scope.prepare
     if not prepare:
         return
+    env.update(model=scope.model, property_resolver=None)
     if isinstance(prepare, dict):
         prepare = asttoexpr(prepare)
-    env.call("validate_prepare", scope.model, prepare)
+    env.call("validate_prepare", prepare)
 
 
-@ufunc.resolver(ScopeLoader, Model, Expr)
-def validate_prepare(env: ScopeLoader, model: Model, expr: Expr):
-    if expr.name == "getattr":
-        if expr.args:
-            env.call("validate_prepare", model, expr.args[0])
-        return
-    if expr.name == "bind":
-        if expr.args and isinstance(expr.args[0], str):
-            env.call("validate_prepare", model, Bind(expr.args[0]))
+@ufunc.resolver(ScopeLoader, Expr)
+def validate_prepare(env: ScopeLoader, expr: Expr):
+    if expr.name in ("bind", "getattr"):
+        result = env.resolve(expr)
+        env.resolve_property(result)
         return
     for arg in expr.args:
-        env.call("validate_prepare", model, arg)
+        env.call("validate_prepare", arg)
     for value in expr.kwargs.values():
-        env.call("validate_prepare", model, value)
+        env.call("validate_prepare", value)
 
 
-@ufunc.resolver(ScopeLoader, Model, Bind)
-def validate_prepare(env: ScopeLoader, model: Model, bind: Bind):
-    if bind.name not in model.properties:
-        raise PropertyNotFound(model, property=bind.name)
-
-
-@ufunc.resolver(ScopeLoader, Model, object)
-def validate_prepare(env: ScopeLoader, model: Model, value: object):
+@ufunc.resolver(ScopeLoader, object)
+def validate_prepare(env: ScopeLoader, value: object):
     return

--- a/spinta/manifests/commands/link.py
+++ b/spinta/manifests/commands/link.py
@@ -1,6 +1,7 @@
 from spinta import commands
 from spinta.components import Context, MetaData
 from spinta.dimensions.param.helpers import finalize_param_link
+from spinta.dimensions.scope.helpers import finalize_scope_link
 from spinta.manifests.components import Manifest, get_manifest_object_names
 
 
@@ -11,6 +12,7 @@ def link(context: Context, manifest: Manifest):
             commands.link(context, obj)
 
     finalize_param_link(context, manifest)
+    finalize_scope_link(context, manifest)
 
 
 @commands.link.register(Context, MetaData)

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -21,7 +21,7 @@ from spinta.dimensions.enum.helpers import link_enums, load_enums
 from spinta.dimensions.lang.helpers import load_lang_data
 from spinta.dimensions.param.helpers import load_params
 from spinta.dimensions.scope.components import Scope
-from spinta.dimensions.scope.helpers import load_scopes
+from spinta.dimensions.scope.helpers import load_scopes, link_scopes
 from spinta.exceptions import (
     InvalidCustomPropertyTypeConfiguration,
     InvalidCustomPropertyTypeWithArgsConfiguration,
@@ -235,6 +235,8 @@ def link(context: Context, model: Model):
     # Link model properties.
     for prop in model.properties.values():
         commands.link(context, prop)
+
+    link_scopes(context, model.manifest, model.scopes)
 
     _link_model_page(model)
 

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -21,7 +21,7 @@ from spinta.dimensions.enum.helpers import link_enums, load_enums
 from spinta.dimensions.lang.helpers import load_lang_data
 from spinta.dimensions.param.helpers import load_params
 from spinta.dimensions.scope.components import Scope
-from spinta.dimensions.scope.helpers import load_scopes, link_scopes
+from spinta.dimensions.scope.helpers import load_scopes
 from spinta.exceptions import (
     InvalidCustomPropertyTypeConfiguration,
     InvalidCustomPropertyTypeWithArgsConfiguration,

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -236,8 +236,6 @@ def link(context: Context, model: Model):
     for prop in model.properties.values():
         commands.link(context, prop)
 
-    link_scopes(context, model.manifest, model.scopes)
-
     _link_model_page(model)
 
 

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1330,7 +1330,7 @@ def test_copy_scope_invalid_name(context: Context, rc, cli: SpintaCliRunner, tmp
     d | r | b | m | property | type   | ref  | source | prepare             | access
     datasets/gov/example     |        |      |        |                     |
       |   |   | Country      |        | code | salis  |                     |
-      |   |   |   |          | scope  | LTU  |        | country.code='lt'   | public
+      |   |   |   |          | scope  | LTU  |        | code='lt'           | public
       |   |   |   | code     | string |      | kodas  |                     | public
     """),
     )
@@ -1385,8 +1385,8 @@ def test_copy_multiple_scopes(context: Context, rc, cli: SpintaCliRunner, tmp_pa
     d | r | b | m | property | type   | ref  | source | prepare                | access
     datasets/gov/example     |        |      |        |                        |
       |   |   | Country      |        | code | salis  |                        |
-      |   |   |   |          | scope  | ltu  |        | country.code='lt'      | public
-      |   |   |   |          | scope  | eu   |        | country.region='EU'    | public
+      |   |   |   |          | scope  | ltu  |        | code='lt'              | public
+      |   |   |   |          | scope  | eu   |        | region='EU'            | public
       |   |   |   | code     | string |      | kodas  |                        | public
       |   |   |   | region   | string |      | region |                        | public
     """),
@@ -1410,8 +1410,8 @@ def test_copy_multiple_scopes(context: Context, rc, cli: SpintaCliRunner, tmp_pa
     datasets/gov/example     |        |      |        |                        |
                              |        |      |        |                        |
       |   |   | Country      |        | code | salis  |                        |
-                             | scope  | ltu  |        | country.code='lt'      | public
-                             | scope  | eu   |        | country.region='EU'    | public
+                             | scope  | ltu  |        | code='lt'              | public
+                             | scope  | eu   |        | region='EU'            | public
       |   |   |   | code     | string |      | kodas  |                        | public
       |   |   |   | region   | string |      | region |                        | public
     """

--- a/tests/dimensions/scope/test_helpers.py
+++ b/tests/dimensions/scope/test_helpers.py
@@ -4,8 +4,11 @@ import pytest
 
 from spinta.components import Context, Model
 from spinta.core.access import Access
+from spinta.core.ufuncs import Expr, Bind
 from spinta.dimensions.scope.components import Scope
-from spinta.dimensions.scope.helpers import load_scopes
+from spinta.dimensions.scope.helpers import load_scopes, load_prepare, link_scopes
+from spinta.exceptions import PropertyNotFound
+from spinta.manifests.components import Manifest
 from spinta.spyna import parse
 
 
@@ -101,3 +104,186 @@ class TestLoadScopes:
         assert set(result.keys()) == {"ltu", "eu"}
         assert result["ltu"].given.access == "private"
         assert result["eu"].given.access == "protected"
+
+
+class TestLoadPrepare:
+    def test_sets_prepare_as_expr(
+        self,
+        context: Context,
+        model: Model,
+    ) -> None:
+        scope = Scope()
+        scope.name = "ltu"
+        scope.model = model
+
+        load_prepare(context, scope, parse("code = 'lt'"))
+
+        assert isinstance(scope.prepare, Expr)
+
+    def test_top_level_op_name_matches_formula(
+        self,
+        context: Context,
+        model: Model,
+    ) -> None:
+        scope = Scope()
+        scope.name = "ltu"
+        scope.model = model
+
+        load_prepare(context, scope, parse("code = 'lt'"))
+
+        assert scope.prepare.name == "eq"
+
+    def test_nested_getattr_preserved(
+        self,
+        context: Context,
+        model: Model,
+    ) -> None:
+        scope = Scope()
+        scope.name = "ltu"
+        scope.model = model
+
+        load_prepare(context, scope, parse("country.code = 'lt'"))
+
+        assert scope.prepare.name == "eq"
+        assert isinstance(scope.prepare.args[0], Expr)
+        assert scope.prepare.args[0].name == "getattr"
+
+    def test_bind_arg_inside_expr(
+        self,
+        context: Context,
+        model: Model,
+    ) -> None:
+        scope = Scope()
+        scope.name = "ltu"
+        scope.model = model
+
+        load_prepare(context, scope, parse("select(code)"))
+
+        assert scope.prepare.name == "select"
+        inner = scope.prepare.args[0]
+        assert isinstance(inner, Expr)
+        assert inner.name == "bind"
+        assert inner.args[0] == "code"
+
+
+class TestLinkScopes:
+    @pytest.fixture
+    def model_with_props(self) -> Model:
+        model = Model()
+        model.name = "example/City"
+        model.eid = "test/example/City"
+        model.properties = {"id": None, "code": None, "name": None}
+        return model
+
+    @pytest.fixture
+    def manifest(self) -> Manifest:
+        return Manifest()
+
+    def _build_scope(self, model: Model, name: str, prepare: Expr) -> Scope:
+        scope = Scope()
+        scope.name = name
+        scope.model = model
+        scope.prepare = prepare
+        return scope
+
+    def test_unknown_property_inside_select_raises(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = Scope()
+        scope.name = "bad_scope"
+        scope.model = model_with_props
+        load_prepare(context, scope, parse("select(country)"))
+
+        with pytest.raises(PropertyNotFound):
+            link_scopes(context, manifest, {"bad_scope": scope})
+
+    def test_valid_bind_passes(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "valid_scope",
+            Expr("eq", Bind("code"), "lt"),
+        )
+        # Should not raise.
+        link_scopes(context, manifest, {"valid_scope": scope})
+
+    def test_unknown_property_raises(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            Expr("eq", Bind("country"), "lt"),
+        )
+        with pytest.raises(PropertyNotFound):
+            link_scopes(context, manifest, {"bad_scope": scope})
+
+    def test_nested_expr_is_walked(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            Expr("select", Bind("country")),
+        )
+        with pytest.raises(PropertyNotFound):
+            link_scopes(context, manifest, {"bad_scope": scope})
+
+    def test_getattr_head_validated(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            Expr("getattr", Bind("country"), Bind("name")),
+        )
+        with pytest.raises(PropertyNotFound):
+            link_scopes(context, manifest, {"bad_scope": scope})
+
+    def test_literal_args_ignored(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "good_scope",
+            Expr("eq", Bind("code"), "lt"),
+        )
+        link_scopes(context, manifest, {"good_scope": scope})
+
+    def test_first_invalid_scope_raises(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        good_scope = self._build_scope(
+            model_with_props,
+            "good_scope",
+            Expr("eq", Bind("code"), "lt"),
+        )
+        bad_scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            Expr("eq", Bind("country"), "lt"),
+        )
+        with pytest.raises(PropertyNotFound):
+            link_scopes(context, manifest, {"good_scope": good_scope, "bad_scope": bad_scope})

--- a/tests/dimensions/scope/test_helpers.py
+++ b/tests/dimensions/scope/test_helpers.py
@@ -7,7 +7,7 @@ from spinta.core.access import Access
 from spinta.core.ufuncs import Expr, Bind
 from spinta.dimensions.scope.components import Scope
 from spinta.dimensions.scope.helpers import load_scopes, link_scopes
-from spinta.exceptions import PropertyNotFound
+from spinta.exceptions import PropertyNotFound, FieldNotInResource
 from spinta.manifests.components import Manifest
 from spinta.spyna import parse
 
@@ -123,7 +123,9 @@ class TestLinkScopes:
         model = Model()
         model.name = "example/City"
         model.eid = "test/example/City"
-        model.properties = {"id": None, "code": None, "name": None}
+        props = {"id": None, "code": None, "name": None}
+        model.properties = props
+        model.flatprops = props
         return model
 
     @pytest.fixture
@@ -137,6 +139,33 @@ class TestLinkScopes:
         scope.prepare = prepare
         return scope
 
+    def test_valid_local_property_passes(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "valid_scope",
+            parse("code = 'lt'"),
+        )
+        link_scopes(context, manifest, {"valid_scope": scope})
+
+    def test_unknown_local_property_raises(
+        self,
+        context: Context,
+        manifest: Manifest,
+        model_with_props: Model,
+    ) -> None:
+        scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            parse("country = 'lt'"),
+        )
+        with pytest.raises((PropertyNotFound, FieldNotInResource)):
+            link_scopes(context, manifest, {"bad_scope": scope})
+
     def test_unknown_property_inside_select_raises(
         self,
         context: Context,
@@ -148,49 +177,7 @@ class TestLinkScopes:
             "bad_scope",
             parse("select(country)"),
         )
-
-        with pytest.raises(PropertyNotFound):
-            link_scopes(context, manifest, {"bad_scope": scope})
-
-    def test_valid_bind_passes(
-        self,
-        context: Context,
-        manifest: Manifest,
-        model_with_props: Model,
-    ) -> None:
-        scope = self._build_scope(
-            model_with_props,
-            "valid_scope",
-            Expr("eq", Bind("code"), "lt"),
-        )
-        link_scopes(context, manifest, {"valid_scope": scope})
-
-    def test_unknown_property_raises(
-        self,
-        context: Context,
-        manifest: Manifest,
-        model_with_props: Model,
-    ) -> None:
-        scope = self._build_scope(
-            model_with_props,
-            "bad_scope",
-            Expr("eq", Bind("country"), "lt"),
-        )
-        with pytest.raises(PropertyNotFound):
-            link_scopes(context, manifest, {"bad_scope": scope})
-
-    def test_nested_expr_is_walked(
-        self,
-        context: Context,
-        manifest: Manifest,
-        model_with_props: Model,
-    ) -> None:
-        scope = self._build_scope(
-            model_with_props,
-            "bad_scope",
-            Expr("select", Bind("country")),
-        )
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises((PropertyNotFound, FieldNotInResource)):
             link_scopes(context, manifest, {"bad_scope": scope})
 
     def test_getattr_head_validated(
@@ -202,9 +189,9 @@ class TestLinkScopes:
         scope = self._build_scope(
             model_with_props,
             "bad_scope",
-            Expr("getattr", Bind("country"), Bind("name")),
+            parse("country.name = 'lt'"),
         )
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises((PropertyNotFound, FieldNotInResource)):
             link_scopes(context, manifest, {"bad_scope": scope})
 
     def test_first_invalid_scope_raises(
@@ -216,12 +203,16 @@ class TestLinkScopes:
         good_scope = self._build_scope(
             model_with_props,
             "good_scope",
-            Expr("eq", Bind("code"), "lt"),
+            parse("code = 'lt'"),
         )
         bad_scope = self._build_scope(
             model_with_props,
             "bad_scope",
-            Expr("eq", Bind("country"), "lt"),
+            parse("country = 'lt'"),
         )
-        with pytest.raises(PropertyNotFound):
-            link_scopes(context, manifest, {"good_scope": good_scope, "bad_scope": bad_scope})
+        with pytest.raises((PropertyNotFound, FieldNotInResource)):
+            link_scopes(
+                context,
+                manifest,
+                {"good_scope": good_scope, "bad_scope": bad_scope},
+            )

--- a/tests/dimensions/scope/test_helpers.py
+++ b/tests/dimensions/scope/test_helpers.py
@@ -4,7 +4,6 @@ import pytest
 
 from spinta.components import Context, Model
 from spinta.core.access import Access
-from spinta.core.ufuncs import Expr, Bind
 from spinta.dimensions.scope.components import Scope
 from spinta.dimensions.scope.helpers import load_scopes, link_scopes
 from spinta.exceptions import PropertyNotFound, FieldNotInResource

--- a/tests/dimensions/scope/test_helpers.py
+++ b/tests/dimensions/scope/test_helpers.py
@@ -149,7 +149,7 @@ class TestLinkScopes:
             "valid_scope",
             parse("code = 'lt'"),
         )
-        link_scopes(context, manifest, {"valid_scope": scope})
+        link_scopes(context, model_with_props, {"valid_scope": scope})
 
     def test_unknown_local_property_raises(
         self,
@@ -163,7 +163,7 @@ class TestLinkScopes:
             parse("country = 'lt'"),
         )
         with pytest.raises((PropertyNotFound, FieldNotInResource)):
-            link_scopes(context, manifest, {"bad_scope": scope})
+            link_scopes(context, model_with_props, {"bad_scope": scope})
 
     def test_unknown_property_inside_select_raises(
         self,
@@ -177,7 +177,7 @@ class TestLinkScopes:
             parse("select(country)"),
         )
         with pytest.raises((PropertyNotFound, FieldNotInResource)):
-            link_scopes(context, manifest, {"bad_scope": scope})
+            link_scopes(context, model_with_props, {"bad_scope": scope})
 
     def test_getattr_head_validated(
         self,
@@ -191,7 +191,7 @@ class TestLinkScopes:
             parse("country.name = 'lt'"),
         )
         with pytest.raises((PropertyNotFound, FieldNotInResource)):
-            link_scopes(context, manifest, {"bad_scope": scope})
+            link_scopes(context, model_with_props, {"bad_scope": scope})
 
     def test_first_invalid_scope_raises(
         self,
@@ -212,6 +212,6 @@ class TestLinkScopes:
         with pytest.raises((PropertyNotFound, FieldNotInResource)):
             link_scopes(
                 context,
-                manifest,
+                model_with_props,
                 {"good_scope": good_scope, "bad_scope": bad_scope},
             )

--- a/tests/dimensions/scope/test_helpers.py
+++ b/tests/dimensions/scope/test_helpers.py
@@ -6,7 +6,7 @@ from spinta.components import Context, Model
 from spinta.core.access import Access
 from spinta.core.ufuncs import Expr, Bind
 from spinta.dimensions.scope.components import Scope
-from spinta.dimensions.scope.helpers import load_scopes, load_prepare, link_scopes
+from spinta.dimensions.scope.helpers import load_scopes, link_scopes
 from spinta.exceptions import PropertyNotFound
 from spinta.manifests.components import Manifest
 from spinta.spyna import parse
@@ -75,6 +75,17 @@ class TestLoadScopes:
 
         assert result["ltu"].given.access == "private"
 
+    def test_prepare_stored_as_ast_dict(
+        self,
+        context: Context,
+        model: Model,
+        scope_data: dict[str, dict[str, Any]],
+    ) -> None:
+        result = load_scopes(context, [model], scope_data)
+
+        assert isinstance(result["ltu"].prepare, dict)
+        assert result["ltu"].prepare["name"] == "eq"
+
     def test_loads_multiple_scopes(
         self,
         context: Context,
@@ -106,66 +117,6 @@ class TestLoadScopes:
         assert result["eu"].given.access == "protected"
 
 
-class TestLoadPrepare:
-    def test_sets_prepare_as_expr(
-        self,
-        context: Context,
-        model: Model,
-    ) -> None:
-        scope = Scope()
-        scope.name = "ltu"
-        scope.model = model
-
-        load_prepare(context, scope, parse("code = 'lt'"))
-
-        assert isinstance(scope.prepare, Expr)
-
-    def test_top_level_op_name_matches_formula(
-        self,
-        context: Context,
-        model: Model,
-    ) -> None:
-        scope = Scope()
-        scope.name = "ltu"
-        scope.model = model
-
-        load_prepare(context, scope, parse("code = 'lt'"))
-
-        assert scope.prepare.name == "eq"
-
-    def test_nested_getattr_preserved(
-        self,
-        context: Context,
-        model: Model,
-    ) -> None:
-        scope = Scope()
-        scope.name = "ltu"
-        scope.model = model
-
-        load_prepare(context, scope, parse("country.code = 'lt'"))
-
-        assert scope.prepare.name == "eq"
-        assert isinstance(scope.prepare.args[0], Expr)
-        assert scope.prepare.args[0].name == "getattr"
-
-    def test_bind_arg_inside_expr(
-        self,
-        context: Context,
-        model: Model,
-    ) -> None:
-        scope = Scope()
-        scope.name = "ltu"
-        scope.model = model
-
-        load_prepare(context, scope, parse("select(code)"))
-
-        assert scope.prepare.name == "select"
-        inner = scope.prepare.args[0]
-        assert isinstance(inner, Expr)
-        assert inner.name == "bind"
-        assert inner.args[0] == "code"
-
-
 class TestLinkScopes:
     @pytest.fixture
     def model_with_props(self) -> Model:
@@ -179,7 +130,7 @@ class TestLinkScopes:
     def manifest(self) -> Manifest:
         return Manifest()
 
-    def _build_scope(self, model: Model, name: str, prepare: Expr) -> Scope:
+    def _build_scope(self, model: Model, name: str, prepare) -> Scope:
         scope = Scope()
         scope.name = name
         scope.model = model
@@ -192,10 +143,11 @@ class TestLinkScopes:
         manifest: Manifest,
         model_with_props: Model,
     ) -> None:
-        scope = Scope()
-        scope.name = "bad_scope"
-        scope.model = model_with_props
-        load_prepare(context, scope, parse("select(country)"))
+        scope = self._build_scope(
+            model_with_props,
+            "bad_scope",
+            parse("select(country)"),
+        )
 
         with pytest.raises(PropertyNotFound):
             link_scopes(context, manifest, {"bad_scope": scope})
@@ -211,7 +163,6 @@ class TestLinkScopes:
             "valid_scope",
             Expr("eq", Bind("code"), "lt"),
         )
-        # Should not raise.
         link_scopes(context, manifest, {"valid_scope": scope})
 
     def test_unknown_property_raises(
@@ -255,19 +206,6 @@ class TestLinkScopes:
         )
         with pytest.raises(PropertyNotFound):
             link_scopes(context, manifest, {"bad_scope": scope})
-
-    def test_literal_args_ignored(
-        self,
-        context: Context,
-        manifest: Manifest,
-        model_with_props: Model,
-    ) -> None:
-        scope = self._build_scope(
-            model_with_props,
-            "good_scope",
-            Expr("eq", Bind("code"), "lt"),
-        )
-        link_scopes(context, manifest, {"good_scope": scope})
 
     def test_first_invalid_scope_raises(
         self,

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -2102,7 +2102,7 @@ def test_scope_loaded_with_prepare(manifest_type: str, tmp_path: Path, rc: RawCo
         example                  |         |     |
                                  |         |     |
           |   |   | Country      |         |     |
-                                 | scope   | ltu | country.code='lt'
+                                 | scope   | ltu | code='lt'
           |   |   |   | code     | string  |     |
     """,
         manifest_type,
@@ -2119,8 +2119,8 @@ def test_multiple_scopes_on_model(manifest_type, tmp_path, rc):
         example                  |         |     |
                                  |         |     |
           |   |   | Country      |         |     |
-                                 | scope   | ltu | country.code='lt'
-                                 | scope   | eu  | country.region='EU'
+                                 | scope   | ltu | code='lt'
+                                 | scope   | eu  | region='EU'
           |   |   |   | code     | string  |     |
           |   |   |   | region   | string  |     |
     """,
@@ -2138,7 +2138,7 @@ def test_scope_with_full_metadata(manifest_type, tmp_path, rc):
         example                  |         |     |                   |         |         |           |
                                  |         |     |                   |         |         |           |
           |   |   | Country      |         |     |                   |         |         |           |
-                                 | scope   | ltu | country.code='lt' | private | eli:eli | Lithuania | Lietuvos scope
+                                 | scope   | ltu | code='lt'         | private | eli:eli | Lithuania | Lietuvos scope
           |   |   |   | code     | string  |     |                   |         |         |           |
     """,
         manifest_type,

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -288,6 +288,7 @@ def test_scope_with_invalid_denorm_subproperty_raises(manifest_type: str, tmp_pa
             tmp_path=tmp_path,
         )
 
+
 @pytest.mark.manifests("csv")
 def test_scope_with_valid_object_subproperty_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
     context = load_manifest_get_context(
@@ -327,6 +328,7 @@ def test_scope_with_invalid_object_subproperty_raises(manifest_type: str, tmp_pa
             tmp_path=tmp_path,
         )
 
+
 @pytest.mark.manifests("csv")
 def test_scope_with_valid_text_property_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
     context = load_manifest_get_context(
@@ -345,6 +347,7 @@ def test_scope_with_valid_text_property_loads(manifest_type: str, tmp_path: Path
     )
     city = context.get("store").manifest.get_objects()["model"]["example/City"]
     assert "text" in city.scopes
+
 
 @pytest.mark.manifests("csv")
 def test_scope_with_invalid_text_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
@@ -384,6 +387,7 @@ def test_multiple_scopes_on_same_model_load(manifest_type, tmp_path, rc):
     )
     city = context.get("store").manifest.get_objects()["model"]["example/City"]
     assert set(city.scopes.keys()) == {"ids", "code", "name"}
+
 
 @pytest.mark.manifests("csv")
 def test_cross_model_scope_3_level_chain_loads(manifest_type, tmp_path, rc):

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -199,8 +199,6 @@ def test_scope_with_valid_property_loads(manifest_type: str, tmp_path: Path, rc:
     )
     store = context.get("store")
     city = store.manifest.get_objects()["model"]["example/City"]
-    print("properties:", list(city.properties.keys()))
-    print("scopes:", list(city.scopes.keys()))
 
     assert "ltu" in city.scopes
     assert city.scopes["ltu"].model is city

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from spinta.core.config import RawConfig
-from spinta.exceptions import MissingRefModel
+from spinta.exceptions import MissingRefModel, PropertyNotFound
 from spinta.testing.manifest import load_manifest, load_manifest_get_context
 from spinta.types.datatype import Object
 
@@ -180,3 +180,82 @@ def test_undeclared_array_model_transforms_to_object(manifest_type, tmp_path, rc
     prepare = comment.prepare.replace(" ", "").replace('"', "").replace("'", "")
     assert "type:array" in prepare
     assert "ref:example2/CityCountry[city,country]" in prepare
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_valid_property_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref | prepare       | access
+    example                  |        |     |               |
+      |   |   | City         |        | id  |               |
+      |   |   |              | scope  | ltu | code = 'lt'   | private
+      |   |   |   | id       | string |     |               | private
+      |   |   |   | code     | string |     |               | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    store = context.get("store")
+    city = store.manifest.get_objects()["model"]["example/City"]
+    print("properties:", list(city.properties.keys()))
+    print("scopes:", list(city.scopes.keys()))
+
+    assert "ltu" in city.scopes
+    assert city.scopes["ltu"].model is city
+    assert city.scopes["ltu"].prepare is not None
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_unknown_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises(PropertyNotFound):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref | prepare           | access
+    example                  |        |     |                   |
+      |   |   | City         |        | id  |                   |
+      |   |   |              | scope  | bad | country = 'lt'    | private
+      |   |   |   | id       | string |     |                   | private
+      |   |   |   | code     | string |     |                   | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_select_bare_identifier_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises(PropertyNotFound):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref | prepare         | access
+    example                  |        |     |                 |
+      |   |   | City         |        | id  |                 |
+      |   |   |              | scope  | bad | select(country) | private
+      |   |   |   | id       | string |     |                 | private
+      |   |   |   | code     | string |     |                 | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+
+@pytest.mark.manifests("csv")
+def test_scope_getattr_head_against_missing_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises(PropertyNotFound):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref | prepare              | access
+    example                  |        |     |                      |
+      |   |   | City         |        | id  |                      |
+      |   |   |              | scope  | bad | country.name = 'lt'  | private
+      |   |   |   | id       | string |     |                      | private
+      |   |   |   | code     | string |     |                      | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from spinta.core.config import RawConfig
-from spinta.exceptions import MissingRefModel, PropertyNotFound
+from spinta.exceptions import MissingRefModel, PropertyNotFound, FieldNotInResource
 from spinta.testing.manifest import load_manifest, load_manifest_get_context
 from spinta.types.datatype import Object
 
@@ -208,7 +208,7 @@ def test_scope_with_valid_property_loads(manifest_type: str, tmp_path: Path, rc:
 
 
 @pytest.mark.manifests("csv")
-def test_scope_with_unknown_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+def test_scope_with_unknown_property_raises(manifest_type, tmp_path, rc):
     with pytest.raises(PropertyNotFound):
         load_manifest_get_context(
             rc,
@@ -216,7 +216,7 @@ def test_scope_with_unknown_property_raises(manifest_type: str, tmp_path: Path, 
     d | r | b | m | property | type   | ref | prepare           | access
     example                  |        |     |                   |
       |   |   | City         |        | id  |                   |
-      |   |   |              | scope  | bad | country = 'lt'    | private
+      |   |   |              | scope  | bad | foo = 'lt'        | private
       |   |   |   | id       | string |     |                   | private
       |   |   |   | code     | string |     |                   | private
             """,
@@ -244,18 +244,167 @@ def test_scope_with_select_bare_identifier_raises(manifest_type: str, tmp_path: 
 
 
 @pytest.mark.manifests("csv")
-def test_scope_getattr_head_against_missing_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
-    with pytest.raises(PropertyNotFound):
+def test_scope_with_valid_denorm_property_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property     | type   | ref     | prepare              | access
+    example                      |        |         |                      |
+      |   |   | City             |        | id      |                      |
+      |   |   |                  | scope  | denorm  | country.code = 'lt'  | private
+      |   |   |   | id           | string |         |                      | private
+      |   |   |   | country      | ref    | Country |                      | private
+      |   |   |   | country.code | string |         |                      | private
+      |   |   | Country          |        | id      |                      |
+      |   |   |   | id           | string |         |                      | private
+      |   |   |   | code         | string |         |                      | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    city = context.get("store").manifest.get_objects()["model"]["example/City"]
+    assert "denorm" in city.scopes
+    assert city.scopes["denorm"].model is city
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_invalid_denorm_subproperty_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises((PropertyNotFound, FieldNotInResource)):
         load_manifest_get_context(
             rc,
             manifest="""
-    d | r | b | m | property | type   | ref | prepare              | access
-    example                  |        |     |                      |
-      |   |   | City         |        | id  |                      |
-      |   |   |              | scope  | bad | country.name = 'lt'  | private
-      |   |   |   | id       | string |     |                      | private
-      |   |   |   | code     | string |     |                      | private
+    d | r | b | m | property     | type   | ref     | prepare               | access
+    example                      |        |         |                       |
+      |   |   | City             |        | id      |                       |
+      |   |   |                  | scope  | bad     | country.foo = 'x'     | private
+      |   |   |   | id           | string |         |                       | private
+      |   |   |   | country      | ref    | Country |                       | private
+      |   |   |   | country.code | string |         |                       | private
+      |   |   | Country          |        | id      |                       |
+      |   |   |   | id           | string |         |                       | private
+      |   |   |   | code         | string |         |                       | private
             """,
             manifest_type=manifest_type,
             tmp_path=tmp_path,
         )
+
+@pytest.mark.manifests("csv")
+def test_scope_with_valid_object_subproperty_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property       | type   | ref | prepare                  | access
+    example                        |        |     |                          |
+      |   |   | City               |        | id  |                          |
+      |   |   |                    | scope  | obj | address.street = 'Main'  | private
+      |   |   |   | id             | string |     |                          | private
+      |   |   |   | address        | object |     |                          | private
+      |   |   |   | address.street | string |     |                          | private
+      |   |   |   | address.city   | string |     |                          | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    city = context.get("store").manifest.get_objects()["model"]["example/City"]
+    assert "obj" in city.scopes
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_invalid_object_subproperty_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises((PropertyNotFound, FieldNotInResource)):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property       | type   | ref | prepare              | access
+    example                        |        |     |                      |
+      |   |   | City               |        | id  |                      |
+      |   |   |                    | scope  | bad | address.foo = 'x'    | private
+      |   |   |   | id             | string |     |                      | private
+      |   |   |   | address        | object |     |                      | private
+      |   |   |   | address.street | string |     |                      | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+@pytest.mark.manifests("csv")
+def test_scope_with_valid_text_property_loads(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref  | prepare           | access
+    example                  |        |      |                   |
+      |   |   | City         |        | id   |                   |
+      |   |   |              | scope  | text | name = 'Vilnius'  | private
+      |   |   |   | id       | string |      |                   | private
+      |   |   |   | name@lt  | string |      |                   | private
+      |   |   |   | name@en  | string |      |                   | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    city = context.get("store").manifest.get_objects()["model"]["example/City"]
+    assert "text" in city.scopes
+
+@pytest.mark.manifests("csv")
+def test_scope_with_invalid_text_property_raises(manifest_type: str, tmp_path: Path, rc: RawConfig):
+    with pytest.raises((PropertyNotFound, FieldNotInResource)):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref | prepare         | access
+    example                  |        |     |                 |
+      |   |   | City         |        | id  |                 |
+      |   |   |              | scope  | bad | foo = 'x'       | private
+      |   |   |   | id       | string |     |                 | private
+      |   |   |   | name@lt  | string |     |                 | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+
+@pytest.mark.manifests("csv")
+def test_multiple_scopes_on_same_model_load(manifest_type, tmp_path, rc):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref  | prepare         | access
+    example                  |        |      |                 |
+      |   |   | City         |        | id   |                 |
+      |   |   |              | scope  | ids  | select(id)      | private
+      |   |   |              | scope  | code | code = 'lt'     | private
+      |   |   |              | scope  | name | select(name)    | private
+      |   |   |   | id       | string |      |                 | private
+      |   |   |   | code     | string |      |                 | private
+      |   |   |   | name     | string |      |                 | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    city = context.get("store").manifest.get_objects()["model"]["example/City"]
+    assert set(city.scopes.keys()) == {"ids", "code", "name"}
+
+@pytest.mark.manifests("csv")
+def test_cross_model_scope_3_level_chain_loads(manifest_type, tmp_path, rc):
+    context = load_manifest_get_context(
+        rc,
+        manifest="""
+    d | r | b | m | property | type   | ref       | prepare                        | access
+    example                  |        |           |                                |
+      |   |   | City         |        | id        |                                |
+      |   |   |              | scope  | continent | select(country.continent.name) | private
+      |   |   |   | id       | string |           |                                | private
+      |   |   |   | country  | ref    | Country   |                                | private
+      |   |   | Country      |        | id        |                                |
+      |   |   |   | id       | string |           |                                | private
+      |   |   |   | continent| ref    | Continent |                                | private
+      |   |   | Continent    |        | id        |                                |
+      |   |   |   | id       | string |           |                                | private
+      |   |   |   | name     | string |           |                                | private
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    city = context.get("store").manifest.get_objects()["model"]["example/City"]
+    assert "continent" in city.scopes

--- a/tests/types/test_link.py
+++ b/tests/types/test_link.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from spinta.core.config import RawConfig
-from spinta.exceptions import MissingRefModel, PropertyNotFound, FieldNotInResource
+from spinta.exceptions import MissingRefModel, PropertyNotFound, FieldNotInResource, LangNotDeclared
 from spinta.testing.manifest import load_manifest, load_manifest_get_context
 from spinta.types.datatype import Object
 
@@ -334,13 +334,13 @@ def test_scope_with_valid_text_property_loads(manifest_type: str, tmp_path: Path
     context = load_manifest_get_context(
         rc,
         manifest="""
-    d | r | b | m | property | type   | ref  | prepare           | access
-    example                  |        |      |                   |
-      |   |   | City         |        | id   |                   |
-      |   |   |              | scope  | text | name = 'Vilnius'  | private
-      |   |   |   | id       | string |      |                   | private
-      |   |   |   | name@lt  | string |      |                   | private
-      |   |   |   | name@en  | string |      |                   | private
+    d | r | b | m | property | type   | ref  | prepare             | access
+    example                  |        |      |                     |
+      |   |   | City         |        | id   |                     | 
+      |   |   |              | scope  | text | name@lt = 'Vilnius' | private
+      |   |   |   | id       | string |      |                     | private
+      |   |   |   | name@lt  | string |      |                     | private
+      |   |   |   | name@en  | string |      |                     | private
         """,
         manifest_type=manifest_type,
         tmp_path=tmp_path,
@@ -412,3 +412,72 @@ def test_cross_model_scope_3_level_chain_loads(manifest_type, tmp_path, rc):
     )
     city = context.get("store").manifest.get_objects()["model"]["example/City"]
     assert "continent" in city.scopes
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_invalid_lang_tag_raises(
+    manifest_type: str,
+    tmp_path: Path,
+    rc: RawConfig,
+):
+    with pytest.raises(LangNotDeclared):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref  | prepare              | access
+    example                  |        |      |                      |
+      |   |   | City         |        | id   |                      |
+      |   |   |              | scope  | text | name@fr = 'Vilnius'  | private
+      |   |   |   | id       | string |      |                      | private
+      |   |   |   | name@lt  | string |      |                      | private
+      |   |   |   | name@en  | string |      |                      | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_or_invalid_property_raises(
+    manifest_type: str,
+    tmp_path: Path,
+    rc: RawConfig,
+):
+    with pytest.raises((PropertyNotFound, FieldNotInResource)):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref  | prepare                            | access
+    example                  |        |      |                                    |
+      |   |   | City         |        | id   |                                    |
+      |   |   |              | scope  | text | or(name@lt = 'Vilnius', foo = 'x') | private
+      |   |   |   | id       | string |      |                                    | private
+      |   |   |   | name@lt  | string |      |                                    | private
+      |   |   |   | name@en  | string |      |                                    | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+
+
+@pytest.mark.manifests("csv")
+def test_scope_with_and_invalid_lang_tag_raises(
+    manifest_type: str,
+    tmp_path: Path,
+    rc: RawConfig,
+):
+    with pytest.raises(LangNotDeclared):
+        load_manifest_get_context(
+            rc,
+            manifest="""
+    d | r | b | m | property | type   | ref  | prepare                                       | access
+    example                  |        |      |                                               |
+      |   |   | City         |        | id   |                                               |
+      |   |   |              | scope  | text | and(name@lt = 'Vilnius', name@xx = 'Vilnius') | private
+      |   |   |   | id       | string |      |                                               | private
+      |   |   |   | name@lt  | string |      |                                               | private
+      |   |   |   | name@en  | string |      |                                               | private
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )


### PR DESCRIPTION
Summary:
- Added new ScopeLoader class
- Added `link_scopes` func to resolve new ufunc resolvers
- Added ufuncs.py in scopes, with validate_prepare resolvers for bind objects, and for plain objects

Ticket: https://github.com/atviriduomenys/spinta/issues/1922