### PR TITLE
1937: Adding custom_scope as UrlParam that we get from url param. Add…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,17 @@ Improvements:
 .. _#1935: https://github.com/atviriduomenys/spinta/issues/1935
 .. _#1928: https://github.com/atviriduomenys/spinta/issues/1928
 
+New Features:
+
+- Implemented named scope enforcement for data access restriction.
+  Scopes are defined in the manifest and applied per request to restrict what rows and fields a consumer can see. (`#1937`_).
+
+  - Scope row filters are appended after user conditions are validated — user cannot override or drop them.
+  - A contradicting user filter (country_code='de' against scope country_code='lt') produces zero rows, not a bypass.
+  - When scope defines select(...), user filter/sort on hidden fields raises `PropertyNotFound` — field existence is not revealed
+
+.. _#1937: https://github.com/atviriduomenys/spinta/issues/1937
+
 Bug fixes:
 
 - Fixed `count()` function not working properly with `dask` backends (`#1950`_).

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -929,6 +929,8 @@ class UrlParams:
     select_props: Optional[Dict[str, Union[Expr, Bind]]] = None
     select_funcs: Optional[Dict[str, FuncProperty]] = None
 
+    custom_scope: Optional[str] = None
+
     sort: List[dict] = None
     limit: Optional[int] = None
     offset: Optional[int] = None

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -929,7 +929,7 @@ class UrlParams:
     select_props: Optional[Dict[str, Union[Expr, Bind]]] = None
     select_funcs: Optional[Dict[str, FuncProperty]] = None
 
-    custom_scope: Optional[str] = None
+    custom_scope: str | None = None
 
     sort: List[dict] = None
     limit: Optional[int] = None

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -1,13 +1,19 @@
 from typing import cast
 
 from spinta import commands
-from spinta.components import Context, Model
+from spinta.components import Context, Model, UrlParams
 from spinta.core.access import load_access_param
 from spinta.core.enums import load_level, load_status, load_visibility
 from spinta.core.ufuncs import Expr
 from spinta.dimensions.scope.components import Scope, ScopeLoader
 from spinta.manifests.components import Manifest
 from spinta.nodes import load_node
+
+
+def get_active_custom_scope(model: Model, params: UrlParams) -> Scope | None:
+    if not params.custom_scope:
+        return None
+    return model.scopes.get(params.custom_scope)
 
 
 def _load_scope(

--- a/spinta/dimensions/scope/helpers.py
+++ b/spinta/dimensions/scope/helpers.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from spinta import commands
+from spinta import commands, exceptions
 from spinta.components import Context, Model, UrlParams
 from spinta.core.access import load_access_param
 from spinta.core.enums import load_level, load_status, load_visibility
@@ -13,7 +13,10 @@ from spinta.nodes import load_node
 def get_active_custom_scope(model: Model, params: UrlParams) -> Scope | None:
     if not params.custom_scope:
         return None
-    return model.scopes.get(params.custom_scope)
+    scope = model.scopes.get(params.custom_scope)
+    if scope is None:
+        raise exceptions.ScopeNotFound(scope=params.custom_scope, model=model.name)
+    return scope
 
 
 def _load_scope(

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -231,6 +231,11 @@ class PropertyNotFound(UserError):
     template = "Property {property!r} not found."
 
 
+class ScopeNotFound(UserError):
+    status_code = 404
+    template = "Scope {scope!r} not found in model {model!r}."
+
+
 class PropertiesNotFound(UserError):
     status_code = 404
     template = "Properties {properties!r} not found."

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -231,6 +231,11 @@ class PropertyNotFound(UserError):
     template = "Property {property!r} not found."
 
 
+class PropertiesNotFound(UserError):
+    status_code = 404
+    template = "Properties {properties!r} not found."
+
+
 class NoItemRevision(UserError):
     template = "'_revision' must be given on rewrite operation."
 

--- a/spinta/urlparams.py
+++ b/spinta/urlparams.py
@@ -381,11 +381,10 @@ def _apply_scope_select(params: UrlParams, allowed_args: list[dict]) -> None:
         return
 
     allowed = {spyna.unparse(allowed) for allowed in allowed_args}
-    intersection = [select for select in params.select if spyna.unparse(select) in allowed]
-    if not intersection:
-        first_requested = spyna.unparse(params.select[0])
-        raise exceptions.PropertyNotFound(property=first_requested)
-    params.select = intersection
+    for select in params.select:
+        name = spyna.unparse(select)
+        if name not in allowed:
+            raise exceptions.PropertyNotFound(property=name)
 
 
 def _apply_custom_scope(params: UrlParams) -> None:

--- a/spinta/urlparams.py
+++ b/spinta/urlparams.py
@@ -1,8 +1,7 @@
 import re
 import urllib.parse
 from collections import OrderedDict
-from typing import List
-from typing import Union
+from typing import Any, List, Union
 
 from starlette.requests import Request
 
@@ -18,6 +17,7 @@ from spinta.components import Model
 from spinta.components import Namespace
 from spinta.components import UrlParams, Version
 from spinta.core.ufuncs import Bind, Expr, asttoexpr
+from spinta.dimensions.scope.helpers import get_active_custom_scope
 from spinta.exceptions import ModelNotFound, InvalidPageParameterCount, InvalidPageKey
 from spinta.manifests.components import Manifest
 from spinta.ufuncs.querybuilder.components import QueryBuilder
@@ -84,6 +84,8 @@ def parse_url_query(query):
 def prepare_urlparams(context: Context, params: UrlParams, request: Request):
     _prepare_urlparams_from_path(params)
     _resolve_path(context, params)
+    _apply_custom_scope(params)
+
     params.format = get_response_type(context, request, params)
     params.accept_langs = get_preferred_accept_lang(request, params)
     params.content_langs = get_preferred_content_lang(request, params)
@@ -256,6 +258,18 @@ def _prepare_urlparams_from_path(params: UrlParams):
                 params.lang = args
             else:
                 params.lang += args
+        elif name == "custom-scope":
+            if params.custom_scope is not None:
+                raise exceptions.InvalidValue(
+                    operator="custom_scope",
+                    message="Custom scope can be set only once per request.",
+                )
+            if len(args) != 1:
+                raise exceptions.InvalidValue(
+                    operator="custom_scope",
+                    message="Custom scope expects exactly one name.",
+                )
+            params.custom_scope = args[0]
         else:
             if params.query is None:
                 params.query = []
@@ -319,6 +333,74 @@ def _resolve_path(context: Context, params: UrlParams) -> None:
     if parts:
         given_path = "/".join(params.path_parts)
         raise ModelNotFound(model=given_path)
+
+
+def _extract_scope_parts(prepare: dict) -> tuple[list[dict] | None, list[dict]]:
+    # Top-level `and` is flattened; `select(...)` is pulled out as field restriction.
+    conditions = prepare.get("args", []) if prepare.get("name") == "and" else [prepare]
+
+    select_args = None
+    filter_exprs = []
+    for condition in conditions:
+        if isinstance(condition, dict) and condition.get("name") == "select":
+            select_args = condition.get("args", [])
+        else:
+            filter_exprs.append(condition)
+
+    return select_args, filter_exprs
+
+
+def _collect_field_refs(expr: Any) -> set[str]:
+    if not isinstance(expr, dict):
+        return set()
+    name = expr.get("name")
+    if name in ("bind", "getattr"):
+        return {spyna.unparse(expr)}
+    return {ref for arg in expr.get("args", []) for ref in _collect_field_refs(arg)}
+
+
+def _check_field_access(params: UrlParams, allowed_args: list[dict]) -> None:
+    allowed = {spyna.unparse(a) for a in allowed_args}
+
+    if params.sort:
+        for sort_item in params.sort:
+            for field in _collect_field_refs(sort_item) - allowed:
+                raise exceptions.PropertyNotFound(property=field)
+
+    if params.query:
+        for condition in params.query:
+            for field in _collect_field_refs(condition) - allowed:
+                raise exceptions.PropertyNotFound(property=field)
+
+
+def _apply_scope_select(params: UrlParams, allowed_args: list[dict]) -> None:
+    if params.select is None:
+        params.select = list(allowed_args)
+        return
+
+    allowed = {spyna.unparse(allowed) for allowed in allowed_args}
+    intersection = [select for select in params.select if spyna.unparse(select) in allowed]
+    if not intersection:
+        first_requested = spyna.unparse(params.select[0])
+        raise exceptions.PropertyNotFound(property=first_requested)
+    params.select = intersection
+
+
+def _apply_custom_scope(params: UrlParams) -> None:
+    if not isinstance(params.model, Model):
+        return
+    scope = get_active_custom_scope(params.model, params)
+    if scope is None:
+        return
+
+    select_args, filter_exprs = _extract_scope_parts(scope.prepare)
+
+    if select_args is not None:
+        _apply_scope_select(params, select_args)
+        _check_field_access(params, select_args)
+
+    if filter_exprs:
+        params.query = (params.query or []) + filter_exprs
 
 
 def get_model_by_name(context: Context, manifest: Manifest, name: str) -> Node:

--- a/spinta/urlparams.py
+++ b/spinta/urlparams.py
@@ -361,16 +361,18 @@ def _collect_field_refs(expr: Any) -> set[str]:
 
 def _check_field_access(params: UrlParams, allowed_args: list[dict]) -> None:
     allowed = {spyna.unparse(a) for a in allowed_args}
+    fields_not_found = []
 
     if params.sort:
         for sort_item in params.sort:
-            for field in _collect_field_refs(sort_item) - allowed:
-                raise exceptions.PropertyNotFound(property=field)
+            fields_not_found.extend(_collect_field_refs(sort_item) - allowed)
 
     if params.query:
         for condition in params.query:
-            for field in _collect_field_refs(condition) - allowed:
-                raise exceptions.PropertyNotFound(property=field)
+            fields_not_found.extend(_collect_field_refs(condition) - allowed)
+
+    if fields_not_found:
+        raise exceptions.PropertiesNotFound(properties=fields_not_found)
 
 
 def _apply_scope_select(params: UrlParams, allowed_args: list[dict]) -> None:

--- a/spinta/utils/url.py
+++ b/spinta/utils/url.py
@@ -43,6 +43,9 @@ RULES = {
     "inspect": {"maxargs": 0},
     "schema": {"maxargs": 0},
     "move": {"maxargs": 0},
+    "custom-scope": {
+        "maxargs": 1,
+    },
 }
 
 
@@ -83,6 +86,11 @@ def parse_url_path(path) -> List[UrlParseNode]:
                 )
             name = part[1:]
             args = []
+        elif part.startswith("@"):
+            if name is not None:
+                query.append({"name": name, "args": args})
+            name = "custom-scope"
+            args = [part[1:]]
         else:
             args.append(part)
     query.append(
@@ -107,6 +115,8 @@ def build_url_path(query: List[UrlParseNode]):
             parts.extend(args)
         elif name in ("format", "ns", "changes"):
             parts.extend([f":{name}"] + args)
+        elif name == "custom-scope":
+            parts.append(f"@{args[0]}")
         else:
             other.append(param)
     path = "/".join(map(str, parts))

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -7,12 +7,14 @@ import pytest
 from spinta.components import Context
 from spinta.core.config import RawConfig
 from spinta.core.enums import Mode
+from spinta.exceptions import PropertyNotFound
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.client import create_client, create_test_client
 from spinta.testing.data import listdata
 from spinta.testing.datasets import Sqlite
 from spinta.testing.manifest import prepare_manifest
 from spinta.testing.tabular import create_tabular_manifest
+from spinta.testing.utils import error
 
 
 @pytest.fixture
@@ -424,12 +426,9 @@ def test_scope_select_dotted_path_sqlite(context: Context, rc: RawConfig, tmp_pa
     app = create_client(rc, tmp_path, sqlite)
     app.authmodel("example/City", ["getall", "search"])
 
-    # User requests country.code alongside the scope-allowed fields — blocked
+    # User requests country.code which is outside scope — raises error
     resp = app.get("/example/City/@public?select(name,country.name,country.code)")
-    assert resp.status_code == 200
-    data = resp.json()["_data"]
-    assert sorted(row["name"] for row in data) == ["Kaunas", "Vilnius"]
-    assert all("code" not in row.get("country", {}) for row in data)
+    assert resp.status_code == 404
 
 
 def test_scope_caps_user_filter_csv(rc: RawConfig, fs: MemoryFileSystem):
@@ -843,6 +842,7 @@ def test_scope_select_fallback_when_no_overlap(context: Context, rc: RawConfig, 
     # User asks for a field entirely outside the scope — looks like the property doesn't exist.
     resp = app.get("/example/City/@pub?select(country_code)")
     assert resp.status_code == 404
+    assert error(resp, status=404) == "PropertyNotFound"
 
 
 def test_scope_select_blocks_sort_by_hidden_field(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
@@ -873,6 +873,7 @@ def test_scope_select_blocks_sort_by_hidden_field(context: Context, rc: RawConfi
     # Sorting by a hidden field must be rejected
     resp = app.get("/example/City/@pub?sort(country_code)")
     assert resp.status_code == 404
+    assert error(resp, status=404) == "PropertiesNotFound"
 
 
 def test_scope_select_blocks_filter_by_hidden_field(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
@@ -909,6 +910,7 @@ def test_scope_select_blocks_filter_by_hidden_field(context: Context, rc: RawCon
     # Filtering by a hidden field must be rejected
     resp = app.get("/example/City/@pub?country_code='lt'")
     assert resp.status_code == 404
+    assert error(resp, status=404) == "PropertiesNotFound"
 
 
 def test_scope_or_filter_blocks_outside_countries_sqlite(

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -7,7 +7,6 @@ import pytest
 from spinta.components import Context
 from spinta.core.config import RawConfig
 from spinta.core.enums import Mode
-from spinta.exceptions import PropertyNotFound
 from spinta.manifests.tabular.helpers import striptable
 from spinta.testing.client import create_client, create_test_client
 from spinta.testing.data import listdata

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -240,3 +240,672 @@ def test_undeclared_base_with_ref_and_level_comment_prepare(rc: RawConfig):
     assert model.comments, "restore comment should be added"
     comment = model.comments[0]
     assert comment.prepare == 'insert(base:"dataset/gov/vssa/is/ds/Address", ref:"id", level:4)'
+
+
+def test_custom_scope_caps_user_filter_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare           | access
+    example                       |        |     |              |                   |
+      | resource                  | sql    |     |              |                   |
+      |   |   | City              |        |     | CITY         |                   |
+                                  | scope  | ltu |              | country_code='lt' |
+      |   |   |   | name          | string |     | NAME         |                   | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |                   | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv"},
+            {"NAME": "Tallinn", "COUNTRY_CODE": "ee"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: only the Lithuanian city is returned
+    resp = app.get("/example/City/@ltu")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    # Contradicting user filter: scope requires lt, user asks for lv → empty
+    resp = app.get('/example/City/@ltu?country_code="lv"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Compatible user filter narrows within the scope
+    resp = app.get('/example/City/@ltu?name="Vilnius"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_no_scope_returns_all_data(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare           | access
+    example                       |        |     |              |                   |
+      | resource                  | sql    |     |              |                   |
+      |   |   | City              |        |     | CITY         |                   |
+                                  | scope  | ltu |              | country_code='lt' |
+      |   |   |   | name          | string |     | NAME         |                   | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |                   | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv"},
+            {"NAME": "Tallinn", "COUNTRY_CODE": "ee"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall"])
+
+    resp = app.get("/example/City")
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Riga", "Tallinn", "Vilnius"]
+
+
+def test_scope_gt_filter_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """Scope prepare with gt (>) restricts rows; user filter cannot reach outside the scope."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property  | type    | ref | source   | prepare         | access
+    example                   |         |     |          |                 |
+      | resource              | sql     |     |          |                 |
+      |   |   | Country       |         |     | COUNTRY  |                 |
+                              | scope   | big |          | area_km2>200000 |
+      |   |   |   | name      | string  |     | NAME     |                 | open
+      |   |   |   | area_km2  | integer |     | AREA_KM2 |                 | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "COUNTRY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("AREA_KM2", sa.Integer),
+            ],
+        }
+    )
+    sqlite.write(
+        "COUNTRY",
+        [
+            {"NAME": "Lithuania", "AREA_KM2": 65300},
+            {"NAME": "Germany", "AREA_KM2": 357000},
+            {"NAME": "India", "AREA_KM2": 3287000},
+            {"NAME": "Rwanda", "AREA_KM2": 26338},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/Country", ["getall", "search"])
+
+    # Scope allows only area_km2 > 200000 — Lithuania and Rwanda excluded
+    resp = app.get("/example/Country/@big")
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Germany", "India"]
+
+    # User tries to get small countries (area < 100000) — scope blocks them, result empty
+    resp = app.get('/example/Country/@big?area_km2<"100000"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+
+def test_scope_select_dotted_path_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """Scope select(name,country.name) blocks country.code even when user explicitly requests it."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property | type   | ref     | source     | prepare                   | access
+    example                  |        |         |            |                           |
+      | resource             | sql    |         |            |                           |
+      |   |   | Country      |        | name    | COUNTRY    |                           |
+      |   |   |   | name     | string |         | NAME       |                           | open
+      |   |   |   | code     | string |         | CODE       |                           | open
+      |   |   | City         |        | name    | CITY       |                           |
+                             | scope  | public  |            | select(name,country.name) |
+      |   |   |   | name     | string |         | NAME       |                           | open
+      |   |   |   | country  | ref    | Country | COUNTRY_ID |                           | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "COUNTRY": [
+                sa.Column("CODE", sa.Text),
+                sa.Column("NAME", sa.Text),
+            ],
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_ID", sa.Text),
+            ],
+        }
+    )
+    sqlite.write("COUNTRY", [{"CODE": "lt", "NAME": "Lithuania"}])
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_ID": "lt"},
+            {"NAME": "Kaunas", "COUNTRY_ID": "lt"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # User requests country.code alongside the scope-allowed fields — blocked
+    resp = app.get("/example/City/@public?select(name,country.name,country.code)")
+    assert resp.status_code == 200
+    data = resp.json()["_data"]
+    assert sorted(row["name"] for row in data) == ["Kaunas", "Vilnius"]
+    assert all("code" not in row.get("country", {}) for row in data)
+
+
+def test_scope_caps_user_filter_csv(rc: RawConfig, fs: MemoryFileSystem):
+    """Scope on CSV source; user filter that contradicts the scope returns empty rows."""
+    fs.pipe(
+        "cities.csv",
+        b"name,country_code\nVilnius,lt\nRiga,lv\nTallinn,ee\n",
+    )
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+        d | r | b | m | property      | type     | ref | source              | prepare           | access
+        example                       |          |     |                     |                   |
+          | csv                       | dask/csv |     | memory://cities.csv |                   |
+          |   |   | City              |          |     |                     |                   |
+                                      | scope    | ltu |                     | country_code='lt' |
+          |   |   |   | name          | string   |     | name                |                   | open
+          |   |   |   | country_code  | string   |     | country_code        |                   | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: only the Lithuanian city is returned
+    resp = app.get("/example/City/@ltu")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    # Contradicting user filter: scope requires lt, user asks for lv → empty
+    resp = app.get('/example/City/@ltu?country_code="lv"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Compatible user filter still narrows within the scope
+    resp = app.get('/example/City/@ltu?name="Vilnius"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_scope_caps_user_filter_xml(rc: RawConfig, tmp_path: Path):
+    """Scope on XML source; user filter that contradicts the scope returns empty rows."""
+    path = tmp_path / "cities.xml"
+    path.write_text("""
+        <cities>
+            <city>
+                <name>Vilnius</name>
+                <country_code>lt</country_code>
+            </city>
+            <city>
+                <name>Riga</name>
+                <country_code>lv</country_code>
+            </city>
+            <city>
+                <name>Tallinn</name>
+                <country_code>ee</country_code>
+            </city>
+        </cities>
+    """)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+        d | r | b | m | property      | type     | ref | source       | prepare           | access
+        example                       |          |     |              |                   |
+          | xml                       | dask/xml |     | {path}       |                   |
+          |   |   | City              |          |     | /cities/city |                   |
+                                      | scope    | ltu |              | country_code='lt' |
+          |   |   |   | name          | string   |     | name         |                   | open
+          |   |   |   | country_code  | string   |     | country_code |                   | open
+        """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: only the Lithuanian city is returned
+    resp = app.get("/example/City/@ltu")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    # Contradicting user filter: scope requires lt, user asks for ee → empty
+    resp = app.get('/example/City/@ltu?country_code="ee"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Compatible user filter still narrows within the scope
+    resp = app.get('/example/City/@ltu?name="Vilnius"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_scope_and_conditions_caps_filter_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """Scope with two AND conditions; contradicting either condition returns empty rows."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare                           | access
+    example                       |        |     |              |                                   |
+      | resource                  | sql    |     |              |                                   |
+      |   |   | City              |        |     | CITY         |                                   |
+                                  | scope  | ltu |              | country_code='lt'&status='active' |
+      |   |   |   | name          | string |     | NAME         |                                   | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |                                   | open
+      |   |   |   | status        | string |     | STATUS       |                                   | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+                sa.Column("STATUS", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt", "STATUS": "active"},
+            {"NAME": "Kaunas", "COUNTRY_CODE": "lt", "STATUS": "inactive"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv", "STATUS": "active"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: only Vilnius (lt + active) passes both conditions
+    resp = app.get("/example/City/@ltu")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    # Contradicts country_code condition: scope requires lt, user asks for lv
+    resp = app.get('/example/City/@ltu?country_code="lv"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Contradicts status condition: scope requires active, user asks for inactive
+    resp = app.get('/example/City/@ltu?status="inactive"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Compatible user filter still narrows within both scope conditions
+    resp = app.get('/example/City/@ltu?name="Vilnius"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_scope_ne_caps_filter_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """Scope using != (ne) operator; user filter requesting the excluded value returns empty rows."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property  | type   | ref | source   | prepare            | access
+    example                   |        |     |          |                    |
+      | resource              | sql    |     |          |                    |
+      |   |   | City          |        |     | CITY     |                    |
+                              | scope  | pub |          | status!='inactive' |
+      |   |   |   | name      | string |     | NAME     |                    | open
+      |   |   |   | status    | string |     | STATUS   |                    | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("STATUS", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "STATUS": "active"},
+            {"NAME": "Kaunas", "STATUS": "inactive"},
+            {"NAME": "Riga", "STATUS": "active"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: excludes Kaunas (inactive)
+    resp = app.get("/example/City/@pub")
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Riga", "Vilnius"]
+
+    # User requests the excluded value: scope says !=inactive, user says =inactive → empty
+    resp = app.get('/example/City/@pub?status="inactive"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # User narrows within scope (requests active only)
+    resp = app.get('/example/City/@pub?status="active"')
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Riga", "Vilnius"]
+
+
+def test_multiple_scopes_caps_cross_scope_filter_sqlite(
+    context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite
+):
+    """Two named scopes on the same model; using one scope while filtering for data
+    exclusive to the other scope returns empty rows."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare           | access
+    example                       |        |     |              |                   |
+      | resource                  | sql    |     |              |                   |
+      |   |   | City              |        |     | CITY         |                   |
+                                  | scope  | ltu |              | country_code='lt' |
+                                  | scope  | est |              | country_code='ee' |
+      |   |   |   | name          | string |     | NAME         |                   | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |                   | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv"},
+            {"NAME": "Tallinn", "COUNTRY_CODE": "ee"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Each scope returns its own country's cities
+    resp = app.get("/example/City/@ltu")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    resp = app.get("/example/City/@est")
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Tallinn"]
+
+    # Using ltu scope but filtering for ee data: scope requires lt, user asks ee → empty
+    resp = app.get('/example/City/@ltu?country_code="ee"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Using est scope but filtering for lt data: scope requires ee, user asks lt → empty
+    resp = app.get('/example/City/@est?country_code="lt"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # Using either scope but filtering for lv (in neither scope) → empty
+    resp = app.get('/example/City/@ltu?country_code="lv"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+
+def test_scope_range_caps_filter_sqlite(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """Scope with a numeric range (>= AND <= on same field); user filter outside the range returns empty rows."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property  | type    | ref | source   | prepare                           | access
+    example                   |         |     |          |                                   |
+      | resource              | sql     |     |          |                                   |
+      |   |   | Country       |         |     | COUNTRY  |                                   |
+                              | scope   | mid |          | area_km2>=50000&area_km2<=400000  |
+      |   |   |   | name      | string  |     | NAME     |                                   | open
+      |   |   |   | area_km2  | integer |     | AREA_KM2 |                                   | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "COUNTRY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("AREA_KM2", sa.Integer),
+            ],
+        }
+    )
+    sqlite.write(
+        "COUNTRY",
+        [
+            {"NAME": "Rwanda", "AREA_KM2": 26338},
+            {"NAME": "Lithuania", "AREA_KM2": 65300},
+            {"NAME": "Germany", "AREA_KM2": 357000},
+            {"NAME": "India", "AREA_KM2": 3287000},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/Country", ["getall", "search"])
+
+    # Scope alone: only medium-sized countries pass both bounds
+    resp = app.get("/example/Country/@mid")
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Germany", "Lithuania"]
+
+    # User filters below the lower bound → contradicts scope >= 50000 → empty
+    resp = app.get('/example/Country/@mid?area_km2<"30000"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # User filters above the upper bound → contradicts scope <= 400000 → empty
+    resp = app.get('/example/Country/@mid?area_km2>"1000000"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # User narrows within the range → compatible, returns matching row
+    resp = app.get('/example/Country/@mid?name="Germany"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Germany"]
+
+
+def test_scope_select_enforces_fields_without_user_select(
+    context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite
+):
+    """Scope with select(name) enforces the field list when the user provides no select at all."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare       | access
+    example                       |        |     |              |               |
+      | resource                  | sql    |     |              |               |
+      |   |   | City              |        |     | CITY         |               |
+                                  | scope  | pub |              | select(name)  |
+      |   |   |   | name          | string |     | NAME         |               | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |               | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # No user select — scope enforces its own field list
+    resp = app.get("/example/City/@pub")
+    assert resp.status_code == 200
+    data = resp.json()["_data"]
+    assert sorted(row["name"] for row in data) == ["Riga", "Vilnius"]
+    assert all("country_code" not in row for row in data)
+
+
+def test_scope_select_fallback_when_no_overlap(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """When user's select has no fields in common with the scope's select,
+    the request is rejected with a 404 PropertyNotFound — from the user's
+    perspective those fields simply do not exist."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare       | access
+    example                       |        |     |              |               |
+      | resource                  | sql    |     |              |               |
+      |   |   | City              |        |     | CITY         |               |
+                                  | scope  | pub |              | select(name)  |
+      |   |   |   | name          | string |     | NAME         |               | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |               | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # User asks for a field entirely outside the scope — looks like the property doesn't exist.
+    resp = app.get("/example/City/@pub?select(country_code)")
+    assert resp.status_code == 404
+
+
+def test_scope_select_blocks_sort_by_hidden_field(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """A select scope must reject sort expressions that reference fields outside
+    the allowed set — otherwise field values could be inferred by ordering."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare       | access
+    example                       |        |     |              |               |
+      | resource                  | sql    |     |              |               |
+      |   |   | City              |        |     | CITY         |               |
+                                  | scope  | pub |              | select(name)  |
+      |   |   |   | name          | string |     | NAME         |               | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |               | open
+    """),
+    )
+    sqlite.init({"CITY": [sa.Column("NAME", sa.Text), sa.Column("COUNTRY_CODE", sa.Text)]})
+    sqlite.write("CITY", [{"NAME": "Vilnius", "COUNTRY_CODE": "lt"}])
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Sorting by an allowed field is fine
+    resp = app.get("/example/City/@pub?sort(name)")
+    assert resp.status_code == 200
+
+    # Sorting by a hidden field must be rejected
+    resp = app.get("/example/City/@pub?sort(country_code)")
+    assert resp.status_code == 404
+
+
+def test_scope_select_blocks_filter_by_hidden_field(context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite):
+    """A select scope must reject filter expressions that reference fields outside
+    the allowed set — otherwise field values could be inferred by binary search."""
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare       | access
+    example                       |        |     |              |               |
+      | resource                  | sql    |     |              |               |
+      |   |   | City              |        |     | CITY         |               |
+                                  | scope  | pub |              | select(name)  |
+      |   |   |   | name          | string |     | NAME         |               | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |               | open
+    """),
+    )
+    sqlite.init({"CITY": [sa.Column("NAME", sa.Text), sa.Column("COUNTRY_CODE", sa.Text)]})
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Berlin", "COUNTRY_CODE": "de"},
+        ],
+    )
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Filtering by an allowed field is fine
+    resp = app.get("/example/City/@pub?name='Vilnius'")
+    assert resp.status_code == 200
+
+    # Filtering by a hidden field must be rejected
+    resp = app.get("/example/City/@pub?country_code='lt'")
+    assert resp.status_code == 404

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -909,3 +909,57 @@ def test_scope_select_blocks_filter_by_hidden_field(context: Context, rc: RawCon
     # Filtering by a hidden field must be rejected
     resp = app.get("/example/City/@pub?country_code='lt'")
     assert resp.status_code == 404
+
+
+def test_scope_or_filter_blocks_outside_countries_sqlite(
+    context: Context, rc: RawConfig, tmp_path: Path, sqlite: Sqlite
+):
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+    d | r | b | m | property      | type   | ref | source       | prepare                                         | access
+    example                       |        |     |              |                                                 |
+      | resource                  | sql    |     |              |                                                 |
+      |   |   | City              |        |     | CITY         |                                                 |
+                                  | scope  | baltic |           | or(country_code='lt',country_code='lv')         |
+      |   |   |   | name          | string |     | NAME         |                                                 | open
+      |   |   |   | country_code  | string |     | COUNTRY_CODE |                                                 | open
+    """),
+    )
+
+    sqlite.init(
+        {
+            "CITY": [
+                sa.Column("NAME", sa.Text),
+                sa.Column("COUNTRY_CODE", sa.Text),
+            ],
+        }
+    )
+    sqlite.write(
+        "CITY",
+        [
+            {"NAME": "Vilnius", "COUNTRY_CODE": "lt"},
+            {"NAME": "Riga", "COUNTRY_CODE": "lv"},
+            {"NAME": "Berlin", "COUNTRY_CODE": "de"},
+        ],
+    )
+
+    app = create_client(rc, tmp_path, sqlite)
+    app.authmodel("example/City", ["getall", "search"])
+
+    # Scope alone: Baltic cities only
+    resp = app.get("/example/City/@baltic")
+    assert resp.status_code == 200
+    assert sorted(listdata(resp, "name")) == ["Riga", "Vilnius"]
+
+    # User requests a non-Baltic country directly — scope blocks it
+    resp = app.get('/example/City/@baltic?country_code="de"')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == []
+
+    # User constructs an OR query mixing an allowed and a disallowed country —
+    # scope AND-combines with the user OR, so only the allowed branch survives
+    resp = app.get('/example/City/@baltic?or(country_code="lt",country_code="de")')
+    assert resp.status_code == 200
+    assert listdata(resp, "name") == ["Vilnius"]

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -215,14 +215,12 @@ class TestApplyCustomScopeSelect:
         assert params.select is not None
         assert [spyna.unparse(s) for s in params.select] == ["name"]
 
-    def test_scope_select_intersected_with_user_select(self):
+    def test_scope_select_raises_if_user_selects_outside_scope(self):
         model = _make_model(("pub", "select(name,country_code)"))
         params = _params(model, scope="pub", select=["name", "country_code", "status"])
 
-        _apply_custom_scope(params)
-
-        result = {spyna.unparse(s) for s in params.select}
-        assert result == {"name", "country_code"}
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
 
     def test_user_select_subset_of_scope_select_kept(self):
         model = _make_model(("pub", "select(name,country_code,status)"))

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -169,15 +169,6 @@ class TestApplyCustomScopeRowFilter:
         unparsed = [spyna.unparse(q) for q in params.query]
         assert unparsed == ["name='Vilnius'"]
 
-    def test_unknown_scope_name_leaves_query_unchanged(self):
-        model = _make_model(("ltu", "country_code='lt'"))
-        params = _params(model, scope="nonexistent", query=["name='Vilnius'"])
-
-        _apply_custom_scope(params)
-
-        unparsed = [spyna.unparse(q) for q in params.query]
-        assert unparsed == ["name='Vilnius'"]
-
     def test_conflicting_user_filter_both_appended(self):
         # User sends country_code='de' but scope requires country_code='lt'.
         # Both must appear in query — the scope filter is never dropped, so the

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -3,6 +3,7 @@ import pytest
 from spinta import spyna
 from spinta.components import Context
 from spinta.components import Model
+from spinta.components import Namespace
 from spinta.components import UrlParams
 from spinta.components import Version
 from spinta.commands import prepare
@@ -63,6 +64,27 @@ def test_prepare_urlparams_sets_custom_scope():
     ]
     _prepare_urlparams_from_path(params)
     assert params.custom_scope == "ltu"
+
+
+def test_prepare_urlparams_raises_if_custom_scope_set_twice():
+    params = UrlParams()
+    params.parsetree = [
+        {"name": "path", "args": ["example", "City"]},
+        {"name": "custom-scope", "args": ["ltu"]},
+        {"name": "custom-scope", "args": ["est"]},
+    ]
+    with pytest.raises(InvalidValue):
+        _prepare_urlparams_from_path(params)
+
+
+def test_prepare_urlparams_raises_if_custom_scope_has_no_args():
+    params = UrlParams()
+    params.parsetree = [
+        {"name": "path", "args": ["example", "City"]},
+        {"name": "custom-scope", "args": []},
+    ]
+    with pytest.raises(InvalidValue):
+        _prepare_urlparams_from_path(params)
 
 
 def _make_model(*scope_names_and_prepares: tuple[str, str]) -> Model:
@@ -352,3 +374,16 @@ class TestApplyCustomScopeFieldAccess:
 
         result = [spyna.unparse(s) for s in params.select]
         assert result == ["name", "status", "population"]
+
+
+class TestApplyCustomScopeWithNamespace:
+    def test_namespace_model_is_ignored(self):
+        ns = Namespace()
+        params = UrlParams()
+        params.model = ns
+        params.custom_scope = "ltu"
+        params.query = None
+
+        _apply_custom_scope(params)
+
+        assert params.query is None

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -8,7 +8,7 @@ from spinta.components import UrlParams
 from spinta.components import Version
 from spinta.commands import prepare
 from spinta.dimensions.scope.components import Scope
-from spinta.exceptions import InvalidValue, PropertiesNotFound, PropertyNotFound
+from spinta.exceptions import InvalidValue, PropertiesNotFound, PropertyNotFound, ScopeNotFound
 from spinta.testing.request import make_get_request
 from spinta.urlparams import _apply_custom_scope, _prepare_urlparams_from_path
 
@@ -374,6 +374,15 @@ class TestApplyCustomScopeFieldAccess:
 
         result = [spyna.unparse(s) for s in params.select]
         assert result == ["name", "status", "population"]
+
+
+class TestApplyCustomScopeNotFound:
+    def test_raises_when_scope_not_in_model(self):
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="deu")
+
+        with pytest.raises(ScopeNotFound):
+            _apply_custom_scope(params)
 
 
 class TestApplyCustomScopeWithNamespace:

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -1,11 +1,15 @@
 import pytest
 
+from spinta import spyna
 from spinta.components import Context
+from spinta.components import Model
 from spinta.components import UrlParams
 from spinta.components import Version
 from spinta.commands import prepare
-from spinta.exceptions import InvalidValue
+from spinta.dimensions.scope.components import Scope
+from spinta.exceptions import InvalidValue, PropertyNotFound
 from spinta.testing.request import make_get_request
+from spinta.urlparams import _apply_custom_scope, _prepare_urlparams_from_path
 
 
 def _parse(
@@ -49,3 +53,302 @@ def test_limit(context):
 def test_encoded_plus_for(context: Context, url_query: str):
     params_space = _parse(context, url_query)
     assert params_space.formatparams["title"] == '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+
+
+def test_prepare_urlparams_sets_custom_scope():
+    params = UrlParams()
+    params.parsetree = [
+        {"name": "path", "args": ["example", "City"]},
+        {"name": "custom-scope", "args": ["ltu"]},
+    ]
+    _prepare_urlparams_from_path(params)
+    assert params.custom_scope == "ltu"
+
+
+def _make_model(*scope_names_and_prepares: tuple[str, str]) -> Model:
+    model = Model()
+    model.name = "example/City"
+    model.scopes = {}
+    for name, prepare_expr in scope_names_and_prepares:
+        scope = Scope()
+        scope.name = name
+        scope.prepare = spyna.parse(prepare_expr)
+        model.scopes[name] = scope
+    return model
+
+
+def _params(
+    model: Model,
+    scope: str | None = None,
+    query: list | None = None,
+    select: list | None = None,
+    sort: list | None = None,
+) -> UrlParams:
+    params = UrlParams()
+    params.model = model
+    params.custom_scope = scope
+    params.query = [spyna.parse(q) for query in query] if query else None
+    params.select = [spyna.parse(s) for select in select] if select else None
+    params.sort = [spyna.parse(s) for sort in sort] if sort else None
+    return params
+
+
+class TestApplyCustomScopeRowFilter:
+    def test_scope_filter_applied_when_no_user_query(self):
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="ltu")
+
+        _apply_custom_scope(params)
+
+        assert params.query is not None
+        assert len(params.query) == 1
+        assert spyna.unparse(params.query[0]) == "country_code='lt'"
+
+    def test_scope_filter_appended_to_user_query(self):
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="ltu", query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "name='Vilnius'" in unparsed
+        assert "country_code='lt'" in unparsed
+        assert len(unparsed) == 2
+
+    def test_scope_and_conditions_both_appended(self):
+        model = _make_model(("ltu", "country_code='lt'&status='active'"))
+        params = _params(model, scope="ltu")
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "country_code='lt'" in unparsed
+        assert "status='active'" in unparsed
+        assert len(unparsed) == 2
+
+    def test_scope_and_conditions_merged_with_user_query(self):
+        model = _make_model(("ltu", "country_code='lt'&status='active'"))
+        params = _params(model, scope="ltu", query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "country_code='lt'" in unparsed
+        assert "status='active'" in unparsed
+        assert "name='Vilnius'" in unparsed
+        assert len(unparsed) == 3
+
+    def test_no_scope_leaves_query_unchanged(self):
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope=None, query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert unparsed == ["name='Vilnius'"]
+
+    def test_unknown_scope_name_leaves_query_unchanged(self):
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="nonexistent", query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert unparsed == ["name='Vilnius'"]
+
+    def test_conflicting_user_filter_both_appended(self):
+        # User sends country_code='de' but scope requires country_code='lt'.
+        # Both must appear in query — the scope filter is never dropped, so the
+        # conjunction produces zero rows rather than letting the user bypass the scope.
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="ltu", query=["country_code='de'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "country_code='de'" in unparsed
+        assert "country_code='lt'" in unparsed
+        assert len(unparsed) == 2
+
+    def test_scope_or_filter_appended_as_single_condition(self):
+        model = _make_model(("baltic", "or(country_code='lt',country_code='lv')"))
+        params = _params(model, scope="baltic")
+
+        _apply_custom_scope(params)
+
+        assert params.query is not None
+        assert len(params.query) == 1
+        assert spyna.unparse(params.query[0]) == "or(country_code='lt', country_code='lv')"
+
+    def test_scope_or_filter_appended_to_user_query(self):
+        model = _make_model(("baltic", "or(country_code='lt',country_code='lv')"))
+        params = _params(model, scope="baltic", query=["status='active'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "status='active'" in unparsed
+        assert "or(country_code='lt', country_code='lv')" in unparsed
+        assert len(unparsed) == 2
+
+
+class TestApplyCustomScopeSelect:
+    def test_scope_select_applied_when_no_user_select(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub")
+
+        _apply_custom_scope(params)
+
+        assert params.select is not None
+        assert [spyna.unparse(s) for s in params.select] == ["name"]
+
+    def test_scope_select_intersected_with_user_select(self):
+        model = _make_model(("pub", "select(name,country_code)"))
+        params = _params(model, scope="pub", select=["name", "country_code", "status"])
+
+        _apply_custom_scope(params)
+
+        result = {spyna.unparse(s) for s in params.select}
+        assert result == {"name", "country_code"}
+
+    def test_user_select_subset_of_scope_select_kept(self):
+        model = _make_model(("pub", "select(name,country_code,status)"))
+        params = _params(model, scope="pub", select=["name"])
+
+        _apply_custom_scope(params)
+
+        assert [spyna.unparse(s) for s in params.select] == ["name"]
+
+    def test_no_overlap_raises_property_not_found(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub", select=["country_code"])
+
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
+
+    def test_scope_select_and_filter_combined(self):
+        model = _make_model(("pub", "select(name)&country_code='lt'"))
+        params = _params(model, scope="pub")
+
+        _apply_custom_scope(params)
+
+        assert [spyna.unparse(s) for s in params.select] == ["name"]
+        assert params.query is not None
+        assert spyna.unparse(params.query[0]) == "country_code='lt'"
+
+    def test_scope_select_filter_and_user_select_filter_combined(self):
+        # Scope restricts to select(name) and rows where country_code='lt'.
+        # User requests select(name) and filters name='Vilnius'.
+        # Expected: select=[name], query=[country_code='lt', name='Vilnius'].
+        model = _make_model(("pub", "select(name)&country_code='lt'"))
+        params = _params(model, scope="pub", select=["name"], query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        assert [spyna.unparse(s) for s in params.select] == ["name"]
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "country_code='lt'" in unparsed
+        assert "name='Vilnius'" in unparsed
+        assert len(unparsed) == 2
+
+    def test_scope_select_narrows_user_select_and_filter_combined(self):
+        # Scope restricts to select(name, country_code) and rows where status='active'.
+        # User requests select(name) and filters country_code='lt'.
+        # Expected: select narrows to [name], query=[status='active', country_code='lt'].
+        model = _make_model(("pub", "select(name,country_code)&status='active'"))
+        params = _params(model, scope="pub", select=["name"], query=["country_code='lt'"])
+
+        _apply_custom_scope(params)
+
+        assert [spyna.unparse(s) for s in params.select] == ["name"]
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "status='active'" in unparsed
+        assert "country_code='lt'" in unparsed
+        assert len(unparsed) == 2
+
+
+class TestApplyCustomScopeFieldAccess:
+    def test_filter_on_hidden_field_raises_property_not_found(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub", query=["country_code='lt'"])
+
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
+
+    def test_filter_on_allowed_field_passes(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub", query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "name='Vilnius'" in unparsed
+
+    def test_sort_on_hidden_field_raises_property_not_found(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub", sort=["country_code"])
+
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
+
+    def test_sort_on_allowed_field_passes(self):
+        model = _make_model(("pub", "select(name)"))
+        params = _params(model, scope="pub", sort=["name"])
+
+        _apply_custom_scope(params)
+
+        assert params.sort is not None
+
+    def test_scope_with_row_filter_and_select_blocks_filter_on_hidden_field(self):
+        # Scope has both a row-filter and a select; user filter references a hidden field.
+        model = _make_model(("pub", "select(name)&country_code='lt'"))
+        params = _params(model, scope="pub", query=["status='active'"])
+
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
+
+    def test_scope_with_row_filter_and_select_allows_filter_on_visible_field(self):
+        # Scope has both a row-filter and a select; user filter references an allowed field.
+        model = _make_model(("pub", "select(name)&country_code='lt'"))
+        params = _params(model, scope="pub", query=["name='Vilnius'"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "country_code='lt'" in unparsed
+        assert "name='Vilnius'" in unparsed
+        assert len(unparsed) == 2
+
+    def test_user_filter_on_scope_row_filter_field_raises_even_with_matching_value(self):
+        # Scope uses country_code='lt' as its own row-filter but hides country_code via
+        # select(name). The user is not allowed to reference country_code at all — even
+        # supplying the exact same value must raise PropertyNotFound, because the field
+        # is not in the visible set.
+        model = _make_model(("pub", "select(name)&country_code='lt'"))
+        params = _params(model, scope="pub", query=["country_code='lt'"])
+
+        with pytest.raises(PropertyNotFound):
+            _apply_custom_scope(params)
+
+    def test_scope_row_filter_only_allows_any_field_in_user_query(self):
+        # When a scope has only a row-filter and no select(), there is no field
+        # restriction — the user may filter or sort on any field.
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="ltu", query=["status='active'"], sort=["population"])
+
+        _apply_custom_scope(params)
+
+        unparsed = [spyna.unparse(q) for q in params.query]
+        assert "status='active'" in unparsed
+        assert "country_code='lt'" in unparsed
+        assert params.sort is not None
+
+    def test_scope_row_filter_only_allows_any_field_in_user_select(self):
+        # No select in scope → user select is not restricted.
+        model = _make_model(("ltu", "country_code='lt'"))
+        params = _params(model, scope="ltu", select=["name", "status", "population"])
+
+        _apply_custom_scope(params)
+
+        result = [spyna.unparse(s) for s in params.select]
+        assert result == ["name", "status", "population"]

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -87,9 +87,9 @@ def _params(
     params = UrlParams()
     params.model = model
     params.custom_scope = scope
-    params.query = [spyna.parse(q) for query in query] if query else None
-    params.select = [spyna.parse(s) for select in select] if select else None
-    params.sort = [spyna.parse(s) for sort in sort] if sort else None
+    params.query = [spyna.parse(q) for q in query] if query else None
+    params.select = [spyna.parse(s) for s in select] if select else None
+    params.sort = [spyna.parse(s) for s in sort] if sort else None
     return params
 
 

--- a/tests/test_urlparams.py
+++ b/tests/test_urlparams.py
@@ -8,7 +8,7 @@ from spinta.components import UrlParams
 from spinta.components import Version
 from spinta.commands import prepare
 from spinta.dimensions.scope.components import Scope
-from spinta.exceptions import InvalidValue, PropertyNotFound
+from spinta.exceptions import InvalidValue, PropertiesNotFound, PropertyNotFound
 from spinta.testing.request import make_get_request
 from spinta.urlparams import _apply_custom_scope, _prepare_urlparams_from_path
 
@@ -294,7 +294,7 @@ class TestApplyCustomScopeFieldAccess:
         model = _make_model(("pub", "select(name)"))
         params = _params(model, scope="pub", query=["country_code='lt'"])
 
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises(PropertiesNotFound):
             _apply_custom_scope(params)
 
     def test_filter_on_allowed_field_passes(self):
@@ -310,7 +310,7 @@ class TestApplyCustomScopeFieldAccess:
         model = _make_model(("pub", "select(name)"))
         params = _params(model, scope="pub", sort=["country_code"])
 
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises(PropertiesNotFound):
             _apply_custom_scope(params)
 
     def test_sort_on_allowed_field_passes(self):
@@ -326,7 +326,7 @@ class TestApplyCustomScopeFieldAccess:
         model = _make_model(("pub", "select(name)&country_code='lt'"))
         params = _params(model, scope="pub", query=["status='active'"])
 
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises(PropertiesNotFound):
             _apply_custom_scope(params)
 
     def test_scope_with_row_filter_and_select_allows_filter_on_visible_field(self):
@@ -349,7 +349,7 @@ class TestApplyCustomScopeFieldAccess:
         model = _make_model(("pub", "select(name)&country_code='lt'"))
         params = _params(model, scope="pub", query=["country_code='lt'"])
 
-        with pytest.raises(PropertyNotFound):
+        with pytest.raises(PropertiesNotFound):
             _apply_custom_scope(params)
 
     def test_scope_row_filter_only_allows_any_field_in_user_query(self):

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -59,3 +59,16 @@ def test_parse_url_path_recognizes_custom_scope():
         {"name": "path", "args": ["example", "City"]},
         {"name": "custom-scope", "args": ["ltu"]},
     ]
+
+
+def test_build_url_path_serializes_custom_scope():
+    query = [
+        {"name": "path", "args": ["example", "City"]},
+        {"name": "custom-scope", "args": ["ltu"]},
+    ]
+    assert build_url_path(query) == "example/City/@ltu"
+
+
+def test_custom_scope_round_trip():
+    path = "example/City/@ltu"
+    assert build_url_path(parse_url_path(path)) == path

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -51,3 +51,11 @@ def test_maxgargs():
     with pytest.raises(Exception) as e:
         parse_url_path("foo/bar/:ns/arg")
     assert str(e.value) == "URL parameter 'ns' can only have 0 arguments."
+
+
+def test_parse_url_path_recognizes_custom_scope():
+    result = parse_url_path("example/City/@ltu")
+    assert result == [
+        {"name": "path", "args": ["example", "City"]},
+        {"name": "custom-scope", "args": ["ltu"]},
+    ]


### PR DESCRIPTION
Custom scope enforcement via `@scopeName` URL syntax
  Summary:
    - Implementing named scope enforcement for data access restriction. Scopes are defined in the manifest and applied per request to restrict what rows and fields a consumer can see.

  Manifest definition:
  | scope | ltu | | country_code='lt' |
  | scope | pub | | select(name)&country_code='lt' |
  
  URL activation:
  GET /example/City/@ltu
  GET /example/City/@pub?name="Vilnius"

  Changes
  
  - spinta/utils/url.py — @scopeName URL segment parsed as custom-scope param; serialized back in build_url_path
  - spinta/components.py — custom_scope: Optional[str] added to UrlParams
  - spinta/urlparams.py — _apply_custom_scope called after path resolution; five new private functions:
    - _extract_scope_parts — splits scope AST into (select_args, filter_exprs)
    - _collect_field_refs — recursively extracts field names from an AST expression
    - _check_field_access — blocks user filter/sort on fields hidden by scope select
    - _apply_scope_select — intersects user select with scope-allowed fields
    - _apply_custom_scope — orchestrates the above
  - spinta/dimensions/scope/helpers.py — get_active_custom_scope(model, params) resolves the active scope by name
  - tests/test_urlparams.py — 25 unit tests covering row filter, select restriction, and field access enforcement
  - tests/cli/test_run.py — 14 integration tests across SQLite, CSV, and XML backends

  Security guarantees
  
  - Scope row filters are appended after user conditions are validated — user cannot override or drop them
  - A contradicting user filter (country_code='de' against scope country_code='lt') produces zero rows, not a bypass
  - When scope defines select(...), user filter/sort on hidden fields raises PropertyNotFound — field existence is not revealed
  - Sorting by a hidden field is also blocked (prevents value inference by ordering)

