### PR TITLE
1950 prideti count funkcijos palaikyma su dask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 0.2dev26 (unreleased)
 =====================
 
+Bug fixes:
+
+- Fixed `count()` function not working properly with `dask` backends (`#1950`_).
+
+.. _#1950: https://github.com/atviriduomenys/spinta/issues/1950
 
 0.2dev25 (2026-05-22)
 =====================

--- a/spinta/datasets/backends/dataframe/commands/read.py
+++ b/spinta/datasets/backends/dataframe/commands/read.py
@@ -31,6 +31,7 @@ from spinta.ufuncs.querybuilder.components import Selected
 from spinta.ufuncs.helpers import merge_formulas
 from spinta.ufuncs.resultbuilder.components import ResultBuilder
 from spinta.utils.data import take
+from spinta.utils.nestedstruct import flat_dicts_to_nested, extract_list_property_names
 from spinta.utils.schema import NA
 
 OBJECT_DTYPE = "object"
@@ -268,12 +269,14 @@ def dask_get_all(
     where = env.execute(expr)
     qry = env.build(where)
 
+    env_selected = env.selected
+    list_keys = extract_list_property_names(model, env_selected.keys())
     for i, row in qry.iterrows():
         row = row.to_dict()
         res = {
             "_type": model.model_type(),
         }
-        for key, sel in env.selected.items():
+        for key, sel in env_selected.items():
             val = _get_row_value(context, row, sel, env.params)
             if sel.prop:
                 if isinstance(sel.prop.dtype, PrimaryKey):
@@ -288,6 +291,7 @@ def dask_get_all(
                 elif is_custom_id_prop(sel.prop) and isinstance(val, list) and not isinstance(sel.prop.dtype, Base32):
                     val = encode_composite_string_id(val, model.external.pkeys)
             res[key] = val
+        res = flat_dicts_to_nested(res, list_keys=list_keys)
         res = commands.cast_backend_to_python(context, model, backend, res, extra_properties=extra_properties)
         yield res
 

--- a/spinta/datasets/backends/dataframe/ufuncs/query/components.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/components.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
 
-from dask.dataframe import DataFrame
+import pandas as pd
+from dask.dataframe import DataFrame, from_delayed
+from dask import delayed
 
 from spinta.components import Model, Property
 from spinta.core.ufuncs import Env, Expr
 
 from spinta.exceptions import UnknownMethod
 from spinta.ufuncs.propertyresolver.components import PropertyResolver
-from spinta.ufuncs.querybuilder.components import Selected
+from spinta.ufuncs.querybuilder.components import Selected, Func
 from spinta.utils.schema import NA
 from spinta.datasets.backends.dataframe.components import DaskBackend
 
@@ -33,6 +36,7 @@ class DaskDataFrameQueryBuilder(Env):
             offset=None,
             params=params,
             url_query=None,
+            count_prop="",
         )
 
     def build(self, where):
@@ -48,6 +52,16 @@ class DaskDataFrameQueryBuilder(Env):
 
         if where is not None:
             df = df[where]
+
+        if self.count_prop:
+            # To only return one row, we need to calculate the count first and then transform it back to dataframe
+            # Otherwise iterrows will duplicate the result with the number of rows equal to count.
+            # Dask allows delayed calculations which ar lazy.
+
+            # Create a delayed scalar function that returns the count of the dataframe as a new one-column dataframe
+            count_scalar = delayed(lambda value: pd.DataFrame({self.count_prop: [value]}))(df.map_partitions(len).sum())
+            df = from_delayed([count_scalar], meta=pd.DataFrame({self.count_prop: pd.Series(dtype="int64")}))
+
         return df
 
     def execute(self, expr: Any):
@@ -73,3 +87,8 @@ class DaskSelected(Selected):
     prop: Property = None
     # A value or an Expr for further processing on selected value.
     prep: Any = NA
+
+
+@dataclasses.dataclass
+class Count(Func):
+    prop_name: str

--- a/spinta/datasets/backends/dataframe/ufuncs/query/components.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/components.py
@@ -36,7 +36,7 @@ class DaskDataFrameQueryBuilder(Env):
             offset=None,
             params=params,
             url_query=None,
-            count_prop="",
+            count=False,
         )
 
     def build(self, where):
@@ -53,14 +53,16 @@ class DaskDataFrameQueryBuilder(Env):
         if where is not None:
             df = df[where]
 
-        if self.count_prop:
+        if self.count:
             # To only return one row, we need to calculate the count first and then transform it back to dataframe
             # Otherwise iterrows will duplicate the result with the number of rows equal to count.
             # Dask allows delayed calculations which ar lazy.
 
             # Create a delayed scalar function that returns the count of the dataframe as a new one-column dataframe
-            count_scalar = delayed(lambda value: pd.DataFrame({self.count_prop: [value]}))(df.map_partitions(len).sum())
-            df = from_delayed([count_scalar], meta=pd.DataFrame({self.count_prop: pd.Series(dtype="int64")}))
+            count_scalar = delayed(lambda value: pd.DataFrame({RESERVED_COUNT_PROP: [value]}))(
+                df.map_partitions(len).sum()
+            )
+            df = from_delayed([count_scalar], meta=pd.DataFrame({RESERVED_COUNT_PROP: pd.Series(dtype="int64")}))
 
         return df
 
@@ -89,6 +91,9 @@ class DaskSelected(Selected):
     prep: Any = NA
 
 
+RESERVED_COUNT_PROP = "__dask_count"
+
+
 @dataclasses.dataclass
 class Count(Func):
-    prop_name: str
+    pass

--- a/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
@@ -14,6 +14,7 @@ from spinta.datasets.backends.dataframe.ufuncs.query.components import (
     DaskDataFrameQueryBuilder,
     DaskSelected as Selected,
     Count,
+    RESERVED_COUNT_PROP,
 )
 from spinta.datasets.components import Param
 from spinta.datasets.utils import iterparams
@@ -27,7 +28,6 @@ from spinta.types.datatype import DataType, PrimaryKey, Ref
 from spinta.types.text.components import Text
 from spinta.ufuncs.components import ForeignProperty
 from spinta.utils.data import take
-from spinta.utils.naming import Deduplicator
 from spinta.utils.schema import NA
 
 
@@ -130,10 +130,7 @@ def _resolve_unresolved(env: DaskDataFrameQueryBuilder, field: Bind) -> str:
 
 @ufunc.resolver(DaskDataFrameQueryBuilder)
 def count(env: DaskDataFrameQueryBuilder) -> Count:
-    deduplicator = Deduplicator()
-    for key in env.dataframe.columns:
-        deduplicator(key)
-    return Count(deduplicator("_dask_count"))
+    return Count()
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder, Expr)
@@ -490,8 +487,8 @@ def select(
     env: DaskDataFrameQueryBuilder,
     value: Count,
 ) -> Selected:
-    env.count_prop = value.prop_name
-    return Selected(item=value.prop_name)
+    env.count = True
+    return Selected(item=RESERVED_COUNT_PROP)
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder, Expr)

--- a/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
@@ -13,6 +13,7 @@ from spinta.core.ufuncs import Expr, ufunc, Bind, Unresolved, GetAttr
 from spinta.datasets.backends.dataframe.ufuncs.query.components import (
     DaskDataFrameQueryBuilder,
     DaskSelected as Selected,
+    Count,
 )
 from spinta.datasets.components import Param
 from spinta.datasets.utils import iterparams
@@ -26,6 +27,7 @@ from spinta.types.datatype import DataType, PrimaryKey, Ref
 from spinta.types.text.components import Text
 from spinta.ufuncs.components import ForeignProperty
 from spinta.utils.data import take
+from spinta.utils.naming import Deduplicator
 from spinta.utils.schema import NA
 
 
@@ -127,8 +129,11 @@ def _resolve_unresolved(env: DaskDataFrameQueryBuilder, field: Bind) -> str:
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder)
-def count(env: DaskDataFrameQueryBuilder):
-    return len(env.dataframe.index)
+def count(env: DaskDataFrameQueryBuilder) -> Count:
+    deduplicator = Deduplicator()
+    for key in env.dataframe.columns:
+        deduplicator(key)
+    return Count(deduplicator("_dask_count"))
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder, Expr)
@@ -142,30 +147,8 @@ def select(env: DaskDataFrameQueryBuilder, expr: Expr):
 
     env.selected = {}
     if args:
-        resolved = {}
-        selected_keys = set()
-        selected_languages = {}
         for key, arg in args:
-            resolved[key] = env.call("_resolve_property", arg)
-        for key, prop in resolved.items():
-            prop_parent = getattr(prop, "parent", None)
-            if prop_parent and isinstance(prop_parent.dtype, Text):
-                selected_keys.add(prop_parent.place)
-                selected_languages.setdefault(prop_parent.place, set()).add(prop.name)
-            else:
-                selected_keys.add(prop.name)
-        for selected_key in selected_keys:
-            prop = env.model.flatprops.get(selected_key)
-            if isinstance(prop.dtype, Text) and authorized(env.context, prop, Action.GETALL):
-                selected_language = selected_languages.get(prop.place)
-                if not selected_language:
-                    env.selected[prop.place] = env.call("select", prop)
-                else:
-                    env.selected[prop.place] = env.call("select", prop, selected_language)
-            elif authorized(env.context, prop, Action.GETALL):
-                env.selected[resolved[selected_key].place] = env.call("select", resolved[selected_key])
-            else:
-                raise PropertyNotFound(env.model, property=resolved[selected_key])
+            env.selected[key] = env.call("select", arg)
     else:
         for prop in take(["_id", "_revision", all], env.model.properties).values():
             if prop.name == "_revision" and not is_custom_revision_prop(prop):
@@ -500,6 +483,15 @@ def select(
     prep: Dict[str, Any],
 ) -> Dict[str, Any]:
     return {k: env.call("select", v) for k, v in prep.items()}
+
+
+@ufunc.resolver(DaskDataFrameQueryBuilder, Count)
+def select(
+    env: DaskDataFrameQueryBuilder,
+    value: Count,
+) -> Selected:
+    env.count_prop = value.prop_name
+    return Selected(item=value.prop_name)
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder, Expr)

--- a/tests/datasets/dataframe/test_read.py
+++ b/tests/datasets/dataframe/test_read.py
@@ -373,3 +373,49 @@ def test_swap_ufunc(rc: RawConfig, fs: AbstractFileSystem):
         ("3", "---"),
         ("4", "---"),
     ]
+
+
+def test_count(rc: RawConfig, fs: AbstractFileSystem):
+    fs.pipe("cities.csv", ("id,name\n1,test\n2,\n3,\n4,null").encode("utf-8"))
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+    d | r | b | m | property | type     | ref  | source              | prepare            | access
+    example/csv              |          |      |                     |                    |
+      | csv                  | dask/csv |      | memory://cities.csv |                    |
+      |   |   | City         |          | name |                     |                    |
+      |   |   |   | id       | string   |      | id                  |                    | open
+      |   |   |   | name     | string   |      | name                |                    | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/csv/City", ["search"])
+
+    resp = app.get("/example/csv/City?count()")
+    assert listdata(resp) == [4]
+
+
+def test_select_count(rc: RawConfig, fs: AbstractFileSystem):
+    fs.pipe("cities.csv", ("id,name\n1,test\n2,\n3,\n4,null").encode("utf-8"))
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+    d | r | b | m | property | type     | ref  | source              | prepare            | access
+    example/csv              |          |      |                     |                    |
+      | csv                  | dask/csv |      | memory://cities.csv |                    |
+      |   |   | City         |          | name |                     |                    |
+      |   |   |   | id       | string   |      | id                  |                    | open
+      |   |   |   | name     | string   |      | name                |                    | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/csv/City", ["search"])
+
+    resp = app.get("/example/csv/City?select(count())")
+    assert listdata(resp) == [4]


### PR DESCRIPTION
- Reverted some `Text` support changes for dask, since they broke non-property selects (updated `getall` parser to mimic `sql` backend functionality with nested properties, this should re-enable `Text` support without hacks).
- Changed `count` function to now recreate dataframe with only count property.