### PR TITLE
1959: Adding new _eq resolvers for DaskDataFrameQueryBuilder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,10 @@ Improvements:
 Bug fixes:
 
 - Fixed `count()` function not working properly with `dask` backends (`#1950`_).
+- Fixed `eq` comparison not working properly with `dask` backends on Number, Integer, Boolean values (`#1959`_).
 
 .. _#1950: https://github.com/atviriduomenys/spinta/issues/1950
+.. _#1959: https://github.com/atviriduomenys/spinta/issues/1959
 
 0.2dev25 (2026-05-22)
 =====================

--- a/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
+++ b/spinta/datasets/backends/dataframe/ufuncs/query/ufuncs.py
@@ -24,7 +24,7 @@ from spinta.exceptions import (
     SourceOrPrepareNotAllowed,
     InvalidArgumentInExpression,
 )
-from spinta.types.datatype import DataType, PrimaryKey, Ref
+from spinta.types.datatype import DataType, Integer, Number, Boolean, PrimaryKey, Ref
 from spinta.types.text.components import Text
 from spinta.ufuncs.components import ForeignProperty
 from spinta.utils.data import take
@@ -520,6 +520,24 @@ def compare(env: DaskDataFrameQueryBuilder, op: Bind, field: object, value: Any)
 def eq_(env: DaskDataFrameQueryBuilder, dtype: DataType, obj: object) -> Series:
     name = dtype.prop.external.name
     return env.dataframe[name] == str(obj)
+
+
+@ufunc.resolver(DaskDataFrameQueryBuilder, Integer, object, name="eq")
+def eq_(env: DaskDataFrameQueryBuilder, dtype: Integer, obj: object) -> Series:
+    name = dtype.prop.external.name
+    return env.dataframe[name] == obj
+
+
+@ufunc.resolver(DaskDataFrameQueryBuilder, Number, object, name="eq")
+def eq_(env: DaskDataFrameQueryBuilder, dtype: Number, obj: object) -> Series:
+    name = dtype.prop.external.name
+    return env.dataframe[name] == obj
+
+
+@ufunc.resolver(DaskDataFrameQueryBuilder, Boolean, object, name="eq")
+def eq_(env: DaskDataFrameQueryBuilder, dtype: Boolean, obj: object) -> Series:
+    name = dtype.prop.external.name
+    return env.dataframe[name] == obj
 
 
 @ufunc.resolver(DaskDataFrameQueryBuilder, Param, name="eval")

--- a/tests/datasets/dataframe/test_ufunc.py
+++ b/tests/datasets/dataframe/test_ufunc.py
@@ -193,6 +193,127 @@ def test_xsd_getall_raise_error_if_base64_is_invalid(rc: RawConfig, tmp_path: Pa
         )
 
 
+def test_csv_integer_eq_filter(rc: RawConfig, fs: AbstractFileSystem):
+    fs.pipe("cities.csv", b"name,population\nVilnius,500000\nRyga,600000\nTallinn,400000")
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+    d | r | b | m | property   | type     | ref  | source                   | access
+    example                    |          |      |                          |
+      | res                    | dask/csv |      | memory://cities.csv      |
+      |   |   | City           |          | name |                          |
+      |   |   |   | name       | string   |      | name                     | open
+      |   |   |   | population | integer  |      | population               | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    resp = app.get("/example/City?population=500000")
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_json_integer_eq_filter(rc: RawConfig, tmp_path: Path):
+    data = '{"cities": [{"name": "Vilnius", "population": 500000}, {"name": "Ryga", "population": 600000}, {"name": "Tallinn", "population": 400000}]}'
+    (tmp_path / "cities.json").write_text(data)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+    d | r | b | m | property   | type      | ref  | source                       | access
+    example                    |           |      |                              |
+      | res                    | dask/json |      | {tmp_path}/cities.json       |
+      |   |   | City           |           | name | cities                       |
+      |   |   |   | name       | string    |      | name                         | open
+      |   |   |   | population | integer   |      | population                   | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    resp = app.get("/example/City?population=500000")
+    assert listdata(resp, "name") == ["Vilnius"]
+
+
+def test_csv_number_eq_filter(rc: RawConfig, fs: AbstractFileSystem):
+    fs.pipe("cities.csv", b"name,score\nVilnius,8.5\nRyga,7.2\nTallinn,9.1")
+
+    context, manifest = prepare_manifest(
+        rc,
+        """
+    d | r | b | m | property | type     | ref  | source                   | access
+    example                  |          |      |                          |
+      | res                  | dask/csv |      | memory://cities.csv      |
+      |   |   | City         |          | name |                          |
+      |   |   |   | name     | string   |      | name                     | open
+      |   |   |   | score    | number   |      | score                    | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    resp = app.get("/example/City?score=9.1")
+    assert listdata(resp, "name") == ["Tallinn"]
+
+
+def test_json_number_eq_filter(rc: RawConfig, tmp_path: Path):
+    data = '{"cities": [{"name": "Vilnius", "score": 8.5}, {"name": "Ryga", "score": 7.2}, {"name": "Tallinn", "score": 9.1}]}'
+    (tmp_path / "cities.json").write_text(data)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+    d | r | b | m | property | type      | ref  | source                       | access
+    example                  |           |      |                              |
+      | res                  | dask/json |      | {tmp_path}/cities.json       |
+      |   |   | City         |           | name | cities                       |
+      |   |   |   | name     | string    |      | name                         | open
+      |   |   |   | score    | number    |      | score                        | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    resp = app.get("/example/City?score=9.1")
+    assert listdata(resp, "name") == ["Tallinn"]
+
+
+def test_json_boolean_eq_filter(rc: RawConfig, tmp_path: Path):
+    data = '{"cities": [{"name": "Vilnius", "capital": true}, {"name": "Kaunas", "capital": false}, {"name": "Klaipeda", "capital": false}]}'
+    (tmp_path / "cities.json").write_text(data)
+
+    context, manifest = prepare_manifest(
+        rc,
+        f"""
+    d | r | b | m | property | type      | ref  | source                       | access
+    example                  |           |      |                              |
+      | res                  | dask/json |      | {tmp_path}/cities.json       |
+      |   |   | City         |           | name | cities                       |
+      |   |   |   | name     | string    |      | name                         | open
+      |   |   |   | capital  | boolean   |      | capital                      | open
+    """,
+        mode=Mode.external,
+    )
+    context.loaded = True
+    app = create_test_client(context)
+    app.authmodel("example/City", ["getall", "search"])
+
+    resp = app.get("/example/City?capital=true")
+    assert listdata(resp, "name") == ["Vilnius"]
+
+    resp = app.get("/example/City?capital=false")
+    assert listdata(resp, "name") == ["Kaunas", "Klaipeda"]
+
+
 def test_csv_and_operation(rc: RawConfig, fs: AbstractFileSystem):
     fs.pipe("cities.csv", ("salis,miestas\nlt,Vilnius\nlt,Kaunas\nlt,Siauliai\nlv,Ryga\nee,Talin").encode("utf-8"))
 


### PR DESCRIPTION
Summary:  
  - The generic `eq_` resolver was coercing all filter values to `str(obj)` before
  comparison, causing integer, number and boolean field filtering to always
  return empty results in dask backends
  - Added separate `eq_` resolvers for Integer, Number and Boolean dtypes that
  compare values directly without string coercion
  - Added tests covering integer, number and boolean filtering for both
  dask/json and dask/csv backends
Root cause:
  dask/json reads native JSON types as Python int/float/bool, and dask/csv
  infers integer and float columns as int64/float64. Comparing these with a
  string value always returns False.
Not affected: dask/xml and dask/soap — these backends always return values as
  strings, so the generic str() handler remains correct for them.

Ticket: https://github.com/atviriduomenys/spinta/issues/1959