### PR TITLE
saugesni kešavimo nustatymai

### DIFF
--- a/spinta/api/__init__.py
+++ b/spinta/api/__init__.py
@@ -468,12 +468,12 @@ def init(context: Context):
     ]
 
     middleware = [
-        Middleware(PathNormalizationMiddleware),
-        Middleware(ContextMiddleware, context=context),
         Middleware(
             StrictTransportSecurityMiddleware,
             value=config.http_strict_transport_security,
         ),
+        Middleware(PathNormalizationMiddleware),
+        Middleware(ContextMiddleware, context=context),
     ]
 
     exception_handlers = {

--- a/spinta/api/__init__.py
+++ b/spinta/api/__init__.py
@@ -49,6 +49,7 @@ from spinta.exceptions import (
     NoAuthServer,
     error_response,
 )
+from spinta.middlewares import ContextMiddleware, PathNormalizationMiddleware
 from spinta.formats.html.helpers import get_templates
 from spinta.middlewares import ContextMiddleware, StrictTransportSecurityMiddleware
 from spinta.urlparams import Version, get_response_type
@@ -370,7 +371,7 @@ async def error(request, exc):
     elif isinstance(exc, BaseError):
         status_code = exc.status_code
         errors = [error_response(exc)]
-        headers = exc.headers
+        headers = dict(exc.headers)
     else:
         if isinstance(exc, HTTPException):
             status_code = exc.status_code
@@ -399,6 +400,11 @@ async def error(request, exc):
         ]
 
     response = {"errors": errors}
+
+    # Error responses can reflect request input (e.g. the requested path) and
+    # must never be stored by shared caches, otherwise they can be used for
+    # web cache poisoning.
+    headers["Cache-Control"] = "no-store"
 
     fmt = get_response_type(request.state.context, request)
     if fmt == "json" or fmt is None:
@@ -463,11 +469,12 @@ def init(context: Context):
     ]
 
     middleware = [
+        Middleware(PathNormalizationMiddleware),
+        Middleware(ContextMiddleware, context=context),
         Middleware(
             StrictTransportSecurityMiddleware,
             value=config.http_strict_transport_security,
         ),
-        Middleware(ContextMiddleware, context=context),
     ]
 
     exception_handlers = {

--- a/spinta/api/__init__.py
+++ b/spinta/api/__init__.py
@@ -49,9 +49,8 @@ from spinta.exceptions import (
     NoAuthServer,
     error_response,
 )
-from spinta.middlewares import ContextMiddleware, PathNormalizationMiddleware
 from spinta.formats.html.helpers import get_templates
-from spinta.middlewares import ContextMiddleware, StrictTransportSecurityMiddleware
+from spinta.middlewares import ContextMiddleware, PathNormalizationMiddleware, StrictTransportSecurityMiddleware
 from spinta.urlparams import Version, get_response_type
 
 log = logging.getLogger(__name__)

--- a/spinta/middlewares.py
+++ b/spinta/middlewares.py
@@ -17,6 +17,11 @@ def _is_normalized_path(scope: Scope) -> bool:
     if "\\" in path:
         return False
     normalized = posixpath.normpath(path)
+    # posixpath.normpath preserves a leading "//" (POSIX leaves two leading
+    # slashes implementation-defined), but shared caches collapse it to "/",
+    # so treat such a path as non-normalized.
+    if normalized.startswith("//"):
+        normalized = normalized[1:]
     if path.endswith("/") and normalized != "/":
         normalized += "/"
     return path == normalized

--- a/spinta/middlewares.py
+++ b/spinta/middlewares.py
@@ -1,6 +1,59 @@
+import posixpath
+
+from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from spinta.components import Context
+
+
+def _is_normalized_path(scope: Scope) -> bool:
+    raw_path = (scope.get("raw_path") or b"").lower()
+    # Percent-encoded slashes, backslashes and dots decode into extra path
+    # delimiters and dot segments that shared caches do not see when they
+    # build the cache key.
+    if b"%2f" in raw_path or b"%5c" in raw_path or b"%2e" in raw_path:
+        return False
+    path = scope["path"]
+    if "\\" in path:
+        return False
+    normalized = posixpath.normpath(path)
+    if path.endswith("/") and normalized != "/":
+        normalized += "/"
+    return path == normalized
+
+
+class PathNormalizationMiddleware:
+    """Rejects requests whose path is not in normalized form.
+
+    Shared caches (proxies, CDNs) normalize URLs (resolve `.` and `..`
+    segments, decode percent-encoded slashes, collapse duplicate slashes)
+    when building the cache key, while the application receives the original
+    path and may reflect it in the response. This discrepancy enables web
+    cache poisoning: a response generated for a malicious non-normalized path
+    gets cached under the key of a legitimate URL. Rejecting such requests
+    with a non-cacheable response closes that gap.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and not _is_normalized_path(scope):
+            response = JSONResponse(
+                {
+                    "errors": [
+                        {
+                            "code": "InvalidRequestPath",
+                            "message": "Request path is not normalized.",
+                        }
+                    ]
+                },
+                status_code=404,
+                headers={"Cache-Control": "no-store"},
+            )
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
 
 
 class StrictTransportSecurityMiddleware:

--- a/spinta/utils/response.py
+++ b/spinta/utils/response.py
@@ -387,6 +387,9 @@ def cache_control_response_headers(context: Context, model: Model, target_id: st
 
     cache_control = {
         "Cache-Control": config.cache_control,
+        # Response body depends on these request headers (content negotiation,
+        # auth scopes), so shared caches must include them in the cache key.
+        "Vary": "Accept, Accept-Language, Authorization",
         "Last-Modified": last_modified,
         "ETag": revision,
     }

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,6 +2,13 @@ import datetime
 from datetime import timezone
 from email.utils import format_datetime
 
+import pytest
+
+from spinta.core.config import RawConfig
+from spinta.middlewares import _is_normalized_path
+from spinta.testing.client import create_test_client
+from spinta.testing.manifest import prepare_manifest
+
 
 def test_cache_control_postgres_get_one(context, app):
     model = "backends/postgres/Report"
@@ -43,6 +50,7 @@ def test_cache_control_postgres_get_one(context, app):
     )
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "public, max-age=60, must-revalidate"
+    assert resp.headers["Vary"] == "Accept, Accept-Language, Authorization"
     assert resp.headers["ETag"] == changelog_data["_revision"]
     assert resp.headers["Last-Modified"] == format_datetime(
         datetime.datetime.fromisoformat(changelog_data["_created"]).replace(tzinfo=timezone.utc), usegmt=True
@@ -81,6 +89,7 @@ def test_cache_control_postgres_get_all(context, app):
     )
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "public, max-age=60, must-revalidate"
+    assert resp.headers["Vary"] == "Accept, Accept-Language, Authorization"
     assert resp.headers["ETag"] == changelog_data["_revision"]
     assert resp.headers["Last-Modified"] == format_datetime(
         datetime.datetime.fromisoformat(changelog_data["_created"]).replace(tzinfo=timezone.utc), usegmt=True
@@ -345,3 +354,55 @@ def test_cache_control_priority(context, app):
     assert resp.headers["Last-Modified"] == format_datetime(
         datetime.datetime.fromisoformat(changelog_data["_created"]).replace(tzinfo=timezone.utc), usegmt=True
     )
+
+
+@pytest.mark.parametrize(
+    "path, raw_path, expected",
+    [
+        ("/", b"/", True),
+        ("/example/City", b"/example/City", True),
+        ("/example/City/", b"/example/City/", True),
+        ("/example/../City", b"/example/../City", False),
+        ("/example/./City", b"/example/./City", False),
+        ("/example//City", b"/example//City", False),
+        ("/example/City/..", b"/example/City/..", False),
+        ("/example/../City", b"/example/..%2fCity", False),
+        ("/example/../City", b"/example/..%2FCity", False),
+        ("/example/City", b"/example%2fCity", False),
+        ("/example\\City", b"/example%5cCity", False),
+        ("/example/.%2e/City", b"/example/.%2e/City", False),
+    ],
+)
+def test_is_normalized_path(path: str, raw_path: bytes, expected: bool):
+    scope = {"type": "http", "path": path, "raw_path": raw_path}
+    assert _is_normalized_path(scope) is expected
+
+
+def _create_memory_app(rc: RawConfig):
+    context, manifest = prepare_manifest(
+        rc,
+        """
+    d | r | b | m | property | type   | ref  | access
+    example                  |        |      |
+      |   |   | City         |        | name |
+      |   |   |   | name     | string |      | open
+    """,
+        backend="memory",
+    )
+    context.loaded = True
+    return create_test_client(context)
+
+
+def test_error_response_not_cacheable(rc: RawConfig):
+    app = _create_memory_app(rc)
+    resp = app.get("/example/DoesNotExist")
+    assert resp.status_code == 404
+    assert resp.headers["Cache-Control"] == "no-store"
+
+
+def test_non_normalized_path_rejected(rc: RawConfig):
+    app = _create_memory_app(rc)
+    resp = app.get("/example/..%2fCity")
+    assert resp.status_code == 404
+    assert resp.headers["Cache-Control"] == "no-store"
+    assert resp.json()["errors"][0]["code"] == "InvalidRequestPath"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -362,6 +362,8 @@ def test_cache_control_priority(context, app):
         ("/", b"/", True),
         ("/example/City", b"/example/City", True),
         ("/example/City/", b"/example/City/", True),
+        ("//example/City", b"//example/City", False),
+        ("/example/City//", b"/example/City//", False),
         ("/example/../City", b"/example/../City", False),
         ("/example/./City", b"/example/./City", False),
         ("/example//City", b"/example//City", False),


### PR DESCRIPTION
Kešavimas pakeistas į saugesnį. 

Tačiau verta atkreipti dėmesį:

  Vienas realus kompromisas — Vary antraštė:

  Vary: Accept, Accept-Language, Authorization reiškia, kad bendras podėlis laikys atskirą kopiją kiekvienai šių antraščių kombinacijai. Praktinės pasekmės:

  - Anoniminiams vartotojams (be Authorization) — viena bendra kopija, viskas gerai.
  - Autentifikuotiems vartotojams kiekvienas tokenas gaus atskirą podėlio įrašą. Tai sumažina podėlio efektyvumą autentifikuotam srautui, bet tai ir yra saugumo esmė — anksčiau vieno vartotojo atsakymas su public galėjo
  būti atiduotas kitam.
  - Kai kurie podėliai/CDN atsakymų su Vary: Authorization apskritai nekeštuoja. Blogiausiu atveju duomenų atsakymai autentifikuotiems klientams eis tiesiai į serverį — korektiška, bet daugiau apkrovos.

  Kadangi max-age tėra 60 sekundžių, o must-revalidate su ETag ir taip verčia podėlį dažnai revaliduoti (304 atsakymai pigūs), praktinis poveikis turėtų būti nedidelis. Jei produkcinėje aplinkoje pastebėtumėt, kad podėlio
  hit-rate kritęs per daug, tuomet alternatyva būtų Authorization išimti iš Vary ir vietoj to proxy lygyje autentifikuotas užklausas žymėti nekeštuojamomis — bet tai jau infrastruktūros konfigūracijos klausimas, ne kodo.
