### PR TITLE
1976 citus_distribution script update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changes
 0.2dev27 (unreleased)
 =====================
 
+Improvements:
+
+- Added `--destructive` flag support to `citus_distribution` script (it will commit after each distribution change) (`#1976`_).
+
+.. _#1976: https://github.com/atviriduomenys/spinta/issues/1976
+
 
 0.2dev26 (2026-06-10)
 =====================

--- a/spinta/backends/postgresql/helpers/migrate/actions.py
+++ b/spinta/backends/postgresql/helpers/migrate/actions.py
@@ -586,6 +586,7 @@ class DistributeSchema(MigrationAction):
 
 class DistributeReference(MigrationAction):
     def __init__(self, table_identifier: TableIdentifier) -> None:
+        self.table_identifier = table_identifier
         self.query = f"SELECT create_reference_table('{table_identifier.pg_escaped_qualified_name}')"
 
     def execute(self, op: "Operations") -> None:
@@ -594,6 +595,8 @@ class DistributeReference(MigrationAction):
 
 class DistributeTable(MigrationAction):
     def __init__(self, table_identifier: TableIdentifier, column: str) -> None:
+        self.table_identifier = table_identifier
+        self.column = column
         self.query = f"SELECT create_distributed_table('{table_identifier.pg_escaped_qualified_name}', '{column}')"
 
     def execute(self, op: "Operations") -> None:
@@ -611,6 +614,7 @@ class UndistributeSchema(MigrationAction):
 
 class UndistributeTable(MigrationAction):
     def __init__(self, table_identifier: TableIdentifier) -> None:
+        self.table_identifier = table_identifier
         self.query = (
             f"SELECT undistribute_table('{table_identifier.pg_escaped_qualified_name}', cascade_via_foreign_keys=>true)"
         )

--- a/spinta/cli/helpers/admin/scripts/citus_shard.py
+++ b/spinta/cli/helpers/admin/scripts/citus_shard.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from multipledispatch import dispatch
 from tqdm import tqdm
 
@@ -5,7 +7,13 @@ from spinta import commands
 from spinta.backends import Backend
 from spinta.backends.postgresql.components import PostgreSQL
 from spinta.backends.postgresql.helpers.migrate.actions import (
+    DistributeReference,
+    DistributeSchema,
+    DistributeTable,
+    MigrationAction,
     MigrationHandler,
+    UndistributeSchema,
+    UndistributeTable,
 )
 from spinta.backends.postgresql.helpers.migrate.citus import (
     ShardingPlan,
@@ -77,6 +85,36 @@ def generate_citus_migrations(
         distribute_all(context, backend, diff_plan, handler, progress_bar)
 
 
+@dispatch(MigrationAction)
+def generate_progress_bar_message(action: MigrationAction) -> str:
+    return ""
+
+
+@dispatch(UndistributeSchema)
+def generate_progress_bar_message(action: UndistributeSchema) -> str:
+    return "Undistributing schema " + action.schema_name
+
+
+@dispatch(UndistributeTable)
+def generate_progress_bar_message(action: UndistributeTable) -> str:
+    return "Undistributing table " + action.table_identifier.pg_qualified_name
+
+
+@dispatch(DistributeSchema)
+def generate_progress_bar_message(action: DistributeSchema) -> str:
+    return "Distributing schema " + action.schema_name
+
+
+@dispatch(DistributeReference)
+def generate_progress_bar_message(action: DistributeReference) -> str:
+    return "Distributing reference " + action.table_identifier.pg_qualified_name
+
+
+@dispatch(DistributeTable)
+def generate_progress_bar_message(action: DistributeTable) -> str:
+    return "Distributing table " + action.table_identifier.pg_qualified_name + " on column " + action.column
+
+
 def migrate_citus_distributions(context: Context, destructive: bool, **kwargs) -> None:
     from alembic.operations import Operations
     from alembic.runtime.migration import MigrationContext
@@ -96,10 +134,13 @@ def migrate_citus_distributions(context: Context, destructive: bool, **kwargs) -
         handler = MigrationHandler()
         generate_citus_migrations(context, backend, sharded_plan[backend_name], validated_plan, handler)
         with tqdm(desc=f"Updating distributions for '{backend_name}' backend", total=handler.count()) as progress_bar:
-            with backend.begin() as conn:
+            with migration_connection(backend, destructive) as conn:
                 ctx = MigrationContext.configure(conn)
                 operations = Operations(ctx)
                 for migration in handler.gather_migrations():
+                    progress_bar.set_description(
+                        f"Updating distributions for '{backend_name}' backend. {generate_progress_bar_message(migration)}"
+                    )
                     migration.execute(operations)
                     progress_bar.update(1)
     cli_message("Reapplying removed comments")
@@ -124,3 +165,14 @@ def cli_requires_citus_distribution(context: Context, **kwargs) -> bool:
         if req_plan.distributed or req_plan.references or req_plan.schemas:
             return True
     return False
+
+
+@contextmanager
+def migration_connection(backend, destructive: bool):
+    if destructive:
+        cli_message("Running distributions with auto commit")
+        with backend.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            yield conn
+    else:
+        with backend.begin() as conn:
+            yield conn

--- a/spinta/cli/helpers/admin/scripts/citus_shard.py
+++ b/spinta/cli/helpers/admin/scripts/citus_shard.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
+from typing import Generator
 
+import sqlalchemy as sa
 from multipledispatch import dispatch
 from tqdm import tqdm
 
@@ -168,7 +170,7 @@ def cli_requires_citus_distribution(context: Context, **kwargs) -> bool:
 
 
 @contextmanager
-def migration_connection(backend, destructive: bool):
+def migration_connection(backend: PostgreSQL, destructive: bool) -> Generator[sa.engine.Connection, None, None]:
     if destructive:
         cli_message("Running distributions with auto commit")
         with backend.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:


### PR DESCRIPTION
Added `--destructive` support that will AUTOCOMMIT on all actions..
Improved progress bar report to include which action it is executing.

Cannot add any real tests, since testing AUTOCOMMIT would be testing `sqlalchemy` library functionality (aswell as we would need to simulate interruption in the middle of migrations) and `--destructive` tag has been tested in other tests. Although I ran local tests myself to see if it these changes work.