### PR TITLE
enum empty string fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,10 +26,12 @@ New Features:
 
 Bug fixes:
 
+- Fixed a bug where an empty string literal (``""``) in the ``prepare`` column of an enum row was incorrectly rejected with "At least source or prepare must be specified" (`#1936`_).
 - Fixed a bug where nested backrefs where causing an error (`#1608`_).
 
 .. _#1608: https://github.com/atviriduomenys/spinta/issues/1608
 .. _#1922: https://github.com/atviriduomenys/spinta/issues/1922
+.. _#1936: https://github.com/atviriduomenys/spinta/issues/1936
 
 0.2dev24 (2026-05-08)
 =====================

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -1477,9 +1477,9 @@ class EnumReader(TabularReader):
                     prepare = -prepare["args"][0]
                 else:
                     prepare = row[PREPARE]
-            source = str(prepare)
+            source = str(prepare) if prepare is not NA else None
 
-        if not source:
+        if source is None:
             self.error("At least source or prepare must be specified for an enum.")
 
         self.data = {

--- a/tests/datasets/dataframe/test_read.py
+++ b/tests/datasets/dataframe/test_read.py
@@ -353,8 +353,7 @@ def test_swap_ufunc(rc: RawConfig, fs: AbstractFileSystem):
       |   |   | City         |          | name |                     |                    |
       |   |   |   | id       | string   |      | id                  |                    | open
       |   |   |   | name     | string   |      | name                |                    | open
-      |   |   |   |          | enum     |      |                     |                    | open
-      |   |   |   |          |          |      |                     |  swap('nan', '---')  | open
+      |   |   |   |          | enum     |      |                     |  swap('nan', '---')  | open
       |   |   |   |          |          |      |                     |  swap(null, '---') | open
       |   |   |   |          |          |      |                     |  swap('', '---')   | open
       |   |   |   |          |          |      |                     |  '---'             | open

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -366,3 +366,22 @@ def test_check_enum_no_operation_prepare_integer(manifest_type, tmp_path, rc):
         tmp_path=tmp_path,
     )
     commands.check(context, manifest)
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_check_enum_empty_string_prepare(manifest_type, tmp_path, rc):
+    context, manifest = load_manifest_and_context(
+        rc,
+        """
+        d | r | b | m | property | type    | ref | source       | prepare
+        dataset1                 |         |     |              |
+          | resource1            | sql     |     |              |
+          |   |   | City         |         | id  | CITIES       |
+          |   |   |   | id       | integer |     | ID           |
+          |   |   |   | country  | string  |     | COUNTRY_CODE |
+          |   |   |   |          | enum    |     |              | ""
+        """,
+        manifest_type=manifest_type,
+        tmp_path=tmp_path,
+    )
+    commands.check(context, manifest)


### PR DESCRIPTION
## Fix: allow empty string literal (`""`) in enum `prepare` column

### Problem

When parsing a CSV/tabular manifest, an enum row with `prepare=""` (empty string literal) raised:

    TabularManifestError: At least source or prepare must be specified for an enum.

even though `""` is a valid prepare value.

### Root cause

`spyna.parse('""')` correctly returns Python's `''`. The validation code then did `source = str(prepare)` → `str('') == ''`, which is falsy, tripping the `if not source:` check. At the same time, if would also convert `NA` value to `"<NA>"`, which would be truthy and spinta check would let it pass. So this is also now fixed.

### Fix

In `EnumReader.read()`, changed:

    source = str(prepare)
    if not source:
        self.error(...)

to:

    source = str(prepare) if prepare is not NA else None
    if source is None:
        self.error(...)

`NA` is only returned by `_parse_spyna` when the prepare cell is truly absent. Everything else — including `''` from `""` — is an explicitly provided value and should not trigger the error.
