### PR TITLE
1970 fix to the logic of refs to models with no primary keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,10 +48,16 @@ Bug fixes:
 - Fixed a bug where getone method in sql backend did not get any ref data (`#1900`_)
 - Fixed `count()` function not working properly with `dask` backends (`#1950`_).
 - Fixed `eq` comparison not working properly with `dask` backends on Number, Integer, Boolean values (`#1959`_).
+- Fixed data type detection in the tabular manifest reader so that modifiers
+  such as `required` or `unique` no longer interfere with parent and nesting
+  resolution. An `array` of `backref` is now recognised as an array backref, and
+  re-declaring an `object`/`array` property with a modifier no longer raises a
+  spurious nesting error (`#1970`_).
 
 .. _#1900: https://github.com/atviriduomenys/spinta/issues/1900
 .. _#1950: https://github.com/atviriduomenys/spinta/issues/1950
 .. _#1959: https://github.com/atviriduomenys/spinta/issues/1959
+.. _#1970: https://github.com/atviriduomenys/spinta/issues/1970
 
 0.2dev25 (2026-05-22)
 =====================

--- a/spinta/manifests/tabular/helpers.py
+++ b/spinta/manifests/tabular/helpers.py
@@ -653,9 +653,20 @@ class PropertyReader(TabularReader):
     enums: Set[str]
 
     def read(self, row: Dict[str, str]) -> None:
-        complete_structure, parent_structure, prop_name = _extract_and_create_parent_data(self, row, row["property"])
+        # Parse the data type once, here at the boundary, and pass the parsed
+        # result inward. Downstream code must not re-parse `row["type"]` or
+        # compare against the raw string: modifiers (`required`, `unique`) and
+        # arguments would make a type such as `backref required` or
+        # `object required` unrecognisable. Parent and nesting resolution only
+        # needs the bare type, while `_handle_datatype` keeps the modifiers.
+        dtype = _resolve_dtype(self, row)
+        bare_row = {**row, "type": dtype["type"]}
+        complete_structure, parent_structure, prop_name = _extract_and_create_parent_data(
+            self, bare_row, bare_row["property"]
+        )
 
-        prop_data = _handle_datatype(self, row)
+        prop_data = _handle_datatype(self, row, dtype)
+
         prop_name = _combine_parent_with_prop(prop_name, prop_data, parent_structure, complete_structure)
 
         # Edge case where there is no nesting, need to couple `prop_data` with `complete_structure`
@@ -748,8 +759,11 @@ def _initial_text_property_schema(given_name: str, dtype: dict, row: dict):
     return result
 
 
-def _datatype_handler(reader: PropertyReader, row: dict, initial_data_loader: Callable[[str, dict, dict], dict]):
-    dtype: dict = _resolve_dtype(reader, row)
+def _datatype_handler(
+    reader: PropertyReader, row: dict, initial_data_loader: Callable[[str, dict, dict], dict], dtype: dict = None
+):
+    if dtype is None:
+        dtype = _resolve_dtype(reader, row)
     given_name = row["property"]
     reader.name = _clean_up_prop_name(row["property"].split(".")[-1])
 
@@ -759,7 +773,7 @@ def _datatype_handler(reader: PropertyReader, row: dict, initial_data_loader: Ca
             f"Property {reader.name!r} must be defined in a model context. "
             f"Now it is defined in {context.name!r} {context.type} context."
         )
-    _check_if_property_already_set(reader, row, given_name)
+    _check_if_property_already_set(reader, dtype["type"], given_name)
 
     if reader.state.base and not dtype["type"]:
         dtype["type"] = "inherit"
@@ -804,8 +818,9 @@ def _datatype_handler(reader: PropertyReader, row: dict, initial_data_loader: Ca
     return new_data
 
 
-def _string_datatype_handler(reader: PropertyReader, row: dict):
-    dtype: dict = _resolve_dtype(reader, row)
+def _string_datatype_handler(reader: PropertyReader, row: dict, dtype: dict = None):
+    if dtype is None:
+        dtype = _resolve_dtype(reader, row)
     given_name = row["property"]
     reader.name = _clean_up_prop_name(row["property"].split(".")[-1])
 
@@ -815,7 +830,7 @@ def _string_datatype_handler(reader: PropertyReader, row: dict):
             f"Property {reader.name!r} must be defined in a model context. "
             f"Now it is defined in {context.name!r} {context.type} context."
         )
-    existing_data = _check_if_property_already_set(reader, row, given_name)
+    existing_data = _check_if_property_already_set(reader, dtype["type"], given_name)
     if dtype["type"] == DataTypeEnum.TEXT.value and existing_data:
         reader.error(
             f"Property {reader.name!r} with the same name is already "
@@ -835,8 +850,9 @@ def _string_datatype_handler(reader: PropertyReader, row: dict):
     return new_data
 
 
-def _text_datatype_handler(reader: PropertyReader, row: dict):
-    dtype: dict = _resolve_dtype(reader, row)
+def _text_datatype_handler(reader: PropertyReader, row: dict, dtype: dict = None):
+    if dtype is None:
+        dtype = _resolve_dtype(reader, row)
     given_name = row["property"]
     reader.name = _clean_up_prop_name(row["property"].split(".")[-1])
 
@@ -846,7 +862,7 @@ def _text_datatype_handler(reader: PropertyReader, row: dict):
             f"Property {reader.name!r} must be defined in a model context. "
             f"Now it is defined in {context.name!r} {context.type} context."
         )
-    result = _check_if_property_already_set(reader, row, given_name)
+    result = _check_if_property_already_set(reader, dtype["type"], given_name)
     if not (result and result["explicitly_given"] is False and result["type"] == DataTypeEnum.TEXT.value or not result):
         reader.error(
             f"Property {reader.name!r} with the same name is already "
@@ -893,22 +909,23 @@ def _text_datatype_handler(reader: PropertyReader, row: dict):
     return new_data
 
 
-def _default_datatype_handler(reader: PropertyReader, row: dict):
-    return _datatype_handler(reader, row, _initial_normal_property_schema)
+def _default_datatype_handler(reader: PropertyReader, row: dict, dtype: dict = None):
+    return _datatype_handler(reader, row, _initial_normal_property_schema, dtype)
 
 
-def _array_datatype_handler(reader: PropertyReader, row: dict):
-    return _datatype_handler(reader, row, _initial_array_property_schema)
+def _array_datatype_handler(reader: PropertyReader, row: dict, dtype: dict = None):
+    return _datatype_handler(reader, row, _initial_array_property_schema, dtype)
 
 
-def _partial_datatype_handler(reader: PropertyReader, row: dict):
-    return _datatype_handler(reader, row, _initial_partial_property_schema)
+def _partial_datatype_handler(reader: PropertyReader, row: dict, dtype: dict = None):
+    return _datatype_handler(reader, row, _initial_partial_property_schema, dtype)
 
 
-def _handle_datatype(reader: PropertyReader, row: dict):
-    dtype: dict = _resolve_dtype(reader, row)
+def _handle_datatype(reader: PropertyReader, row: dict, dtype: dict = None):
+    if dtype is None:
+        dtype = _resolve_dtype(reader, row)
     handler = DATATYPE_HANDLERS.get(dtype["type"], DATATYPE_HANDLERS["_default"])
-    return handler(reader, row)
+    return handler(reader, row, dtype)
 
 
 DATATYPE_HANDLERS = {
@@ -1204,7 +1221,7 @@ def _extract_children_from_nested(base: dict, children_name: str) -> dict:
     return base
 
 
-def _check_if_property_already_set(reader: PropertyReader, given_row: dict, full_name: str):
+def _check_if_property_already_set(reader: PropertyReader, given_type: str, full_name: str):
     # Treat '@' as normal '.', since '_extract_children_from_nested' is able to extract based on type
     split = full_name.replace("@", ".").split(".")
     base = {}
@@ -1250,11 +1267,14 @@ def _check_if_property_already_set(reader: PropertyReader, given_row: dict, full
             f"Property {full_name!r} with the same name is already defined for this {reader.state.model.name!r} model."
         )
 
+    # `given_type` is the bare data type (modifiers and arguments already
+    # stripped by the caller), so a nesting type such as `object` is recognised
+    # even when it was declared as `object required`.
     if base and (
-        (base["type"] in ALLOWED_PARTIAL_TYPES and given_row["type"] not in ALLOWED_PARTIAL_TYPES)
-        or (base["type"] in ALLOWED_ARRAY_TYPES and given_row["type"] not in ALLOWED_ARRAY_TYPES)
+        (base["type"] in ALLOWED_PARTIAL_TYPES and given_type not in ALLOWED_PARTIAL_TYPES)
+        or (base["type"] in ALLOWED_ARRAY_TYPES and given_type not in ALLOWED_ARRAY_TYPES)
     ):
-        raise DataTypeCannotBeUsedForNesting(dtype=given_row["type"])
+        raise DataTypeCannotBeUsedForNesting(dtype=given_type)
     return base
 
 

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -1127,7 +1127,7 @@ def test_prop_array_backref_nested(tmp_path, rc):
 
 
 @pytest.mark.parametrize("modifier", ["required", "unique"])
-def test_prop_array_backref_with_modifier(modifier, rc):
+def test_prop_array_backref_with_modifier(modifier: str, rc: RawConfig) -> None:
     # Type modifiers such as `required` or `unique` must not prevent an array of
     # `backref` from being recognised as an array backref (`#1970`).
     context, manifest = load_manifest_and_context(
@@ -1150,7 +1150,7 @@ def test_prop_array_backref_with_modifier(modifier, rc):
 
 
 @pytest.mark.parametrize("modifier", ["required", "unique"])
-def test_prop_object_redeclared_with_modifier(modifier, rc):
+def test_prop_object_redeclared_with_modifier(modifier: str, rc: RawConfig) -> None:
     # A nesting type with a modifier (e.g. `object required`) must still be
     # recognised as a nesting type when an auto-created container is later
     # re-declared explicitly, instead of raising DataTypeCannotBeUsedForNesting

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from spinta import commands
 from spinta.core.config import RawConfig
 from spinta.exceptions import (
     DataTypeCannotBeUsedForNesting,
@@ -22,6 +23,9 @@ from spinta.exceptions import (
 )
 from spinta.manifests.tabular.helpers import TabularManifestError
 from spinta.testing.manifest import load_manifest
+from spinta.testing.manifest import load_manifest, load_manifest_and_context
+from spinta.manifests.tabular.helpers import TabularManifestError
+from spinta.types.datatype import ArrayBackRef, BackRef
 
 
 def check(tmp_path, rc, table, manifest_type: str = "csv"):
@@ -1120,6 +1124,49 @@ def test_prop_array_backref_nested(tmp_path, rc):
           |   |   |   | languages[]   | ref     | Language | open
     """,
     )
+
+
+@pytest.mark.parametrize("modifier", ["required", "unique"])
+def test_prop_array_backref_with_modifier(modifier, rc):
+    # Type modifiers such as `required` or `unique` must not prevent an array of
+    # `backref` from being recognised as an array backref (`#1970`).
+    context, manifest = load_manifest_and_context(
+        rc,
+        f"""
+        d | r | b | m | property    | type            | ref      | access
+        example                     |                 |          |
+          |   |   | Language        |                 |          |
+          |   |   |   | name        | string          |          | open
+          |   |   |   | countries[] | backref {modifier} | Country  | open
+          |   |   | Country         |                 |          |
+          |   |   |   | name        | string          |          | open
+          |   |   |   | languages[] | ref             | Language | open
+    """,
+    )
+    model = commands.get_model(context, manifest, "example/Language")
+    prop = model.properties["countries"]
+    assert isinstance(prop.dtype, ArrayBackRef)
+    assert isinstance(prop.dtype.items.dtype, BackRef)
+
+
+@pytest.mark.parametrize("modifier", ["required", "unique"])
+def test_prop_object_redeclared_with_modifier(modifier, rc):
+    # A nesting type with a modifier (e.g. `object required`) must still be
+    # recognised as a nesting type when an auto-created container is later
+    # re-declared explicitly, instead of raising DataTypeCannotBeUsedForNesting
+    # (`#1970`).
+    context, manifest = load_manifest_and_context(
+        rc,
+        f"""
+        d | r | b | m | property | type            | ref | access
+        example                  |                 |     |
+          |   |   | M            |                 |     |
+          |   |   |   | o.a      | string          |     | open
+          |   |   |   | o        | object {modifier} |     | open
+    """,
+    )
+    model = commands.get_model(context, manifest, "example/M")
+    assert "o" in model.properties
 
 
 @pytest.mark.skip("backref not implemented yet #96")

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -22,9 +22,7 @@ from spinta.exceptions import (
     UndefinedPropertyType,
 )
 from spinta.manifests.tabular.helpers import TabularManifestError
-from spinta.testing.manifest import load_manifest
 from spinta.testing.manifest import load_manifest, load_manifest_and_context
-from spinta.manifests.tabular.helpers import TabularManifestError
 from spinta.types.datatype import ArrayBackRef, BackRef
 
 


### PR DESCRIPTION
Pradinė klaida buvo todėl, kad `backref required` būdavo neatpažįstamas kaip `backref`. 

Ji buvo pataisyta skaitymo metu `backref required` tikrinime sumažinus iki `backerf`
 