### PR TITLE
1271 namespace collection done in proper place

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ Changes
 0.2dev28 (unreleased)
 =====================
 
+Bug Fixes:
+
+- Fixed an order dependent ``'ns' with name ... already defined`` error that
+  could occur when a namespace was both explicitly declared and generated from a
+  model or dataset path. Namespaces are now collected during the linking phase
+  instead of while loading, and a namespace declared more than once is reported
+  during the check phase (`#1256`_, `#1271`_).
+
+.. _#1256: https://github.com/atviriduomenys/spinta/issues/1256
+.. _#1271: https://github.com/atviriduomenys/spinta/issues/1271
+
 
 0.2dev27 (2026-06-21)
 =====================

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -431,6 +431,9 @@ class Namespace(MetaData):
     description: str
     # Namespaces generated from model name.
     generated: bool = False
+    # Set when the same namespace is explicitly declared more than once. The
+    # duplicate declaration is reported during the check phase, see #1271.
+    redeclared: bool = False
     given: NamespaceGiven
     lang: LangData = None
     enums: Enums = None
@@ -652,7 +655,8 @@ class Model(MetaData):
     access: Access
     title: str
     description: str
-    ns: Namespace
+    # Set while linking, see spinta.types.namespace.build_namespaces.
+    ns: Namespace = None
     external: Entity = None
     scopes: Dict[str, Scope]
     properties: Dict[str, Property]

--- a/spinta/core/access.py
+++ b/spinta/core/access.py
@@ -40,14 +40,38 @@ def load_access_param(
         else given_access
     )
 
+    component.access = access
+    component.given.access = given_access
+
+    propagate_access_param(component, parents)
+
+
+def propagate_access_param(
+    component: Union[
+        Dataset,
+        Resource,
+        Namespace,
+        Model,
+        Property,
+        EnumItem,
+        Scope,
+    ],
+    parents: Iterable[
+        Union[
+            Manifest,
+            Dataset,
+            Namespace,
+            Model,
+            Property,
+        ]
+    ] = (),
+) -> None:
     # If child has higher access than parent, increase parent access.
+    access = component.access
     if access is not None:
         for parent in parents:
             if parent.access is None or access > parent.access:
                 parent.access = access
-
-    component.access = access
-    component.given.access = given_access
 
 
 def link_access_param(

--- a/spinta/datasets/commands/link.py
+++ b/spinta/datasets/commands/link.py
@@ -2,14 +2,28 @@ from spinta import commands
 from spinta.components import Context
 from spinta.core.access import link_access_param
 from spinta.datasets.components import Attribute, Dataset, Entity, Resource
+from spinta.dimensions.enum.helpers import load_enums
 from spinta.dimensions.param.helpers import link_params
 from spinta.exceptions import MissingReference
+from spinta.types.namespace import ensure_dataset_namespace
 from spinta.ufuncs.linkbuilder.components import LinkBuilder
 
 
 @commands.link.register(Context, Dataset)
 def link(context: Context, dataset: Dataset):
     config = context.get("config")
+
+    # Make sure the dataset is wired to its namespace (build_namespaces already
+    # did this for the full load path; the lazy internal_sql path relies on this
+    # call). Then resolve namespace metadata and enums that used to be handled
+    # during loading.
+    ns = ensure_dataset_namespace(context, dataset.manifest, dataset)
+    if ns.generated:
+        ns.title = dataset.title
+        ns.description = dataset.description
+    if dataset.given.enums is not None:
+        ns.enums = load_enums(context, list(ns.parents()), dataset.given.enums)
+
     link_access_param(dataset, (dataset.manifest,), default_access=config.default_access_level)
     for resource in dataset.resources.values():
         commands.link(context, resource)

--- a/spinta/datasets/commands/load.py
+++ b/spinta/datasets/commands/load.py
@@ -8,14 +8,12 @@ from spinta.core.ufuncs import asttoexpr
 from spinta.datasets.components import Attribute, Dataset, Entity, Resource
 from spinta.datasets.helpers import load_resource_backend
 from spinta.dimensions.comments.helpers import load_comments
-from spinta.dimensions.enum.helpers import load_enums
 from spinta.dimensions.lang.helpers import load_lang_data
 from spinta.dimensions.param.helpers import load_params
 from spinta.dimensions.prefix.helpers import load_prefixes
 from spinta.exceptions import MultipleErrors, PropertyNotFound, RequiredConfigParam
 from spinta.manifests.components import Manifest
 from spinta.nodes import get_node, load_node
-from spinta.types.namespace import load_namespace_from_name
 from spinta.utils.data import take
 from spinta.utils.schema import NA
 
@@ -32,21 +30,16 @@ def load(
 ):
     config = context.get("config")
 
-    ns = load_namespace_from_name(context, manifest, data["name"], drop=False)
-    if ns.generated:
-        ns.title = data.get("title", "")
-        ns.description = data.get("description", "")
     if "prefixes" in data:
         prefixes = load_prefixes(context, manifest, dataset, data.pop("prefixes"))
         dataset.prefixes.update(prefixes)
-    if "enums" in data:
-        parents = list(ns.parents())
-        ns.enums = load_enums(context, parents, data.pop("enums"))
+    # The namespace (and the enums attached to it) is resolved while linking, see
+    # build_namespaces and the dataset link command. Keep the raw enum data until
+    # then.
+    dataset.given.enums = data.pop("enums", None)
 
     load_node(context, dataset, data, parent=manifest)
     load_access_param(dataset, data.get("access"), (manifest,))
-
-    dataset.ns = ns
 
     dataset.lang = load_lang_data(context, dataset.lang)
     dataset.given.name = data.get("given_name", None)

--- a/spinta/datasets/components.py
+++ b/spinta/datasets/components.py
@@ -19,6 +19,8 @@ from spinta.utils.schema import NA
 class DatasetGiven:
     access: str = None
     name: str = None
+    # Raw enum data kept from load, resolved onto the namespace while linking.
+    enums: Any = None
 
 
 class Dataset(MetaData):

--- a/spinta/manifests/commands/link.py
+++ b/spinta/manifests/commands/link.py
@@ -3,10 +3,15 @@ from spinta.components import Context, MetaData
 from spinta.dimensions.param.helpers import finalize_param_link
 from spinta.dimensions.scope.helpers import finalize_scope_link
 from spinta.manifests.components import Manifest, get_manifest_object_names
+from spinta.types.namespace import build_namespaces
 
 
 @commands.link.register(Context, Manifest)
 def link(context: Context, manifest: Manifest):
+    # Collect namespaces from datasets and models before linking, so the linking
+    # can rely on the whole namespace tree being present (see #1271).
+    build_namespaces(context, manifest)
+
     for node in get_manifest_object_names():
         for obj in commands.get_nodes(context, manifest, node).values():
             commands.link(context, obj)

--- a/spinta/manifests/helpers.py
+++ b/spinta/manifests/helpers.py
@@ -16,7 +16,7 @@ from spinta.exceptions import ManifestFileDoesNotExist, UnknownKeyMap, UnknownMa
 from spinta.manifests.components import Manifest, ManifestSchema
 from spinta.manifests.internal.components import InternalManifest
 from spinta.nodes import get_node
-from spinta.types.namespace import load_namespace_from_name
+from spinta.types.namespace import load_namespace_from_name, merge_declared_namespace
 from spinta.utils.enums import enum_by_name
 from spinta.utils.imports import importstr
 
@@ -178,6 +178,14 @@ def _load_manifest_node(
     eid: EntryId,
     data: dict,
 ) -> MetaData:
+    if data.get("type") == "ns" and commands.has_node(context, manifest, "ns", data["name"], loaded=True):
+        # The namespace already exists (generated from a model/dataset path or
+        # declared earlier). Merge the declared metadata onto the existing node
+        # instead of creating a duplicate; the duplicate declaration check is
+        # deferred to the check phase (#1271).
+        ns = commands.get_node(context, manifest, "ns", data["name"])
+        return merge_declared_namespace(ns, eid, data)
+
     node = get_node(context, config, manifest, eid, data)
     node.eid = eid
     node.type = data["type"]

--- a/spinta/nodes.py
+++ b/spinta/nodes.py
@@ -64,23 +64,11 @@ def get_node(
             if commands.has_node(context, manifest, ctype, data["name"], loaded=True):
                 name = data["name"]
                 other_node = commands.get_node(context, manifest, ctype, name)
-
-                # if this namespace generated, and other - declared: pass,
-                #   because dataset path can have ns as part of their path
-                # if this namespace generated, and other generated - pass. Two datasets, each in the same namespace
-                # if this namespace declared, other - generated, pass. It's possible to first declare
-                #   a dataset, then a namespace which is included in dataset's path
-                # if this namespace declared and other - declared, raise error. Namespace can be declared only once.
-                # todo collecting namespaces should be moved to linking and this checking should be done there
-                #   https://github.com/atviriduomenys/spinta/issues/1271
-                if ctype != "ns" or not other_node.generated:
-                    raise exceptions.InvalidManifestFile(
-                        manifest=manifest.name,
-                        eid=eid,
-                        error=(
-                            f"{ctype!r} with name {name!r} already defined in {other_node} (eid: {other_node.eid})."
-                        ),
-                    )
+                raise exceptions.InvalidManifestFile(
+                    manifest=manifest.name,
+                    eid=eid,
+                    error=(f"{ctype!r} with name {name!r} already defined in {other_node} (eid: {other_node.eid})."),
+                )
 
     if ctype not in config.components[group]:
         from spinta.components import Property

--- a/spinta/types/model.py
+++ b/spinta/types/model.py
@@ -11,7 +11,7 @@ from spinta.backends.constants import BackendFeatures, DistributionType
 from spinta.backends.nobackend.components import NoBackend
 from spinta.commands import authorize, check, configure, load
 from spinta.components import Base, Context, Model, Page, PageBy, PageInfo, Property, UrlParams, pagination_enabled
-from spinta.core.access import link_access_param, load_access_param
+from spinta.core.access import link_access_param, load_access_param, propagate_access_param
 from spinta.core.config import RawConfig
 from spinta.core.enums import Action, Level, Mode, load_level, load_status, load_visibility
 from spinta.datasets.components import ExternalBackend
@@ -46,7 +46,7 @@ from spinta.types.helpers import (
     check_scope_name,
     replace_undeclared_base_with_comment,
 )
-from spinta.types.namespace import load_namespace_from_name
+from spinta.types.namespace import ensure_model_namespace
 from spinta.ufuncs.loadbuilder.components import LoadBuilder
 from spinta.ufuncs.loadbuilder.helpers import get_allowed_page_property_types, page_contains_unsupported_keys
 from spinta.units.helpers import is_unit
@@ -58,12 +58,6 @@ if TYPE_CHECKING:
     from spinta.datasets.components import Attribute
 
 INCORRECT_DTYPE_COUPLES = [(Integer, UUID), (Integer, String), (UUID, String), (UUID, Integer)]
-
-
-def _load_namespace_from_model(context: Context, manifest: Manifest, model: Model):
-    ns = load_namespace_from_name(context, manifest, model.name)
-    ns.models[model.model_type()] = model
-    model.ns = ns
 
 
 def _parse_distribution_strategy(
@@ -144,15 +138,10 @@ def load(
     else:
         model.keymap = manifest.keymap
 
-    _load_namespace_from_model(context, manifest, model)
-    load_access_param(
-        model,
-        data.get("access"),
-        itertools.chain(
-            [model.ns],
-            model.ns.parents(),
-        ),
-    )
+    # The namespace is generated and wired to the model while linking
+    # (see build_namespaces), so only the model's own access is parsed here; the
+    # propagation up the namespace tree happens in the model link command.
+    load_access_param(model, data.get("access"))
     load_level(context, model, model.level)
     load_status(model, model.status)
     load_visibility(model, model.visibility)
@@ -239,8 +228,21 @@ def load(context: Context, base: Base, data: dict, manifest: Manifest) -> None:
 @overload
 @commands.link.register(Context, Model)
 def link(context: Context, model: Model):
-    # Link external source.
     config = context.get("config")
+
+    # Make sure the model is wired to its namespace (build_namespaces already
+    # did this for the full load path; the lazy internal_sql path relies on this
+    # call). Then propagate the model access up the namespace tree.
+    ensure_model_namespace(context, model.manifest, model)
+    propagate_access_param(
+        model,
+        itertools.chain(
+            [model.ns],
+            model.ns.parents(),
+        ),
+    )
+
+    # Link external source.
     if model.external:
         commands.link(context, model.external)
 
@@ -400,13 +402,9 @@ def load(
     # load_node overwrites everything, so we either set data through configure, or we call configure after and set it directly
     commands.configure(context, prop)
 
-    parents = list(
-        itertools.chain(
-            [prop.model, prop.model.ns],
-            prop.model.ns.parents(),
-        )
-    )
-    load_access_param(prop, prop.access, parents)
+    # Only the property's own access is parsed here; propagation up the
+    # namespace tree happens while linking (build_namespaces runs first).
+    load_access_param(prop, prop.access)
     prop.lang = load_lang_data(context, prop.lang)
     prop.comments = load_comments(prop, prop.comments)
     if prop.prepare_given:
@@ -466,7 +464,9 @@ def load(
         prop.given.enum = unit
     prop.given.explicit = prop.explicitly_given if prop.explicitly_given is not None else True
     prop.given.name = prop.given_name
-    prop.enums = load_enums(context, [prop] + parents, prop.enums)
+    # Enum item access propagates onto the property here; the property then
+    # propagates further up the namespace tree while linking (see #1271).
+    prop.enums = load_enums(context, [prop], prop.enums)
     return prop
 
 
@@ -505,6 +505,16 @@ def link(context: Context, prop: Property):
             commands.link(context, prop.external)
 
     model = prop.model
+
+    # Propagate the property's own access up the namespace tree (this used to
+    # happen during loading, see #1271).
+    propagate_access_param(
+        prop,
+        itertools.chain(
+            [model, model.ns],
+            model.ns.parents(),
+        ),
+    )
 
     if prop.model.external and prop.model.external.dataset:
         parents = list(

--- a/spinta/types/namespace.py
+++ b/spinta/types/namespace.py
@@ -12,7 +12,7 @@ from spinta.backends.constants import BackendFeatures
 from spinta.backends.nobackend.components import NoBackend
 from spinta.components import Config, Context, Model, Namespace, Node, UrlParams
 from spinta.core.enums import Action
-from spinta.exceptions import InvalidName
+from spinta.exceptions import InvalidManifestFile, InvalidName
 from spinta.manifests.components import Manifest
 from spinta.nodes import load_node
 from spinta.types.datatype import Array, Ref
@@ -62,6 +62,66 @@ def load_namespace_from_name(
     return ns
 
 
+def merge_declared_namespace(ns: Namespace, eid: Any, data: Dict[str, Any]) -> Namespace:
+    """Apply an explicit ``ns`` declaration onto an already existing namespace.
+
+    A namespace may already exist because it was generated from a model/dataset
+    path or because it was declared earlier. Instead of creating a duplicate (or
+    erroring out in the generic ``get_node`` check, which was order dependent),
+    the declared metadata is merged onto the existing node, preserving its
+    collected children (``names``/``models``). If the namespace was already
+    explicitly declared, it is flagged as ``redeclared`` so the duplicate is
+    reported during the check phase (#1271).
+    """
+    if not ns.generated:
+        ns.redeclared = True
+    ns.generated = False
+    ns.eid = eid
+    ns.type = data["type"]
+    ns.title = data.get("title") or ""
+    ns.description = data.get("description") or ""
+    return ns
+
+
+def ensure_model_namespace(context: Context, manifest: Manifest, model: Model) -> Namespace:
+    """Attach a model to its namespace, generating the namespace if needed.
+
+    Idempotent: safe to call more than once (e.g. from ``build_namespaces`` and
+    again from the model ``link`` command used by the lazy internal_sql path).
+    """
+    if model.ns is not None:
+        return model.ns
+    ns = load_namespace_from_name(context, manifest, model.name)
+    ns.models[model.model_type()] = model
+    model.ns = ns
+    return ns
+
+
+def ensure_dataset_namespace(context: Context, manifest: Manifest, dataset) -> Namespace:
+    """Attach a dataset to its namespace, generating the namespace if needed.
+
+    Idempotent, see :func:`ensure_model_namespace`.
+    """
+    if dataset.ns is not None:
+        return dataset.ns
+    dataset.ns = load_namespace_from_name(context, manifest, dataset.name, drop=False)
+    return dataset.ns
+
+
+def build_namespaces(context: Context, manifest: Manifest) -> None:
+    """Generate the namespace tree from datasets and models.
+
+    Namespaces used to be generated during loading (interleaved with node
+    loading), which made duplicate handling order dependent. They are now
+    collected here, once all nodes are loaded, before nodes are linked
+    (see #1271).
+    """
+    for dataset in commands.get_datasets(context, manifest).values():
+        ensure_dataset_namespace(context, manifest, dataset)
+    for model in commands.get_models(context, manifest).values():
+        ensure_model_namespace(context, manifest, model)
+
+
 @commands.load.register(Context, Namespace, dict, Manifest)
 def load(
     context: Context,
@@ -101,6 +161,14 @@ def link(context: Context, ns: Namespace):
 @commands.check.register(Context, Namespace)
 def check(context: Context, ns: Namespace):
     config: Config = context.get("config")
+
+    if ns.redeclared:
+        raise InvalidManifestFile(
+            ns,
+            manifest=ns.manifest.name,
+            eid=ns.eid,
+            error=f"'ns' with name {ns.name!r} is already defined.",
+        )
 
     if config.check_names:
         name = ns.name

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -326,6 +326,32 @@ def test_check_existing_generated_manifest(context: Context, rc, cli: SpintaCliR
     )
 
 
+def test_check_declared_before_generated_manifest(context: Context, rc, cli: SpintaCliRunner, tmp_path):
+    # A namespace declared before the dataset/model that also generates it must
+    # not fail — the check is order independent (#1256).
+    create_tabular_manifest(
+        context,
+        tmp_path / "manifest.csv",
+        striptable("""
+ d | r | b | m | property       | type   | ref  | level
+ datasets/gov/test | | | |      | ns     |      |
+ datasets/gov/test/example1     |        |      |
+                                |        |      |
+   |   |   | City               |        | code | 4
+   |   |   |   | name           | string |      | 4
+   |   |   |   | code           | string |      | 4
+"""),
+    )
+
+    cli.invoke(
+        rc,
+        [
+            "check",
+            tmp_path / "manifest.csv",
+        ],
+    )
+
+
 def test_check_existing_declared_manifest(context: Context, rc, cli: SpintaCliRunner, tmp_path):
     create_tabular_manifest(
         context,

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -255,3 +255,42 @@ def test_sort_models_by_ref_with_base(
         "datasets/basetest/Country",
         "datasets/basetest/Place",
     ]
+
+
+# Namespace can be both generated from a model/dataset path and explicitly
+# declared. Regardless of the order in which they appear, the declaration must
+# merge onto the existing namespace (keeping the models collected under it)
+# instead of raising a duplicate error. See issues #1256 and #1271.
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        # Model first, namespace declared afterwards.
+        """
+     d | r | b | m | property | type   | ref | access
+     datasets/gov/example      |        |     |
+       |   |   | City          |        |     |
+       |   |   |   | name      | string |     | open
+     datasets/gov/example      |  |  |  |  | ns |  |
+     """,
+        # Namespace declared before the model that lives in it.
+        """
+     d | r | b | m | property | type   | ref | access
+     datasets/gov/example      |  |  |  |  | ns |  |
+     datasets/gov/example      |        |     |
+       |   |   | City          |        |     |
+       |   |   |   | name      | string |     | open
+     """,
+    ],
+)
+def test_declared_namespace_merges_and_preserves_models(rc: RawConfig, manifest: str):
+    context, store_manifest = load_manifest_and_context(rc, manifest)
+
+    ns = commands.get_namespace(context, store_manifest, "datasets/gov/example")
+    # The explicit declaration turned the namespace into a declared one.
+    assert ns.generated is False
+    assert ns.redeclared is False
+
+    model = commands.get_model(context, store_manifest, "datasets/gov/example/City")
+    # The model stays wired to the (merged) namespace and is not lost.
+    assert model.ns is ns
+    assert model in ns.models.values()


### PR DESCRIPTION
Fixed an order dependent 'ns' with name ... already defined error that could occur when a namespace was both explicitly declared and generated from a model or dataset path. Namespaces are now collected during the     
  ▎ linking phase instead of while loading, and a namespace declared more than once is reported during the check phase (#1256, #1271).