### PR TITLE
[1938] Validate JWT claims

### DIFF
--- a/spinta/auth.py
+++ b/spinta/auth.py
@@ -23,6 +23,7 @@ import ruamel.yaml
 from authlib.jose import JsonWebKey, RSAKey, JWTClaims
 from authlib.jose import jwt
 from authlib.jose.errors import JoseError, DecodeError, InvalidTokenError, BadSignatureError
+from urllib.parse import urlparse
 from authlib.oauth2 import OAuth2Error
 from authlib.oauth2 import OAuth2Request
 from authlib.oauth2 import rfc6749
@@ -263,17 +264,31 @@ class BearerTokenValidator(rfc6750.BearerTokenValidator):
         self._context = context
         self._default_public_key: RSAKey = load_key(context, KeyType.public)
         self._all_public_keys: list[RSAKey] = load_all_public_keys(context)
+        config = context.get("config")
+        if config.token_issuer:
+            self._issuer = config.token_issuer
+        elif config.token_validation_keys_download_url:
+            parsed = urlparse(config.token_validation_keys_download_url)
+            self._issuer = f"{parsed.scheme}://{parsed.netloc}"
+        else:
+            self._issuer = None
 
     def decode_token(self, token_string: str) -> JWTClaims:
         if not token_string:
             raise InvalidToken("Token string is required")
+
+        claims_options = {}
+        if self._issuer:
+            claims_options["iss"] = {"essential": True, "value": self._issuer}
 
         try:
             token_header = decode_unverified_header(token_string)
             if kid := token_header.get("key"):
                 for key in self._all_public_keys:
                     if key.kid and str(key.kid) == str(kid):
-                        return jwt.decode(token_string, key)
+                        decoded = jwt.decode(token_string, key, claims_options=claims_options)
+                        decoded.validate()
+                        return decoded
 
             token_kty = decode_kty_from_alg(token_header["alg"])
             for key in self._all_public_keys:
@@ -283,7 +298,9 @@ class BearerTokenValidator(rfc6750.BearerTokenValidator):
                 is_same_algorithm_type = key.kty and key.kty == token_kty
                 if is_not_encryption_key and (is_same_algorithm or is_same_algorithm_type):
                     try:
-                        return jwt.decode(token_string, key)
+                        decoded = jwt.decode(token_string, key, claims_options=claims_options)
+                        decoded.validate()
+                        return decoded
                     except BadSignatureError:
                         continue
         except (JoseError, DecodeError, InvalidTokenError) as e:

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -1114,6 +1114,7 @@ class Config:
     http_basic_auth: bool
     token_validation_key: dict | None = None
     token_validation_keys_download_url: str | None = None
+    token_issuer: str | None = None
     downloaded_public_keys_file: pathlib.Path
     datasets: dict
     env: str

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -94,7 +94,8 @@ def load(context: Context, config: Config) -> Config:
     config.http_basic_auth = rc.get("http_basic_auth", default=False, cast=asbool)
     config.token_validation_key = rc.get("token_validation_key", cast=json.loads) or None
     config.token_validation_keys_download_url = rc.get("token_validation_keys_download_url")
-    config.downloaded_public_keys_file = (
+    config.token_issuer = rc.get("token_issuer")
+    config.downloaded_public_keys_file = pathlib.Path(
         rc.get("downloaded_public_keys_file") or DEFAULT_CONFIG_PATH / "downloaded-well-knows.json"
     )
     config.datasets = rc.get("datasets", default={})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -341,6 +341,17 @@ def test_invalid_access_token(app):
     assert get_error_codes(resp.json()) == ["InvalidToken"]
 
 
+def test_expired_token_rejected_at_api_level(app):
+    import time as time_module
+
+    confdir = pathlib.Path(__file__).parent
+    prvkey = JsonWebKey.import_key(json.loads((confdir / "config/keys/private.json").read_text()))
+    token = _make_jwt(prvkey, {"exp": int(time_module.time()) - 10})
+    resp = app.get("/Report", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert get_error_codes(resp.json()) == ["InvalidToken"]
+
+
 @pytest.mark.parametrize("scopes", [["spinta_report_getall"], ["uapi:/Report/:getall"]])
 def test_token_validation_key_config(backends, rc, tmp_path, request, scopes: list):
     confdir = pathlib.Path(__file__).parent
@@ -1290,3 +1301,112 @@ class TestTokenCheckContractScopes:
         context.set("auth.token", token)
 
         assert token.check_contract_scopes(context) is None
+
+
+def _make_jwt(private_key, payload_overrides=None):
+    import time
+    from authlib.jose import jwt as jose_jwt
+
+    now = int(time.time())
+    payload = {
+        "sub": "testclient",
+        "aud": "testclient",
+        "iss": "https://example.com",
+        "iat": now,
+        "exp": now + 600,
+        "scope": "spinta_getall",
+    }
+    if payload_overrides:
+        payload.update(payload_overrides)
+    return jose_jwt.encode({"alg": "RS512"}, payload, private_key).decode("ascii")
+
+
+class TestIssuerValidation:
+    def _make_context(self, rc, tmp_path, request, extra_config=None):
+        from spinta.cli.helpers.store import load_config
+
+        confdir = pathlib.Path(__file__).parent
+        private_key_data = json.loads((confdir / "config/keys/private.json").read_text())
+        pubkey_data = json.loads((confdir / "config/keys/public.json").read_text())
+
+        cfg = {
+            "config_path": str(tmp_path),
+            "default_auth_client": None,
+            "token_validation_key": json.dumps(pubkey_data),
+        }
+        if extra_config:
+            cfg.update(extra_config)
+
+        context = create_test_context(rc.fork(cfg))
+        load_config(context, ensure_config_dir=True, check_config=False)
+        return context, JsonWebKey.import_key(private_key_data)
+
+    def test_correct_iss_accepted(self, rc, tmp_path, request):
+        context, private_key = self._make_context(rc, tmp_path, request, {"token_issuer": "https://example.com"})
+        token_string = _make_jwt(private_key)
+        token = Token(token_string, BearerTokenValidator(context))
+        assert token.get_sub() == "testclient"
+
+    def test_wrong_iss_rejected(self, rc, tmp_path, request):
+        from spinta.exceptions import InvalidToken
+
+        context, private_key = self._make_context(rc, tmp_path, request, {"token_issuer": "https://other.com"})
+        token_string = _make_jwt(private_key)
+        with pytest.raises(InvalidToken):
+            Token(token_string, BearerTokenValidator(context))
+
+    def test_missing_iss_rejected(self, rc, tmp_path, request):
+        from spinta.exceptions import InvalidToken
+
+        context, private_key = self._make_context(rc, tmp_path, request, {"token_issuer": "https://example.com"})
+        token_string = _make_jwt(private_key, {"iss": None})
+        with pytest.raises(InvalidToken):
+            Token(token_string, BearerTokenValidator(context))
+
+    def test_no_token_issuer_config_skips_iss_check(self, rc, tmp_path, request):
+        context, private_key = self._make_context(rc, tmp_path, request)
+        token_string = _make_jwt(private_key, {"iss": "https://anything-goes.example"})
+        token = Token(token_string, BearerTokenValidator(context))
+        assert token.get_sub() == "testclient"
+
+    def test_expired_token_rejected(self, rc, tmp_path, request):
+        import time
+        from spinta.exceptions import InvalidToken
+
+        context, private_key = self._make_context(rc, tmp_path, request)
+        token_string = _make_jwt(private_key, {"exp": int(time.time()) - 10})
+        with pytest.raises(InvalidToken):
+            Token(token_string, BearerTokenValidator(context))
+
+    def test_issuer_derived_from_download_url(self, rc, tmp_path, request, requests_mock):
+        confdir = pathlib.Path(__file__).parent
+        private_key_data = json.loads((confdir / "config/keys/private.json").read_text())
+        pubkey_data = json.loads((confdir / "config/keys/public.json").read_text())
+
+        mock_url = "https://example.com/.well-known/jwks.json"
+        requests_mock.get(mock_url, json={"keys": [pubkey_data]})
+
+        downloaded_file = tmp_path / "downloaded-well-knows.json"
+        downloaded_file.write_text(json.dumps({"keys": [pubkey_data]}))
+
+        from spinta.cli.helpers.store import load_config
+
+        cfg = {
+            "config_path": str(tmp_path),
+            "default_auth_client": None,
+            "token_validation_keys_download_url": mock_url,
+            "downloaded_public_keys_file": str(downloaded_file),
+        }
+        context = create_test_context(rc.fork(cfg))
+        load_config(context, ensure_config_dir=True, check_config=False)
+
+        from spinta.exceptions import InvalidToken
+
+        private_key_obj = JsonWebKey.import_key(private_key_data)
+        good_token = _make_jwt(private_key_obj, {"iss": "https://example.com"})
+        token = Token(good_token, BearerTokenValidator(context))
+        assert token.get_sub() == "testclient"
+
+        bad_token = _make_jwt(private_key_obj, {"iss": "https://wrong.com"})
+        with pytest.raises(InvalidToken):
+            Token(bad_token, BearerTokenValidator(context))


### PR DESCRIPTION
Validate JWT token claims:

- `iss` — Validate that the issuer of the token is what we expect it to be;
- `exp` — Validate that the token is not expired;