### PR TITLE
Ft/1928 optional base check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,14 @@ Changes
 Improvements:
 
 - Added validation that raises an error when a named enum (with a `ref`) is declared directly under a property (`#1935`_).
+- Added a new helper mirroring the existing replace_undeclared_ref_with_object. When a model's base cannot be resolved in
+  the manifest, instead of raising an error, it drops the base from the model, and append a systemic comment row so it can be restored later. (`#1928`_).
+
+  - `spinta comment` — extended to cover base restore comments
+  - `spinta uncomment` — extended to restore base rows
 
 .. _#1935: https://github.com/atviriduomenys/spinta/issues/1935
+.. _#1928: https://github.com/atviriduomenys/spinta/issues/1928
 
 Bug fixes:
 

--- a/spinta/cli/comment.py
+++ b/spinta/cli/comment.py
@@ -5,7 +5,7 @@ from typer import echo
 
 from spinta.cli.helpers.enums import CommentPart
 from spinta.cli.helpers.store import load_manifest
-from spinta.components import Context, Property
+from spinta.components import Context
 from spinta.core.context import configure_context
 from spinta.core.enums import Access
 from spinta.dimensions.comments.components import Comment

--- a/spinta/cli/comment.py
+++ b/spinta/cli/comment.py
@@ -8,10 +8,14 @@ from spinta.cli.helpers.store import load_manifest
 from spinta.components import Context, Property
 from spinta.core.context import configure_context
 from spinta.core.enums import Access
+from spinta.dimensions.comments.components import Comment
 from spinta.manifests.components import Manifest
 from spinta.manifests.tabular.helpers import datasets_to_tabular
 from spinta.manifests.tabular.helpers import render_tabular_manifest_rows
 from spinta.manifests.tabular.helpers import write_tabular_manifest
+
+
+RESTORE_COMMENT_PREFIXES = ("update", "insert")
 
 
 def comment(
@@ -79,7 +83,7 @@ def _update_systemic_comments(
     uri: str | None = None,
     description: str | None = None,
 ) -> None:
-    """Update author/uri/description on comment type properties."""
+    """Update author/uri/description on systemic restore comments (refs and bases)."""
     from spinta import commands
 
     if all(argument is None for argument in [author, uri, description]):
@@ -87,22 +91,24 @@ def _update_systemic_comments(
 
     models = commands.get_models(context, manifest)
     for model in models.values():
+        _patch_restore_comments(model.comments, author=author, uri=uri, description=description)
         for prop in model.properties.values():
-            _patch_property_restore_comments(prop, author=author, uri=uri, description=description)
+            _patch_restore_comments(prop.comments, author=author, uri=uri, description=description)
 
 
-def _patch_property_restore_comments(
-    prop: Property,
+def _patch_restore_comments(
+    comments: list[Comment] | None,
     *,
     author: str | None,
     uri: str | None,
     description: str | None,
 ) -> None:
-    if not prop.comments:
+    if not comments:
         return
 
-    for comment in prop.comments:
-        if not comment.prepare or not comment.prepare.startswith("update"):
+    for comment in comments:
+        prepare = comment.prepare or ""
+        if not prepare.startswith(RESTORE_COMMENT_PREFIXES):
             continue
 
         if author is not None:

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -149,7 +149,6 @@ def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[Man
                     base_row: dict = {col: "" for col in row.keys()}
                     for key, value in fields.items():
                         base_row[key] = value
-                    base_row["level"] = row.get("level") or ""
                     result.insert(last_model_index, base_row)
                     last_model_index += 1
                     base_was_inserted = True

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -149,6 +149,10 @@ def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[Man
                     base_row: dict = {col: "" for col in row.keys()}
                     for key, value in fields.items():
                         base_row[key] = value
+                    if row.get("level"):
+                        model_row = result[last_model_index]
+                        model_row["level"] = row.get("level")
+                        result[last_model_index] = model_row
                     result.insert(last_model_index, base_row)
                     last_model_index += 1
                     base_was_inserted = True

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -17,6 +17,7 @@ from spinta.manifests.tabular.helpers import write_tabular_manifest
 
 UPDATE_FUNCTION = "update"
 COLUMN_TYPE_COMMENT = "comment"
+INSERT_FUNCTION = "insert"
 
 
 def uncomment(
@@ -56,13 +57,13 @@ def _read_raw_manifest_rows(manifests: list[str]) -> list[ManifestRow]:
     return rows
 
 
-def _parse_update_fields(prepare: str) -> dict[str, str]:
-    """Parse 'update(key1:val1, key2:val2, ...)' into {'key1': 'val1', 'key2': 'val2', ...}.
+def _parse_function_fields(prepare: str, func_name: str) -> dict[str, str]:
+    """Parse 'func_name(key1:val1, key2:val2, ...)' into {'key1': 'val1', 'key2': 'val2', ...}.
 
     Splits on commas only when followed by a word-colon pattern, so values containing
     commas inside brackets (e.g. ref:example2/City[id, name]) are handled correctly.
     """
-    match = re.match(rf"{UPDATE_FUNCTION}\((.+)\)\s*$", (prepare or "").strip())
+    match = re.match(rf"{func_name}\((.+)\)\s*$", (prepare or "").strip())
     if not match:
         return {}
     parts = re.split(r",\s*(?=\w+:)", match.group(1))
@@ -73,27 +74,61 @@ def _parse_update_fields(prepare: str) -> dict[str, str]:
     return result
 
 
-def _is_restore_comment(row: ManifestRow) -> bool:
+def _parse_update_fields(prepare: str) -> dict[str, str]:
+    return _parse_function_fields(prepare, UPDATE_FUNCTION)
+
+
+def _parse_insert_fields(prepare: str) -> dict[str, str]:
+    return _parse_function_fields(prepare, INSERT_FUNCTION)
+
+
+def _is_restore_comment(row: ManifestRow, func_name: str) -> bool:
     prepare = row.get("prepare") or ""
-    return row.get("type") == COLUMN_TYPE_COMMENT and prepare.startswith(UPDATE_FUNCTION)
+    return row.get("type") == COLUMN_TYPE_COMMENT and prepare.startswith(func_name)
+
+
+def _insert_base_resets(result: list[ManifestRow]) -> list[ManifestRow]:
+    """Insert `/` reset rows where base context would leak from a previous
+    model into a model that has no base row directly above it."""
+    fixed: list[ManifestRow] = []
+    active_base: str | None = None
+    base_seen_since_last_model: bool = False
+
+    for row in result:
+        is_base_row = row.get("base") and not row.get("model") and not row.get("property")
+        is_model_row = bool(row.get("model"))
+
+        if is_base_row:
+            active_base = row["base"]
+            base_seen_since_last_model = True
+            fixed.append(row)
+        elif is_model_row:
+            if not base_seen_since_last_model and active_base and active_base != "/":
+                # No base row immediately above this model, but a base context
+                # is still active from a previous model. Insert `/` to break it.
+                reset_row = {col: "" for col in row.keys()}
+                reset_row["base"] = "/"
+                fixed.append(reset_row)
+                active_base = "/"
+            base_seen_since_last_model = False
+            fixed.append(row)
+        else:
+            fixed.append(row)
+
+    return fixed
 
 
 def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[ManifestRow]:
-    """
-    Walk rows in order. When an `update` comment is found (and passes the URI filter),
-    patch the most recent property row in result and drop the comment row.
-    """
     result: list[ManifestRow] = []
     last_property_index: int | None = None
+    last_model_index: int | None = None
+    base_was_inserted: bool = False
 
     for row in rows:
-        if _is_restore_comment(row):
-            # Restore only rows that match the `uri` if it is given by input;
+        if _is_restore_comment(row, UPDATE_FUNCTION):
             if uri_filter is not None and row.get("uri") != uri_filter:
                 result.append(row)
                 continue
-
-            # Parse the expression and apply field to the last seen row (comments go after the row they change);
             fields = _parse_update_fields(row.get("prepare", ""))
             if fields and last_property_index is not None:
                 prop_row: dict = dict(result[last_property_index])
@@ -101,10 +136,30 @@ def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[Man
                     prop_row[key] = value
                 prop_row["level"] = row.get("level") or ""
                 result[last_property_index] = prop_row
+
+        elif _is_restore_comment(row, INSERT_FUNCTION):
+            if uri_filter is not None and row.get("uri") != uri_filter:
+                result.append(row)
+                continue
+            fields = _parse_insert_fields(row.get("prepare", ""))
+            if fields and last_model_index is not None:
+                base_row: dict = {col: "" for col in row.keys()}
+                for key, value in fields.items():
+                    base_row[key] = value
+                base_row["level"] = row.get("level") or ""
+                result.insert(last_model_index, base_row)
+                last_model_index += 1
+                base_was_inserted = True
+
         else:
             # If it's not an `update` comment, append to the result as-is;
+            if row.get("model"):
+                last_model_index = len(result)
             if row.get("property"):
                 last_property_index = len(result)
             result.append(row)
+
+    if base_was_inserted:
+        result = _insert_base_resets(result)
 
     return result

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -37,7 +37,7 @@ def uncomment_manifest(
     output: str | None = None,
     manifests: list[str] | None = None,
 ) -> None:
-    """Read raw CSV rows, remove `update` comments, and write the result."""
+    """Read raw CSV rows, remove `update`, `insert` comments, and write the result."""
     rows = _read_raw_manifest_rows(manifests or [])
     result = _uncomment_rows(rows, uri_filter=uri)
     if output:
@@ -119,6 +119,10 @@ def _insert_base_resets(result: list[ManifestRow]) -> list[ManifestRow]:
 
 
 def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[ManifestRow]:
+    """
+    Walk rows in order. When an `update` or `insert` comment is found (and passes the URI filter),
+    patch the most recent property row in `update` case, insert a new base row before the model in `insert` case and drop the comment row.
+    """
     result: list[ManifestRow] = []
     last_property_index: int | None = None
     last_model_index: int | None = None
@@ -152,7 +156,7 @@ def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[Man
                 base_was_inserted = True
 
         else:
-            # If it's not an `update` comment, append to the result as-is;
+            # If it's not an `update` or `insert` comment, append as-is;
             if row.get("model"):
                 last_model_index = len(result)
             if row.get("property"):

--- a/spinta/cli/uncomment.py
+++ b/spinta/cli/uncomment.py
@@ -129,36 +129,36 @@ def _uncomment_rows(rows: list[ManifestRow], uri_filter: str | None) -> list[Man
     base_was_inserted: bool = False
 
     for row in rows:
-        if _is_restore_comment(row, UPDATE_FUNCTION):
+        if _is_restore_comment(row, UPDATE_FUNCTION) or _is_restore_comment(row, INSERT_FUNCTION):
+            # Restore only rows that match the `uri` if it is given by input;
             if uri_filter is not None and row.get("uri") != uri_filter:
                 result.append(row)
                 continue
-            fields = _parse_update_fields(row.get("prepare", ""))
-            if fields and last_property_index is not None:
-                prop_row: dict = dict(result[last_property_index])
-                for key, value in fields.items():
-                    prop_row[key] = value
-                prop_row["level"] = row.get("level") or ""
-                result[last_property_index] = prop_row
+            if _is_restore_comment(row, UPDATE_FUNCTION):
+                fields = _parse_update_fields(row.get("prepare", ""))
+                if fields and last_property_index is not None:
+                    prop_row: dict = dict(result[last_property_index])
+                    for key, value in fields.items():
+                        prop_row[key] = value
+                    prop_row["level"] = row.get("level") or ""
+                    result[last_property_index] = prop_row
 
-        elif _is_restore_comment(row, INSERT_FUNCTION):
-            if uri_filter is not None and row.get("uri") != uri_filter:
-                result.append(row)
-                continue
-            fields = _parse_insert_fields(row.get("prepare", ""))
-            if fields and last_model_index is not None:
-                base_row: dict = {col: "" for col in row.keys()}
-                for key, value in fields.items():
-                    base_row[key] = value
-                base_row["level"] = row.get("level") or ""
-                result.insert(last_model_index, base_row)
-                last_model_index += 1
-                base_was_inserted = True
+            elif _is_restore_comment(row, INSERT_FUNCTION):
+                fields = _parse_insert_fields(row.get("prepare", ""))
+                if fields and last_model_index is not None:
+                    base_row: dict = {col: "" for col in row.keys()}
+                    for key, value in fields.items():
+                        base_row[key] = value
+                    base_row["level"] = row.get("level") or ""
+                    result.insert(last_model_index, base_row)
+                    last_model_index += 1
+                    base_was_inserted = True
 
         else:
             # If it's not an `update` or `insert` comment, append as-is;
             if row.get("model"):
                 last_model_index = len(result)
+                last_property_index = None
             if row.get("property"):
                 last_property_index = len(result)
             result.append(row)

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -128,8 +128,9 @@ def replace_undeclared_base_with_comment(
     base_level: Level | None = base.level
 
     model.base = None
+    model_level = model.level if model.level and model.level > Level.structured else None
 
-    if model.level and model.level > Level.structured:
+    if model_level:
         logger.warning(
             "Base %r used by model %r was not found in the manifest. Dropping base reference and downgrading model level to %d.",
             base_model,
@@ -163,7 +164,7 @@ def replace_undeclared_base_with_comment(
             comment="",
             given=CommentGiven(access=None),
             prepare=prepare,
-            level=4,
+            level=model_level.value if model_level else None,
         )
     )
 

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Iterable, List
 
 from spinta import exceptions
+from spinta.components import Base
 from spinta.components import Config
 from spinta.components import Context
 from spinta.components import Model
@@ -45,8 +46,6 @@ RESERVED_PROPERTY_NAMES = {
 }
 
 C_LANG = "C"
-
-SYSTEMIC_COMMENT_AUTHOR = "author"
 
 
 def check_no_extra_keys(dtype: DataType, schema: Iterable, data: Iterable):
@@ -108,7 +107,7 @@ def replace_undeclared_ref_with_object(
         Comment(
             id=None,
             parent="type",
-            author=SYSTEMIC_COMMENT_AUTHOR,
+            author="",
             access=Access.private,
             created=datetime.now(timezone.utc).isoformat(),
             comment="",
@@ -120,30 +119,50 @@ def replace_undeclared_ref_with_object(
 
 
 def replace_undeclared_base_with_comment(
-    model: Model,
-    base_model: str,
+    context: Context,
+    base: Base,
 ) -> None:
-    logger.warning(
-        "Base %r used by model %r was not found in the manifest. Dropping base reference.",
-        base_model,
-        model.name,
-    )
+    model = base.model
+    base_model = base.parent
+    pk: list[str] = base.pk
+    base_level: Level | None = base.level
 
     model.base = None
+
+    if model.level and model.level > Level.structured:
+        logger.warning(
+            "Base %r used by model %r was not found in the manifest. Dropping base reference and downgrading model level to %d.",
+            base_model,
+            model.name,
+            Level.structured.value,
+        )
+        load_level(context, model, Level.structured)
+    else:
+        logger.warning(
+            "Base %r used by model %r was not found in the manifest. Dropping base reference.",
+            base_model,
+            model.name,
+        )
 
     if model.comments is None:
         model.comments = []
 
+    prepare_parts = [f'base: "{base_model}"']
+    if pk:
+        prepare_parts.append(f'ref: "{", ".join(pk)}"')
+    if base_level is not None:
+        prepare_parts.append(f"level: {base_level.value}")
+    prepare = f"insert({', '.join(prepare_parts)})"
     model.comments.append(
         Comment(
             id=None,
             parent="base",
-            author=SYSTEMIC_COMMENT_AUTHOR,
+            author="",
             access=Access.private,
             created=datetime.now(timezone.utc).isoformat(),
             comment="",
             given=CommentGiven(access=None),
-            prepare=f'insert(base: "{base_model}")',
+            prepare=prepare,
             level=4,
         )
     )

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -147,11 +147,11 @@ def replace_undeclared_base_with_comment(
     if model.comments is None:
         model.comments = []
 
-    prepare_parts = [f'base: "{base_model}"']
+    prepare_parts = [f'base:"{base_model}"']
     if pk:
-        prepare_parts.append(f'ref: "{", ".join(pk)}"')
+        prepare_parts.append(f'ref:"{", ".join(pk)}"')
     if base_level is not None:
-        prepare_parts.append(f"level: {base_level.value}")
+        prepare_parts.append(f"level:{base_level.value}")
     prepare = f"insert({', '.join(prepare_parts)})"
     model.comments.append(
         Comment(

--- a/spinta/types/helpers.py
+++ b/spinta/types/helpers.py
@@ -119,6 +119,36 @@ def replace_undeclared_ref_with_object(
     )
 
 
+def replace_undeclared_base_with_comment(
+    model: Model,
+    base_model: str,
+) -> None:
+    logger.warning(
+        "Base %r used by model %r was not found in the manifest. Dropping base reference.",
+        base_model,
+        model.name,
+    )
+
+    model.base = None
+
+    if model.comments is None:
+        model.comments = []
+
+    model.comments.append(
+        Comment(
+            id=None,
+            parent="base",
+            author=SYSTEMIC_COMMENT_AUTHOR,
+            access=Access.private,
+            created=datetime.now(timezone.utc).isoformat(),
+            comment="",
+            given=CommentGiven(access=None),
+            prepare=f'insert(base: "{base_model}")',
+            level=4,
+        )
+    )
+
+
 def check_model_name(context: Context, model: Model):
     config: Config = context.get("config")
     if config.check_names:

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -326,10 +326,12 @@ def _link_model_page(model: Model):
 @overload
 @commands.link.register(Context, Base)
 def link(context: Context, base: Base):
+    parent_name: str = base.parent
     try:
-        base.parent = commands.get_model(context, base.model.manifest, base.parent)
+        base.parent = commands.get_model(context, base.model.manifest, parent_name)
     except ModelNotFound:
-        replace_undeclared_base_with_comment(base.model, base.parent)
+        base.parent = parent_name
+        replace_undeclared_base_with_comment(context, base)
         return
     base.pk = [base.parent.properties[pk] for pk in base.pk] if base.pk else []
     if commands.identifiable(base):

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -33,13 +33,19 @@ from spinta.exceptions import (
     UnknownPropertyType,
     ReservedPropertyTypeShouldMatchPrimaryKey,
     ReservedPropertySourceOrModelRefShouldBeSet,
+    ModelNotFound,
 )
 from spinta.hacks.urlparams import extract_params_sort_values
 from spinta.manifests.components import Manifest
 from spinta.manifests.tabular.components import PropertyRow
 from spinta.nodes import get_node, load_model_properties, load_node
 from spinta.types.datatype import String, Integer, UUID
-from spinta.types.helpers import check_model_name, check_property_name, check_scope_name
+from spinta.types.helpers import (
+    check_model_name,
+    check_property_name,
+    check_scope_name,
+    replace_undeclared_base_with_comment,
+)
 from spinta.types.namespace import load_namespace_from_name
 from spinta.ufuncs.loadbuilder.components import LoadBuilder
 from spinta.ufuncs.loadbuilder.helpers import get_allowed_page_property_types, page_contains_unsupported_keys
@@ -320,7 +326,11 @@ def _link_model_page(model: Model):
 @overload
 @commands.link.register(Context, Base)
 def link(context: Context, base: Base):
-    base.parent = commands.get_model(context, base.model.manifest, base.parent)
+    try:
+        base.parent = commands.get_model(context, base.model.manifest, base.parent)
+    except ModelNotFound:
+        replace_undeclared_base_with_comment(base.model, base.parent)
+        return
     base.pk = [base.parent.properties[pk] for pk in base.pk] if base.pk else []
     if commands.identifiable(base):
         if base.pk and base.pk != base.parent.external.pkeys:

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -896,3 +896,26 @@ def test_check_enum_named_under_property(context: Context, rc, cli: SpintaCliRun
     assert result.exit_code == 0
     assert "Named enum 'my_status' is declared directly under property 'status'" in result.stdout
     assert "Total errors: 1" in result.stdout
+
+
+def test_check_undeclared_base_does_not_fail(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        [
+            "check",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0

--- a/tests/cli/test_comment.py
+++ b/tests/cli/test_comment.py
@@ -46,7 +46,7 @@ def test_comment_missing_external_refs(context: Context, rc, cli: SpintaCliRunne
       |   |   | City         |         |      |        |                                        |       |         |
       |   |   |   | name     | string  |      |        |                                        |       | private |
       |   |   |   | country  | object  |      |        |                                        | 2     | private |
-                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |         |
+                             | comment | type |        | update(type:"ref", ref:"example2/Country") | 4     |         |
     """
     )
 
@@ -200,7 +200,7 @@ def test_comment_missing_external_bases(context: Context, rc, cli: SpintaCliRunn
     example                  |         |      |        |                                                |       |         |
                              |         |      |        |                                                |       |         |
       |   |   | Country      |         |      |        |                                                |       |         |
-                             | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |         |
+                             | comment | base |        | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |         |
       |   |   |   | name     | string  |      |        |                                                |       | private |
     """
     )
@@ -323,3 +323,27 @@ def test_comment_uncomment_base_reset_roundtrip(context: Context, rc, cli: Spint
     assert len(base_rows) == 1, "Building's Other base should be restored"
     assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Other"
     assert len(reset_rows) == 1, "Region should still have `/` so it doesn't inherit Other"
+
+
+def test_comment_base_with_ref_and_level(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | level | access
+    example                                |         |          |        |     |       |
+                                           |         |          |        |     |       |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        | id  | 4     |
+      |   |                                | Country |          |        |     |       |
+      |   |                                |         | name     | string |     |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "result.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_row = next(row for row in rows if row.get("type") == "comment")
+    assert comment_row["prepare"] == 'insert(base: "dataset/gov/vssa/is/ds/Address", ref: "id", level: 4)'

--- a/tests/cli/test_comment.py
+++ b/tests/cli/test_comment.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from spinta.components import Context
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.cli import SpintaCliRunner
@@ -200,7 +202,7 @@ def test_comment_missing_external_bases(context: Context, rc, cli: SpintaCliRunn
     example                  |         |      |        |                                                |       |         |
                              |         |      |        |                                                |       |         |
       |   |   | Country      |         |      |        |                                                |       |         |
-                             | comment | base |        | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |         |
+                             | comment | base |        | insert(base:"dataset/gov/vssa/is/ds/Address")  |       |         |
       |   |   |   | name     | string  |      |        |                                                |       | private |
     """
     )
@@ -251,7 +253,7 @@ def test_comment_base_all_optional_values_given(context: Context, rc, cli: Spint
     assert comment_row["source"] == "john"
     assert comment_row["uri"] == "http://example.com/issue/1"
     assert comment_row["description"] == "Waiting for Address dataset"
-    assert comment_row["prepare"] == 'insert(base: "dataset/gov/vssa/is/ds/Address")'
+    assert comment_row["prepare"] == 'insert(base:"dataset/gov/vssa/is/ds/Address")'
     assert comment_row["title"], "comment title (creation date) must be set"
     datetime.fromisoformat(comment_row["title"])
 
@@ -346,4 +348,97 @@ def test_comment_base_with_ref_and_level(context: Context, rc, cli: SpintaCliRun
 
     rows = _read_csv(tmp_path / "result.csv")
     comment_row = next(row for row in rows if row.get("type") == "comment")
-    assert comment_row["prepare"] == 'insert(base: "dataset/gov/vssa/is/ds/Address", ref: "id", level: 4)'
+    assert comment_row["prepare"] == 'insert(base:"dataset/gov/vssa/is/ds/Address", ref:"id", level:4)'
+
+
+def test_comment_base_saves_model_level_when_above_structured(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | level | access
+    example                                |         |          |        |     |       |
+                                           |         |          |        |     |       |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |       |
+      |   |                                | Country |          |        |     | 4     |
+      |   |                                |         | name     | string |     |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "result.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_row = next(row for row in rows if row.get("type") == "comment")
+    model_rows = [row for row in rows if row.get("model") and not row.get("property")]
+
+    assert comment_row["level"] == "4"
+    assert model_rows[0]["level"] == "2"
+
+
+def test_comment_uncomment_base_roundtrip_with_model_level(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Full round-trip: model with level > structured gets its level restored after comment + uncomment."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | level | access
+    example                                |         |          |        |     |       |
+                                           |         |          |        |     |       |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |       |
+      |   |                                | Country |          |        |     | 4     |
+      |   |                                |         | name     | string |     |       | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "commented.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    model_rows = [row for row in rows if row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert model_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0
+
+
+@pytest.mark.parametrize("model_level", ["", "1", "2"])
+def test_comment_base_does_not_save_model_level_when_not_above_structured(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path, model_level: str
+):
+    """When model.level <= structured (2) or not set, comment does not write level to the comment row
+    and the model level is left unchanged."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable(f"""
+    d | r | b                              | m       | property | type   | ref | level      | access
+    example                                |         |          |        |     |            |
+                                           |         |          |        |     |            |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |            |
+      |   |                                | Country |          |        |     | {model_level} |
+      |   |                                |         | name     | string |     |            | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "result.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_row = next(row for row in rows if row.get("type") == "comment")
+    model_rows = [row for row in rows if row.get("model") and not row.get("property")]
+
+    assert comment_row["level"] == ""
+    assert model_rows[0]["level"] == model_level

--- a/tests/cli/test_comment.py
+++ b/tests/cli/test_comment.py
@@ -165,3 +165,161 @@ def test_comment_unknown_part_raises(context: Context, rc, cli: SpintaCliRunner,
         fail=False,
     )
     assert result.exit_code != 0
+
+
+def test_comment_missing_external_bases(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        [
+            "comment",
+            "missing-external-refs",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    manifest = load_manifest(rc, tmp_path / "result.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | model   | property | type    | ref  | source | prepare                                        | level | access  | description
+    example                  |         |      |        |                                                |       |         |
+                             |         |      |        |                                                |       |         |
+      |   |   | Country      |         |      |        |                                                |       |         |
+                             | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |         |
+      |   |   |   | name     | string  |      |        |                                                |       | private |
+    """
+    )
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_row = next(row for row in rows if row.get("type") == "comment")
+    assert comment_row["title"], "comment title (creation date) must be set"
+    datetime.fromisoformat(comment_row["title"])
+    assert comment_row["prepare"].startswith("insert(base:")
+
+
+def test_comment_base_all_optional_values_given(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        [
+            "comment",
+            "missing-external-refs",
+            "--author",
+            "john",
+            "--uri",
+            "http://example.com/issue/1",
+            "--description",
+            "Waiting for Address dataset",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "result.csv")
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+    assert len(comment_rows) == 1
+    comment_row = comment_rows[0]
+
+    assert comment_row["source"] == "john"
+    assert comment_row["uri"] == "http://example.com/issue/1"
+    assert comment_row["description"] == "Waiting for Address dataset"
+    assert comment_row["prepare"] == 'insert(base: "dataset/gov/vssa/is/ds/Address")'
+    assert comment_row["title"], "comment title (creation date) must be set"
+    datetime.fromisoformat(comment_row["title"])
+
+
+def test_comment_base_idempotent(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented2.csv", tmp_path / "commented.csv"],
+    )
+    rows1 = _read_csv(tmp_path / "commented.csv")
+    rows2 = _read_csv(tmp_path / "commented2.csv")
+    comment_rows1 = [row for row in rows1 if row.get("type") == "comment"]
+    comment_rows2 = [row for row in rows2 if row.get("type") == "comment"]
+    assert len(comment_rows1) == 1
+    assert len(comment_rows2) == 1, "second run must not duplicate the base restore comment"
+    assert comment_rows1[0]["prepare"] == comment_rows2[0]["prepare"]
+
+
+def test_comment_uncomment_base_reset_roundtrip(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Round-trip preserves `/` semantics: a model originally without base stays without base
+    after comment + uncomment, even when a sibling model had its base restored."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                            | m        | property | type   | ref | access
+    example                              |          |          |        |     |
+                                         |          |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Other |          |          |        |     |
+      |   |                              | Building |          |        |     |
+      |   |                              |          | name     | string |     | private
+      |   | /                            |          |          |        |     |
+      |   |                              | Region   |          |        |     |
+      |   |                              |          | name     | string |     | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "commented.csv"],
+    )
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    reset_rows = [row for row in rows if row.get("base") == "/"]
+    base_rows = [
+        row
+        for row in rows
+        if row.get("base") and row.get("base") != "/" and not row.get("model") and not row.get("property")
+    ]
+    assert len(base_rows) == 1, "Building's Other base should be restored"
+    assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Other"
+    assert len(reset_rows) == 1, "Region should still have `/` so it doesn't inherit Other"

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1453,7 +1453,7 @@ def test_copy_undeclared_base_drops_and_comments(context: Context, rc, cli: Spin
     example                  |         |        |        |                                                |       |
                              |         |        |        |                                                |       |
       |   |   | Country      |         |        |        |                                                |       |
-                             | comment | base   |        | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+                             | comment | base   |        | insert(base:"dataset/gov/vssa/is/ds/Address")  |       |
       |   |   |   | name     | string  |        |        |                                                |       | private
     """
     )

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1449,11 +1449,11 @@ def test_copy_undeclared_base_drops_and_comments(context: Context, rc, cli: Spin
     assert (
         manifest
         == """
-    d | r | b | model    | property | type  | ref    | source| prepare                                        | level | access
-    example              |          |       |        |       |                                                |       |
-                         |          |       |        |       |                                                |       |
-      |   |   | Country  |          |       |        |       |                                                |       |
-                         | comment  | base  | author |       | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
-      |   |   |   | name | string   |       |        |       |                                                |       | private
+    d | r | b | model    | property | type    | ref    | source | prepare                                        | level | access
+    example                  |         |        |        |                                                |       |
+                             |         |        |        |                                                |       |
+      |   |   | Country      |         |        |        |                                                |       |
+                             | comment | base   | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |   | name     | string  |        |        |                                                |       | private
     """
     )

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1416,3 +1416,44 @@ def test_copy_multiple_scopes(context: Context, rc, cli: SpintaCliRunner, tmp_pa
       |   |   |   | region   | string |      | region |                        | public
     """
     )
+
+
+def test_copy_undeclared_base_drops_and_comments(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """When a model declares an undeclared base, copy should output the model
+    without that base and append a restore comment row."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        [
+            "copy",
+            "--no-source",
+            "--access",
+            "private",
+            "-o",
+            tmp_path / "result.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    manifest = load_manifest(rc, tmp_path / "result.csv")
+    assert (
+        manifest
+        == """
+    d | r | b | model    | property | type  | ref    | source| prepare                                        | level | access
+    example              |          |       |        |       |                                                |       |
+                         |          |       |        |       |                                                |       |
+      |   |   | Country  |          |       |        |       |                                                |       |
+                         | comment  | base  | author |       | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |   | name | string   |       |        |       |                                                |       | private
+    """
+    )

--- a/tests/cli/test_copy.py
+++ b/tests/cli/test_copy.py
@@ -1279,7 +1279,7 @@ def test_copy_undeclared_ref_transforms_to_object(context: Context, rc, cli: Spi
       |   |   | City         |         |      |        |                                        |       |
       |   |   |   | name     | string  |      |        |                                        |       | private
       |   |   |   | country  | object  |      |        |                                        | 2     | private
-                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |
+                             | comment | type |        | update(type:"ref", ref:"example2/Country") | 4     |
     """
     )
 
@@ -1453,7 +1453,7 @@ def test_copy_undeclared_base_drops_and_comments(context: Context, rc, cli: Spin
     example                  |         |        |        |                                                |       |
                              |         |        |        |                                                |       |
       |   |   | Country      |         |        |        |                                                |       |
-                             | comment | base   | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+                             | comment | base   |        | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
       |   |   |   | name     | string  |        |        |                                                |       | private
     """
     )

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -218,3 +218,25 @@ def test_undeclared_base_run_does_not_fail_xml(rc: RawConfig, tmp_path: Path):
     resp = app.get("/example/City")
     assert resp.status_code == 200
     assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_base_with_ref_and_level_comment_prepare(rc: RawConfig):
+    from spinta import commands as spinta_commands
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+        d | r | b                              | m       | property | type   | ref | level | access
+        example                                |         |          |        |     |       |
+                                               |         |          |        |     |       |
+          |   | dataset/gov/vssa/is/ds/Address |         |          |        | id  | 4     |
+          |   |                                | Country |          |        |     |       |
+          |   |                                |         | name     | string |     |       | open
+        """,
+        mode=Mode.internal,
+    )
+    model = spinta_commands.get_models(context, manifest)["example/Country"]
+    assert model.base is None, "undeclared base should be dropped"
+    assert model.comments, "restore comment should be added"
+    comment = model.comments[0]
+    assert comment.prepare == 'insert(base: "dataset/gov/vssa/is/ds/Address", ref: "id", level: 4)'

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -239,4 +239,4 @@ def test_undeclared_base_with_ref_and_level_comment_prepare(rc: RawConfig):
     assert model.base is None, "undeclared base should be dropped"
     assert model.comments, "restore comment should be added"
     comment = model.comments[0]
-    assert comment.prepare == 'insert(base: "dataset/gov/vssa/is/ds/Address", ref: "id", level: 4)'
+    assert comment.prepare == 'insert(base:"dataset/gov/vssa/is/ds/Address", ref:"id", level:4)'

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -124,3 +124,97 @@ def test_undeclared_ref_run_does_not_fail_xml(rc: RawConfig, tmp_path: Path):
     resp = app.get("/example/City")
     assert resp.status_code == 200
     assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_base_run_does_not_fail_csv(rc: RawConfig, fs: MemoryFileSystem):
+    """spinta run should not fail (manifest loads, app starts, data is served)
+    when a model declares a base not present in the manifest."""
+    fs.pipe("cities.csv", b"name\nVilnius\nRiga\n")
+    context, manifest = prepare_manifest(
+        rc,
+        """
+        d | r | b                              | m    | property | type     | ref | source              | access
+        example                                |      |          |          |     |                     |
+          | csv                                |      |          | dask/csv |     | memory://cities.csv |
+          |   | dataset/gov/vssa/is/ds/Address |      |          |          |     |                     |
+          |   |                                | City |          |          |     |                     |
+          |   |                                |      | name     | string   |     | name                | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall"])
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_base_run_does_not_fail_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """spinta run should not fail with a SQL data source when a model declares
+    a base not present in the manifest."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m    | property | type   | ref | source | access
+    example                                |      |          |        |     |        |
+      | resource                           |      |          | sql    |     |        |
+      |   | dataset/gov/vssa/is/ds/Address |      |          |        |     |        |
+      |   |                                | City |          |        |     | CITY   |
+      |   |                                |      | name     | string |     | NAME   | open
+    """),
+    )
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius"},
+            {"NAME": "Riga"},
+        ],
+    )
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall"])
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]
+
+
+def test_undeclared_base_run_does_not_fail_xml(rc: RawConfig, tmp_path: Path):
+    """spinta run should not fail with an XML data source when a model declares
+    a base not present in the manifest."""
+    path = tmp_path / "cities.xml"
+    path.write_text("""
+        <cities>
+            <city>
+                <name>Vilnius</name>
+            </city>
+            <city>
+                <name>Riga</name>
+            </city>
+        </cities>
+    """)
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b                              | m    | property | type     | ref | source       | access
+        example                                |      |          |          |     |              |
+          | xml                                |      |          | dask/xml |     | {path}       |
+          |   | dataset/gov/vssa/is/ds/Address |      |          |          |     |              |
+          |   |                                | City |          |          |     | /cities/city |
+          |   |                                |      | name     | string   |     | name         | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall"])
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Riga", "Vilnius"]

--- a/tests/cli/test_uncomment.py
+++ b/tests/cli/test_uncomment.py
@@ -179,3 +179,234 @@ def test_uncomment_uri_filter(context: Context, rc, cli: SpintaCliRunner, tmp_pa
     assert property_country["ref"] == "example2/Country"
     assert property_capital["type"] == "ref"
     assert property_capital["ref"] == "example3/Capital"
+
+
+def test_uncomment_base_direct_input(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                        | level | access
+    example              |          |         |      |        |                                                |       |
+                         |          |         |      |        |                                                |       |
+      |   |   | Country  |          |         |      |        |                                                |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |          | name     | string  |      |        |                                                |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "-o",
+            tmp_path / "restored.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+
+    base_rows = [row for row in rows if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(base_rows) == 1, "base should be restored as its own row"
+    assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
+    assert base_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0, "restore comment should have been removed"
+
+
+def test_comment_uncomment_base_roundtrip(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """Full round-trip: comment drops a missing base, uncomment restores it."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | access
+    example                                |         |          |        |     |
+                                           |         |          |        |     |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        |     |
+      |   |                                | Country |          |        |     |
+      |   |                                |         | name     | string |     | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "commented.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+
+    base_rows = [row for row in rows if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(base_rows) == 1, "base row should be restored above the model"
+    assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
+    assert base_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0, "restore comment should have been removed"
+
+
+def test_uncomment_base_uri_filter(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """uncomment --uri only restores base comments that carry the matching URI tag."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                        | level | access  | uri
+    example              |          |         |      |        |                                                |       |         |
+                         |          |         |      |        |                                                |       |         |
+      |   |   | Country  |          |         |      |        |                                                |       |         |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |         | http://foo
+      |   |   |          | name     | string  |      |        |                                                |       | private |
+      |   |   | City     |          |         |      |        |                                                |       |         |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Other")   | 4     |         | http://foo
+      |   |   |          | name     | string  |      |        |                                                |       | private |
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "--uri",
+            "http://bar",
+            "-o",
+            tmp_path / "restored_bar.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    rows_bar = _read_csv(tmp_path / "restored_bar.csv")
+    base_rows_bar = [row for row in rows_bar if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows_bar = [row for row in rows_bar if row.get("type") == "comment"]
+    assert len(base_rows_bar) == 0, "no base should be restored when URI doesn't match"
+    assert len(comment_rows_bar) == 2, "both comments should remain when URI doesn't match"
+
+    result = cli.invoke(
+        rc,
+        [
+            "uncomment",
+            "--uri",
+            "http://foo",
+            "-o",
+            tmp_path / "restored_foo.csv",
+            tmp_path / "manifest.csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    rows_foo = _read_csv(tmp_path / "restored_foo.csv")
+    base_rows_foo = [row for row in rows_foo if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows_foo = [row for row in rows_foo if row.get("type") == "comment"]
+    assert len(comment_rows_foo) == 0, "all comments should be removed when URI matches"
+    restored_bases = sorted(row["base"] for row in base_rows_foo)
+    assert restored_bases == [
+        "dataset/gov/vssa/is/ds/Address",
+        "dataset/gov/vssa/is/ds/Other",
+    ]
+
+
+def test_uncomment_inserts_base_reset_between_restored_and_baseless_model(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                      | level | access
+    example              |          |         |      |        |                                              |       |
+                         |          |         |      |        |                                              |       |
+      |   |   | Building |          |         |      |        |                                              |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Other") | 4     |
+      |   |   |          | name     | string  |      |        |                                              |       | private
+      |   |   | Region   |          |         |      |        |                                              |       |
+      |   |   |          | name     | string  |      |        |                                              |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+
+    base_or_model_rows = [
+        row
+        for row in rows
+        if (row.get("base") and not row.get("model") and not row.get("property")) or row.get("model")
+    ]
+    sequence = [(row.get("base"), row.get("model")) for row in base_or_model_rows]
+
+    assert sequence == [
+        ("dataset/gov/vssa/is/ds/Other", ""),
+        ("", "Building"),
+        ("/", ""),
+        ("", "Region"),
+    ], f"unexpected base/model sequence: {sequence}"
+
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+    assert len(comment_rows) == 0, "restore comment should have been removed"
+
+
+def test_uncomment_no_base_reset_between_models_with_own_restored_bases(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                        | level | access
+    example              |          |         |      |        |                                                |       |
+                         |          |         |      |        |                                                |       |
+      |   |   | Country  |          |         |      |        |                                                |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |          | name     | string  |      |        |                                                |       | private
+      |   |   | City     |          |         |      |        |                                                |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |          | name     | string  |      |        |                                                |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+
+    reset_rows = [row for row in rows if row.get("base") == "/"]
+    assert reset_rows == [], "no `/` reset should be inserted between models that both have their own base"
+
+    base_rows = [
+        row
+        for row in rows
+        if row.get("base") and row.get("base") != "/" and not row.get("model") and not row.get("property")
+    ]
+    assert len(base_rows) == 2, "both Country and City should have their bases restored"
+    assert all(r["base"] == "dataset/gov/vssa/is/ds/Address" for r in base_rows)
+
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+    assert len(comment_rows) == 0, "all restore comments should have been removed"
+
+
+def test_uncomment_ref_only_does_not_insert_base_resets(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref  | source | prepare                                | level | access
+    example                  |         |      |        |                                        |       |
+                             |         |      |        |                                        |       |
+      |   |   | City         |         |      |        |                                        |       |
+      |   |   |   | country  | object  |      |        |                                        | 2     | private
+                             | comment | type | author | update(type:"ref", ref:"example2/Country") | 4     |
+    """),
+    )
+    cli.invoke(rc, ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"])
+    rows = _read_csv(tmp_path / "restored.csv")
+    reset_rows = [row for row in rows if row.get("base") == "/"]
+    assert reset_rows == [], "ref-only uncomment must not insert `/` rows"

--- a/tests/cli/test_uncomment.py
+++ b/tests/cli/test_uncomment.py
@@ -476,3 +476,59 @@ def test_comment_uncomment_base_with_ref_and_level_roundtrip(
     assert base_rows[0]["ref"] == "id"
     assert base_rows[0]["level"] == "4"
     assert len(comment_rows) == 0
+
+
+def test_uncomment_base_restores_model_level(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    """When an INSERT comment carries a level, uncomment writes that level back to the model row."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                        | level | access
+    example              |          |         |      |        |                                                |       |
+                         |          |         |      |        |                                                |       |
+      |   |   | Country  |          |         |      |        |                                                |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") | 4     |
+      |   |   |          | name     | string  |      |        |                                                |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    model_rows = [row for row in rows if row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(model_rows) == 1
+    assert model_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0
+
+
+def test_uncomment_base_without_level_does_not_change_model_level(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model    | property | type    | ref  | source | prepare                                        | level | access
+    example              |          |         |      |        |                                                |       |
+                         |          |         |      |        |                                                |       |
+      |   |   | Country  |          |         |      |        |                                                |       |
+                         |          | comment | base | author | insert(base: "dataset/gov/vssa/is/ds/Address") |       |
+      |   |   |          | name     | string  |      |        |                                                |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    model_rows = [row for row in rows if row.get("model") and not row.get("property")]
+
+    assert model_rows[0]["level"] == ""

--- a/tests/cli/test_uncomment.py
+++ b/tests/cli/test_uncomment.py
@@ -212,7 +212,7 @@ def test_uncomment_base_direct_input(context: Context, rc, cli: SpintaCliRunner,
 
     assert len(base_rows) == 1, "base should be restored as its own row"
     assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
-    assert base_rows[0]["level"] == "4"
+    assert base_rows[0]["level"] == ""
     assert len(comment_rows) == 0, "restore comment should have been removed"
 
 
@@ -247,7 +247,7 @@ def test_comment_uncomment_base_roundtrip(context: Context, rc, cli: SpintaCliRu
 
     assert len(base_rows) == 1, "base row should be restored above the model"
     assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
-    assert base_rows[0]["level"] == "4"
+    assert base_rows[0]["level"] == ""
     assert len(comment_rows) == 0, "restore comment should have been removed"
 
 
@@ -410,3 +410,69 @@ def test_uncomment_ref_only_does_not_insert_base_resets(context: Context, rc, cl
     rows = _read_csv(tmp_path / "restored.csv")
     reset_rows = [row for row in rows if row.get("base") == "/"]
     assert reset_rows == [], "ref-only uncomment must not insert `/` rows"
+
+
+def test_uncomment_base_with_ref_and_level_direct_input(context: Context, rc, cli: SpintaCliRunner, tmp_path: Path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | model   | property  | type    | ref  | source | prepare                                                              | level | access
+    example              |          |         |      |        |                                                                      |       |
+                         |          |         |      |        |                                                                      |       |
+      |   |   | Country  |          |         |      |        |                                                                      |       |
+                         |          | comment | base |        | insert(base: "dataset/gov/vssa/is/ds/Address", ref: "id", level: 4)  | 4     |
+      |   |   |          | name     | string  |      |        |                                                                      |       | private
+    """),
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "manifest.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    base_rows = [row for row in rows if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(base_rows) == 1
+    assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
+    assert base_rows[0]["ref"] == "id"
+    assert base_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0
+
+
+def test_comment_uncomment_base_with_ref_and_level_roundtrip(
+    context: Context, rc, cli: SpintaCliRunner, tmp_path: Path
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b                              | m       | property | type   | ref | level | access
+    example                                |         |          |        |     |       |
+                                           |         |          |        |     |       |
+      |   | dataset/gov/vssa/is/ds/Address |         |          |        | id  | 4     |
+      |   |                                | Country |          |        |     |       |
+      |   |                                |         | name     | string |     |       | private
+    """),
+    )
+    cli.invoke(
+        rc,
+        ["comment", "missing-external-refs", "-o", tmp_path / "commented.csv", tmp_path / "manifest.csv"],
+    )
+    result = cli.invoke(
+        rc,
+        ["uncomment", "-o", tmp_path / "restored.csv", tmp_path / "commented.csv"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rows = _read_csv(tmp_path / "restored.csv")
+    base_rows = [row for row in rows if row.get("base") and not row.get("model") and not row.get("property")]
+    comment_rows = [row for row in rows if row.get("type") == "comment"]
+
+    assert len(base_rows) == 1
+    assert base_rows[0]["base"] == "dataset/gov/vssa/is/ds/Address"
+    assert base_rows[0]["ref"] == "id"
+    assert base_rows[0]["level"] == "4"
+    assert len(comment_rows) == 0


### PR DESCRIPTION
- Do not throw an exception when base model is not found. Instead, put a Warning log message and insert a comment above that Model.
Summary:
- `replace_undeclared_base_with_comment`
-  Added a new helper mirroring the existing replace_undeclared_ref_with_object. When a model's base cannot be resolved in the manifest, instead of raising an error, it drops the base from the model, and append a systemic comment row so it can be restored later
 - The link command for Base now catches ModelNotFound when resolving the base model. On failure it calls replace_undeclared_base_with_comment and returns early, leaving the model intact but with a restore comment instead of a broken base reference.
- `comment` — extended to cover base restore comments
- `uncomment` — extended to restore base rows
    - Previously uncomment only handled update(...) restore comments (restoring downgraded property refs). It now also handles insert(base: "...") restore comments:
  - Added _insert_base_resets: after base rows are restored, a second pass inserts a / reset row before any model that doesn't have its own base row but would otherwise inherit a base context leaked from the preceding model.

Ticket: https://github.com/atviriduomenys/spinta/issues/1928