### PR TITLE
enum.ref validation fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Improvements:
     new expression shapes can be added without touching the loader.
   - Invalid `prepare` expressions raise a clear `ModelNotFound` `PropertyNotFound`
     error pointing at the offending scope.
+- Added validation that raises an error when a named enum (with a `ref`) is declared directly under a property (`#1935`_).
 
 New Features:
 
@@ -27,6 +28,7 @@ New Features:
 - Added ability to configure default and model specific distribution strategy (`#1691`_).
 
 .. _#1691: https://github.com/atviriduomenys/spinta/issues/1691
+.. _#1935: https://github.com/atviriduomenys/spinta/issues/1935
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 0.2dev26 (unreleased)
 =====================
 
+Improvements:
+
+- Added validation that raises an error when a named enum (with a `ref`) is declared directly under a property (`#1935`_).
+
+.. _#1935: https://github.com/atviriduomenys/spinta/issues/1935
 
 0.2dev25 (2026-05-22)
 =====================
@@ -20,7 +25,6 @@ Improvements:
     new expression shapes can be added without touching the loader.
   - Invalid `prepare` expressions raise a clear `ModelNotFound` `PropertyNotFound`
     error pointing at the offending scope.
-- Added validation that raises an error when a named enum (with a `ref`) is declared directly under a property (`#1935`_).
 
 New Features:
 
@@ -28,7 +32,6 @@ New Features:
 - Added ability to configure default and model specific distribution strategy (`#1691`_).
 
 .. _#1691: https://github.com/atviriduomenys/spinta/issues/1691
-.. _#1935: https://github.com/atviriduomenys/spinta/issues/1935
 
 Bug fixes:
 

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -1215,6 +1215,13 @@ class EnumPrepareMissing(UserError):
     """
 
 
+class InlineEnumWithName(UserError):
+    template = (
+        "Named enum {enum!r} is declared directly under property {property!r}. "
+        "Either remove the name to make it an inline enum, or move it to dataset dimension."
+    )
+
+
 class SourceOrPrepareNotAllowed(UserError):
     template = """
         The source {source} was not expected. Delete it from the manifest or update the prepare function to allow it.    

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -23,6 +23,7 @@ from spinta.dimensions.param.helpers import load_params
 from spinta.dimensions.scope.components import Scope
 from spinta.dimensions.scope.helpers import load_scopes
 from spinta.exceptions import (
+    InlineEnumWithName,
     InvalidCustomPropertyTypeConfiguration,
     InvalidCustomPropertyTypeWithArgsConfiguration,
     KeymapNotSet,
@@ -643,6 +644,10 @@ def check(context: Context, scope: Scope) -> None:
 @check.register(Context, Property)
 def check(context: Context, prop: Property):
     check_property_name(context, prop)
+    if prop.enums:
+        for enum_name in prop.enums:
+            if enum_name:
+                raise InlineEnumWithName(prop, enum=enum_name)
     if prop.enum:
         for value, item in prop.enum.items():
             commands.check(context, item, prop.dtype, item.prepare)

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -647,7 +647,8 @@ def check(context: Context, prop: Property):
     if prop.enums:
         for enum_name in prop.enums:
             if enum_name:
-                raise InlineEnumWithName(prop, enum=enum_name)
+                manager = context.get("error_manager")
+                manager.handle_error(InlineEnumWithName(prop, enum=enum_name))
     if prop.enum:
         for value, item in prop.enum.items():
             commands.check(context, item, prop.dtype, item.prepare)

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -869,3 +869,30 @@ def test_check_scope_duplicate_err(context: Context, rc, cli: SpintaCliRunner, t
 
     assert result.exit_code != 0
     assert "already defined" in str(result.exception).lower()
+
+
+def test_check_enum_named_under_property(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref        | source    | prepare
+    dataset1                 |         |            |           |
+      | resource1            | sql     |            |           |
+      |   |   | City         |         | id         |           |
+      |   |   |   | id       | integer |            |           |
+      |   |   |   | status   | string  |            |           |
+      |   |   |   |          | enum    | my_status  | 'active'  |
+      |   |   |   |          |         |            | 'inactive'|
+        """),
+    )
+
+    result = cli.invoke(
+        rc,
+        ["check", tmp_path / "manifest.csv"],
+        fail=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Named enum 'my_status' is declared directly under property 'status'" in result.stdout
+    assert "Total errors: 1" in result.stdout

--- a/tests/manifests/internal_sql/test_internal.py
+++ b/tests/manifests/internal_sql/test_internal.py
@@ -1464,7 +1464,7 @@ def test_internal_store_old_ids(context, db_type: str, rc: RawConfig, tmp_path: 
     {model_1_id}          |              |          |      | New   |          |         |      |                         |         |                             |                     |
     {comment_id}          |              |          |      |       |          | comment | TEXT |                         |         |                             | Example             | Comment
     {property_1_id}       |              |          |      |       | text     | string  |      |                         |         |                             |                     |
-    {enum_item_0_id}      |              |          |      |       |          | enum    | side | l                       | 'left'  |                             | Left                | Left side.
+    {enum_item_0_id}      |              |          |      |       |          | enum    |      | l                       | 'left'  |                             | Left                | Left side.
     {enum_item_1_id}      |              |          |      |       |          |         |      | r                       | 'right' |                             | Right               | Right side.
     """
 
@@ -1732,11 +1732,11 @@ def test_internal_store_old_ids(context, db_type: str, rc: RawConfig, tmp_path: 
             property_1_id,
             5,
             "data/New/text",
-            "data/res/Test/New/text/side",
+            "data/res/Test/New/text/{13}",
             "enum",
-            "side",
+            None,
             "enum",
-            "side",
+            None,
             None,
             None,
             None,
@@ -1751,7 +1751,7 @@ def test_internal_store_old_ids(context, db_type: str, rc: RawConfig, tmp_path: 
             13,
             6,
             "data/New/text",
-            f"data/res/Test/New/text/side/{enum_item_0_id}",
+            f"data/res/Test/New/text/{{13}}/{enum_item_0_id}",
             "enum.item",
             None,
             None,
@@ -1770,7 +1770,7 @@ def test_internal_store_old_ids(context, db_type: str, rc: RawConfig, tmp_path: 
             13,
             6,
             "data/New/text",
-            f"data/res/Test/New/text/side/{enum_item_1_id}",
+            f"data/res/Test/New/text/{{13}}/{enum_item_1_id}",
             "enum.item",
             None,
             None,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,7 +4,7 @@ import pytest
 
 from spinta import commands
 from spinta.core.config import RawConfig
-from spinta.exceptions import InvalidName, InvalidValue
+from spinta.exceptions import InlineEnumWithName, InvalidName, InvalidValue
 from spinta.testing.manifest import load_manifest_and_context, load_manifest, load_manifest_get_context
 from spinta.testing.tabular import create_tabular_manifest
 
@@ -385,3 +385,27 @@ def test_check_enum_empty_string_prepare(manifest_type, tmp_path, rc):
         tmp_path=tmp_path,
     )
     commands.check(context, manifest)
+
+
+@pytest.mark.manifests("internal_sql", "csv")
+def test_check_enum_named_under_property_raises_error(manifest_type, tmp_path, rc):
+    with pytest.raises(InlineEnumWithName) as e:
+        load_manifest(
+            rc,
+            """
+        d | r | b | m | property | type    | ref        | source    | prepare
+        dataset1                 |         |            |           |
+          | resource1            | sql     |            |           |
+          |   |   | City         |         | id         |           |
+          |   |   |   | id       | integer |            |           |
+          |   |   |   | status   | string  |            |           |
+          |   |   |   |          | enum    | my_status  | 'active'  |
+          |   |   |   |          |         |            | 'inactive'|
+            """,
+            manifest_type=manifest_type,
+            tmp_path=tmp_path,
+        )
+    assert e.value.message == (
+        "Named enum 'my_status' is declared directly under property 'status'. "
+        "Either remove the name to make it an inline enum, or move it to dataset dimension."
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -3,8 +3,11 @@ from pathlib import Path
 import pytest
 
 from spinta import commands
+from spinta.components import Context
 from spinta.core.config import RawConfig
-from spinta.exceptions import InlineEnumWithName, InvalidName, InvalidValue
+from spinta.exceptions import InvalidName, InvalidValue
+from spinta.manifests.tabular.helpers import striptable
+from spinta.testing.cli import SpintaCliRunner
 from spinta.testing.manifest import load_manifest_and_context, load_manifest, load_manifest_get_context
 from spinta.testing.tabular import create_tabular_manifest
 
@@ -387,25 +390,28 @@ def test_check_enum_empty_string_prepare(manifest_type, tmp_path, rc):
     commands.check(context, manifest)
 
 
-@pytest.mark.manifests("internal_sql", "csv")
-def test_check_enum_named_under_property_raises_error(manifest_type, tmp_path, rc):
-    with pytest.raises(InlineEnumWithName) as e:
-        load_manifest(
-            rc,
-            """
-        d | r | b | m | property | type    | ref        | source    | prepare
-        dataset1                 |         |            |           |
-          | resource1            | sql     |            |           |
-          |   |   | City         |         | id         |           |
-          |   |   |   | id       | integer |            |           |
-          |   |   |   | status   | string  |            |           |
-          |   |   |   |          | enum    | my_status  | 'active'  |
-          |   |   |   |          |         |            | 'inactive'|
-            """,
-            manifest_type=manifest_type,
-            tmp_path=tmp_path,
-        )
-    assert e.value.message == (
-        "Named enum 'my_status' is declared directly under property 'status'. "
-        "Either remove the name to make it an inline enum, or move it to dataset dimension."
+def test_check_enum_named_under_property(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type    | ref        | source    | prepare
+    dataset1                 |         |            |           |
+      | resource1            | sql     |            |           |
+      |   |   | City         |         | id         |           |
+      |   |   |   | id       | integer |            |           |
+      |   |   |   | status   | string  |            |           |
+      |   |   |   |          | enum    | my_status  | 'active'  |
+      |   |   |   |          |         |            | 'inactive'|
+        """),
     )
+
+    result = cli.invoke(
+        rc,
+        ["check", tmp_path / "manifest.csv"],
+        fail=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Named enum 'my_status' is declared directly under property 'status'" in result.stdout
+    assert "Total errors: 1" in result.stdout


### PR DESCRIPTION
## Summary

Added `InlineEnumWithName` exception and a validation in `check(Context, Property)` that raises it when an enum with a `ref` (name) is declared directly under a property. Named enums must live at dataset or manifest scope — declaring one under a property is always silently broken: it gets stored under a non-empty key in `prop.enums` but `_link_prop_enum` only reads the `""` key, so the enum is lost without any error.
