### PR TITLE
1989 add copy distribution script

### DIFF
--- a/spinta/backends/components.py
+++ b/spinta/backends/components.py
@@ -65,3 +65,4 @@ SelectTree = Optional[Dict[str, "SelectTree"]]
 class DistributionStrategy:
     distribution_type: DistributionType
     property: str | None = None
+    default: bool = False

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -148,6 +148,11 @@ def create_sharding_plan(context: Context, models: list[Model], **kwargs) -> dic
         if not isinstance(model.backend, PostgreSQL):
             continue
 
+        if (not model.external or not model.external.dataset) and (
+            model.distribution_strategy is None or model.distribution_strategy.default
+        ):
+            continue
+
         distribution_strategy = model.distribution_strategy
         plan = plans[model.backend.name]
         table_identifier = get_table_identifier(model)

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -223,10 +223,10 @@ def invalidate_default_schema_distributions(
     plan_copy = deepcopy(plan)
 
     for reference in plan.references:
-        invalid_schemas.add(reference.schema)
+        invalid_schemas.add(reference.pg_schema_name)
 
     for table in plan.distributed.keys():
-        invalid_schemas.add(table.schema)
+        invalid_schemas.add(table.pg_schema_name)
 
     all_schemas = set(inspector.get_schema_names())
 

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -148,9 +148,6 @@ def create_sharding_plan(context: Context, models: list[Model], **kwargs) -> dic
         if not isinstance(model.backend, PostgreSQL):
             continue
 
-        if not model.external or not model.external.dataset:
-            continue
-
         distribution_strategy = model.distribution_strategy
         plan = plans[model.backend.name]
         table_identifier = get_table_identifier(model)
@@ -214,12 +211,21 @@ def invalidate_default_schema_distributions(
     if not plan.schemas:
         return plan
 
-    invalid_schemas = set()
+    invalid_schemas = {None}
 
     inspector = sa.inspect(backend.engine)
 
     plan_copy = deepcopy(plan)
-    for schema in plan.schemas:
+
+    for reference in plan.references:
+        invalid_schemas.add(reference.schema)
+
+    for table in plan.distributed.keys():
+        invalid_schemas.add(table.schema)
+
+    all_schemas = set(inspector.get_schema_names())
+
+    for schema in all_schemas - invalid_schemas:
         tables = inspector.get_table_names(schema=schema)
 
         for table in tables:

--- a/spinta/cli/helpers/admin/components.py
+++ b/spinta/cli/helpers/admin/components.py
@@ -17,5 +17,6 @@ class Script(enum.Enum):
     CHANGELOG = "changelog"
     ENUM_LIST = "enum_list"
     CITUS_DISTRIBUTION = "citus_distribution"
+    CITUS_REFERENCE_CONFIG = "citus_reference_config"
     ADD_LOCAL_IDS = "add_local_ids"
     REMOVE_LOCAL_IDS = "remove_local_ids"

--- a/spinta/cli/helpers/admin/registry.py
+++ b/spinta/cli/helpers/admin/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from spinta.cli.helpers.admin.components import ADMIN_SCRIPT_TYPE, AdminScript, Script
 from spinta.cli.helpers.admin.scripts.add_local_ids import add_local_ids
 from spinta.cli.helpers.admin.scripts.changelog import cli_requires_changelog_migrations, migrate_changelog_duplicates
+from spinta.cli.helpers.admin.scripts.citus_reference_config import generate_citus_reference_shard_config
 from spinta.cli.helpers.admin.scripts.citus_shard import cli_requires_citus_distribution, migrate_citus_distributions
 from spinta.cli.helpers.admin.scripts.deduplicate import cli_requires_deduplicate_migrations, migrate_duplicates
 from spinta.cli.helpers.admin.scripts.enums import gather_invalid_enum_values
@@ -42,6 +43,14 @@ script_registry.register(
         name=Script.CITUS_DISTRIBUTION.value,
         run=migrate_citus_distributions,
         check=cli_requires_citus_distribution,
+        required=[(UPGRADE_SCRIPT_TYPE, UpgradeScript.POSTGRESQL_SCHEMAS.value)],
+        targets={ScriptTarget.BACKEND.value},
+    )
+)
+script_registry.register(
+    AdminScript(
+        name=Script.CITUS_REFERENCE_CONFIG.value,
+        run=generate_citus_reference_shard_config,
         required=[(UPGRADE_SCRIPT_TYPE, UpgradeScript.POSTGRESQL_SCHEMAS.value)],
         targets={ScriptTarget.BACKEND.value},
     )

--- a/spinta/cli/helpers/admin/scripts/citus_reference_config.py
+++ b/spinta/cli/helpers/admin/scripts/citus_reference_config.py
@@ -169,7 +169,6 @@ def plan_reference_tables(
                 if dependency not in candidates:
                     blocked.add(table_key)
                     break
-        print("BLOCKED", blocked)
         if blocked:
             available -= blocked
             continue
@@ -208,11 +207,14 @@ def _is_eligible_reference_table(context: Context, store, table: ReferenceTable)
     model_name = table.comment or table.qualified_name
     try:
         model = commands.get_model(context, store.manifest, model_name)
+
     except ModelNotFound:
-        cli_error(f"Could not find {model_name} model.")
+        cli_message(f"Could not find {model_name} model.")
         return False
 
-    return model.distribution_strategy is None or model.distribution_strategy.default
+    return (model.external and model.external.dataset) and (
+        model.distribution_strategy is None or model.distribution_strategy.default
+    )
 
 
 def generate_citus_reference_shard_config(

--- a/spinta/cli/helpers/admin/scripts/citus_reference_config.py
+++ b/spinta/cli/helpers/admin/scripts/citus_reference_config.py
@@ -223,6 +223,8 @@ def generate_citus_reference_shard_config(
     config = context.get("config")
     max_size = config.citus_reference_script_size
 
+    config_output = {"models": {}}
+    config_models = config_output["models"]
     for backend_name, backend in store.backends.items():
         if not isinstance(backend, PostgreSQL):
             cli_message(f"Skipping '{backend_name}' backend, it's not PostgreSQL backend")
@@ -249,12 +251,11 @@ def generate_citus_reference_shard_config(
             )
             for table_key, table in tables.items()
         }
-        config_output = {"models": {}}
-        config_models = config_output["models"]
+
         for table in plan_reference_tables(eligible_tables, foreign_keys):
             model_name = table.comment or table.qualified_name
             config_models[model_name] = {"distribute": "copy"}
 
-        output_stream = nullcontext(sys.stdout) if output_path is None else output_path.open("w")
-        with output_stream as out:
-            yaml.dump(config_output, out)
+    output_stream = nullcontext(sys.stdout) if output_path is None else output_path.open("w")
+    with output_stream as out:
+        yaml.dump(config_output, out)

--- a/spinta/cli/helpers/admin/scripts/citus_reference_config.py
+++ b/spinta/cli/helpers/admin/scripts/citus_reference_config.py
@@ -45,7 +45,7 @@ FOREIGN_KEY_METADATA_QUERY = text("""
         obj_description(rel.oid, 'pg_class') AS table_comment,
         pg_total_relation_size(rel.oid) AS table_bytes,
         COALESCE(ct.citus_table_type, 'local') AS citus_table_type,
-        ct.table_name IS NULL AS is_unmanaged_local
+        ct.table_name IS NULL OR citus_table_type = 'local' AS is_unmanaged_local
       FROM pg_class rel
       JOIN pg_namespace ns ON ns.oid = rel.relnamespace
       LEFT JOIN citus_tables ct ON ct.table_name = rel.oid::regclass
@@ -77,8 +77,6 @@ FOREIGN_KEY_METADATA_QUERY = text("""
       ON (tgt.schema_name, tgt.table_name) = (fk.target_schema, fk.target_table)
     ORDER BY fk.source_schema, fk.source_table, fk.target_schema, fk.target_table;
 """)
-
-MAX_REFERENCE_TABLE_SIZE = 10 * 1024**3  # 10 GiB
 
 yaml = YAML(typ="safe")
 yaml.default_flow_style = False
@@ -200,8 +198,8 @@ def _table_from_row(row: dict, prefix: str) -> ReferenceTable:
     )
 
 
-def _is_eligible_reference_table(context: Context, store, table: ReferenceTable) -> bool:
-    if not table.is_unmanaged_local or table.table_bytes >= MAX_REFERENCE_TABLE_SIZE:
+def _is_eligible_reference_table(context: Context, store, table: ReferenceTable, max_size: int) -> bool:
+    if not table.is_unmanaged_local or table.table_bytes >= max_size:
         return False
 
     model_name = table.comment or table.qualified_name
@@ -228,6 +226,9 @@ def generate_citus_reference_shard_config(
     if output_path and output_path.exists() and not destructive:
         cli_error(f"Output file '{output_path}' already exists. Use --destructive to overwrite.")
 
+    config = context.get("config")
+    max_size = config.citus_reference_script_size
+
     for backend_name, backend in store.backends.items():
         if not isinstance(backend, PostgreSQL):
             cli_message(f"Skipping '{backend_name}' backend, it's not PostgreSQL backend")
@@ -250,7 +251,7 @@ def generate_citus_reference_shard_config(
         eligible_tables = {
             table_key: replace(
                 table,
-                eligible=table_key in candidate_keys and _is_eligible_reference_table(context, store, table),
+                eligible=table_key in candidate_keys and _is_eligible_reference_table(context, store, table, max_size),
             )
             for table_key, table in tables.items()
         }

--- a/spinta/cli/helpers/admin/scripts/citus_reference_config.py
+++ b/spinta/cli/helpers/admin/scripts/citus_reference_config.py
@@ -1,0 +1,263 @@
+import pathlib
+import sys
+from collections import defaultdict
+from contextlib import nullcontext
+from dataclasses import dataclass, replace
+
+from ruamel.yaml import YAML
+from sqlalchemy import text
+
+from spinta import commands
+from spinta.backends.postgresql.components import PostgreSQL
+from spinta.cli.helpers.message import cli_error, cli_message
+from spinta.cli.helpers.script.helpers import ensure_store_is_loaded
+from spinta.components import Context
+from spinta.exceptions import ModelNotFound
+
+FOREIGN_KEY_METADATA_QUERY = text("""
+    WITH foreign_keys AS (
+      SELECT DISTINCT
+        src_ns.nspname AS source_schema,
+        src.relname AS source_table,
+        tgt_ns.nspname AS target_schema,
+        tgt.relname AS target_table,
+        src_ns.nspname <> tgt_ns.nspname AS is_cross_schema
+      FROM pg_constraint con
+      JOIN pg_class src ON src.oid = con.conrelid
+      JOIN pg_namespace src_ns ON src_ns.oid = src.relnamespace
+      JOIN pg_class tgt ON tgt.oid = con.confrelid
+      JOIN pg_namespace tgt_ns ON tgt_ns.oid = tgt.relnamespace
+      WHERE con.contype = 'f'
+        AND src.relkind IN ('r', 'p')
+        AND tgt.relkind IN ('r', 'p')
+        AND src_ns.nspname NOT LIKE 'pg_%'
+        AND tgt_ns.nspname NOT LIKE 'pg_%'
+        AND src_ns.nspname <> 'information_schema'
+        AND tgt_ns.nspname <> 'information_schema'
+        AND src_ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
+        AND tgt_ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
+    ),
+    table_metadata AS (
+      SELECT
+        ns.nspname AS schema_name,
+        rel.relname AS table_name,
+        format('%s/%s', ns.nspname, rel.relname) AS qualified_name,
+        obj_description(rel.oid, 'pg_class') AS table_comment,
+        pg_total_relation_size(rel.oid) AS table_bytes,
+        COALESCE(ct.citus_table_type, 'local') AS citus_table_type,
+        ct.table_name IS NULL AS is_unmanaged_local
+      FROM pg_class rel
+      JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+      LEFT JOIN citus_tables ct ON ct.table_name = rel.oid::regclass
+      WHERE rel.relkind IN ('r', 'p')
+        AND ns.nspname NOT LIKE 'pg_%'
+        AND ns.nspname <> 'information_schema'
+        AND ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
+    )
+    SELECT
+      fk.source_schema,
+      fk.source_table,
+      fk.target_schema,
+      fk.target_table,
+      fk.is_cross_schema,
+      src.qualified_name AS source_qualified_name,
+      src.table_comment AS source_table_comment,
+      src.table_bytes AS source_table_bytes,
+      src.citus_table_type AS source_citus_table_type,
+      src.is_unmanaged_local AS source_is_unmanaged_local,
+      tgt.qualified_name AS target_qualified_name,
+      tgt.table_comment AS target_table_comment,
+      tgt.table_bytes AS target_table_bytes,
+      tgt.citus_table_type AS target_citus_table_type,
+      tgt.is_unmanaged_local AS target_is_unmanaged_local
+    FROM foreign_keys fk
+    JOIN table_metadata src
+      ON (src.schema_name, src.table_name) = (fk.source_schema, fk.source_table)
+    JOIN table_metadata tgt
+      ON (tgt.schema_name, tgt.table_name) = (fk.target_schema, fk.target_table)
+    ORDER BY fk.source_schema, fk.source_table, fk.target_schema, fk.target_table;
+""")
+
+MAX_REFERENCE_TABLE_SIZE = 10 * 1024**3  # 10 GiB
+
+yaml = YAML(typ="safe")
+yaml.default_flow_style = False
+
+TableKey = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class ReferenceTable:
+    schema: str
+    table: str
+    qualified_name: str
+    comment: str | None
+    table_bytes: int
+    citus_table_type: str
+    is_unmanaged_local: bool
+    eligible: bool = False
+
+    @property
+    def key(self) -> TableKey:
+        return self.schema, self.table
+
+    @property
+    def is_reference(self) -> bool:
+        return self.citus_table_type == "reference"
+
+
+@dataclass(frozen=True)
+class ForeignKey:
+    source: TableKey
+    target: TableKey
+    is_cross_schema: bool
+
+
+def _dependency_closure(
+    seeds: set[TableKey],
+    dependencies: dict[TableKey, set[TableKey]],
+    tables: dict[TableKey, ReferenceTable],
+    available: set[TableKey] | None = None,
+) -> set[TableKey]:
+    closure: set[TableKey] = set()
+    pending = list(seeds)
+
+    while pending:
+        table_key = pending.pop()
+        if table_key in closure:
+            continue
+        if available is not None and table_key not in available:
+            continue
+
+        table = tables[table_key]
+        if not table.is_unmanaged_local:
+            continue
+
+        closure.add(table_key)
+        for dependency in dependencies[table_key]:
+            dependent_table = tables.get(dependency)
+            if (
+                dependent_table is not None
+                and dependent_table.is_unmanaged_local
+                and (available is None or dependency in available)
+            ):
+                pending.append(dependency)
+
+    return closure
+
+
+def plan_reference_tables(
+    tables: dict[TableKey, ReferenceTable], foreign_keys: set[ForeignKey]
+) -> list[ReferenceTable]:
+    dependencies: dict[TableKey, set[TableKey]] = defaultdict(set)
+    seeds: set[TableKey] = set()
+    for foreign_key in foreign_keys:
+        dependencies[foreign_key.source].add(foreign_key.target)
+        target = tables[foreign_key.target]
+        if foreign_key.is_cross_schema and target.is_unmanaged_local:
+            seeds.add(foreign_key.target)
+
+    available = {table_key for table_key, table in tables.items() if table.eligible}
+    while True:
+        candidates = _dependency_closure(seeds & available, dependencies, tables, available)
+        blocked = set()
+        for table_key in candidates:
+            for dependency in dependencies[table_key]:
+                dependent_table = tables.get(dependency)
+                if dependent_table is not None and dependent_table.is_reference:
+                    continue
+                if dependency not in candidates:
+                    blocked.add(table_key)
+                    break
+        print("BLOCKED", blocked)
+        if blocked:
+            available -= blocked
+            continue
+
+        return [tables[table_key] for table_key in sorted(candidates)]
+
+
+def _reference_table_closure(tables: dict[TableKey, ReferenceTable], foreign_keys: set[ForeignKey]) -> set[TableKey]:
+    dependencies: dict[TableKey, set[TableKey]] = defaultdict(set)
+    seeds: set[TableKey] = set()
+    for foreign_key in foreign_keys:
+        dependencies[foreign_key.source].add(foreign_key.target)
+        target = tables[foreign_key.target]
+        if foreign_key.is_cross_schema and target.is_unmanaged_local:
+            seeds.add(foreign_key.target)
+
+    return _dependency_closure(seeds, dependencies, tables)
+
+
+def _table_from_row(row: dict, prefix: str) -> ReferenceTable:
+    return ReferenceTable(
+        schema=row[f"{prefix}_schema"],
+        table=row[f"{prefix}_table"],
+        qualified_name=row[f"{prefix}_qualified_name"],
+        comment=row[f"{prefix}_table_comment"],
+        table_bytes=row[f"{prefix}_table_bytes"],
+        citus_table_type=row[f"{prefix}_citus_table_type"],
+        is_unmanaged_local=row[f"{prefix}_is_unmanaged_local"],
+    )
+
+
+def _is_eligible_reference_table(context: Context, store, table: ReferenceTable) -> bool:
+    if not table.is_unmanaged_local or table.table_bytes >= MAX_REFERENCE_TABLE_SIZE:
+        return False
+
+    model_name = table.comment or table.qualified_name
+    try:
+        model = commands.get_model(context, store.manifest, model_name)
+    except ModelNotFound:
+        cli_error(f"Could not find {model_name} model.")
+        return False
+
+    return model.distribution_strategy is None or model.distribution_strategy.default
+
+
+def generate_citus_reference_shard_config(
+    context: Context, output_path: pathlib.Path | None, destructive: bool, **kwargs
+) -> None:
+    store = ensure_store_is_loaded(context)
+
+    if output_path and output_path.suffix not in {".yml", ".yaml"}:
+        cli_error(f"Output file '{output_path}' has unsupported format. Use '.yml' or '.yaml'.")
+
+    if output_path and output_path.exists() and not destructive:
+        cli_error(f"Output file '{output_path}' already exists. Use --destructive to overwrite.")
+
+    for backend_name, backend in store.backends.items():
+        if not isinstance(backend, PostgreSQL):
+            cli_message(f"Skipping '{backend_name}' backend, it's not PostgreSQL backend")
+            continue
+
+        with backend.begin() as connection:
+            rows = connection.execute(FOREIGN_KEY_METADATA_QUERY).mappings()
+            rows = list(rows)
+
+        tables: dict[TableKey, ReferenceTable] = {}
+        foreign_keys: set[ForeignKey] = set()
+        for row in rows:
+            source = _table_from_row(row, "source")
+            target = _table_from_row(row, "target")
+            tables[source.key] = source
+            tables[target.key] = target
+            foreign_keys.add(ForeignKey(source=source.key, target=target.key, is_cross_schema=row["is_cross_schema"]))
+
+        candidate_keys = _reference_table_closure(tables, foreign_keys)
+        eligible_tables = {
+            table_key: replace(
+                table,
+                eligible=table_key in candidate_keys and _is_eligible_reference_table(context, store, table),
+            )
+            for table_key, table in tables.items()
+        }
+        config_output = {"models": {}}
+        config_models = config_output["models"]
+        for table in plan_reference_tables(eligible_tables, foreign_keys):
+            model_name = table.comment or table.qualified_name
+            config_models[model_name] = {"distribute": "copy"}
+
+        output_stream = nullcontext(sys.stdout) if output_path is None else output_path.open("w")
+        with output_stream as out:
+            yaml.dump(config_output, out)

--- a/spinta/cli/helpers/admin/scripts/citus_reference_config.py
+++ b/spinta/cli/helpers/admin/scripts/citus_reference_config.py
@@ -15,67 +15,61 @@ from spinta.components import Context
 from spinta.exceptions import ModelNotFound
 
 FOREIGN_KEY_METADATA_QUERY = text("""
-    WITH foreign_keys AS (
-      SELECT DISTINCT
-        src_ns.nspname AS source_schema,
-        src.relname AS source_table,
-        tgt_ns.nspname AS target_schema,
-        tgt.relname AS target_table,
-        src_ns.nspname <> tgt_ns.nspname AS is_cross_schema
-      FROM pg_constraint con
-      JOIN pg_class src ON src.oid = con.conrelid
-      JOIN pg_namespace src_ns ON src_ns.oid = src.relnamespace
-      JOIN pg_class tgt ON tgt.oid = con.confrelid
-      JOIN pg_namespace tgt_ns ON tgt_ns.oid = tgt.relnamespace
-      WHERE con.contype = 'f'
-        AND src.relkind IN ('r', 'p')
-        AND tgt.relkind IN ('r', 'p')
-        AND src_ns.nspname NOT LIKE 'pg_%'
-        AND tgt_ns.nspname NOT LIKE 'pg_%'
-        AND src_ns.nspname <> 'information_schema'
-        AND tgt_ns.nspname <> 'information_schema'
-        AND src_ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
-        AND tgt_ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
-    ),
-    table_metadata AS (
-      SELECT
+WITH table_metadata AS (
+    SELECT
+        rel.oid AS relation_oid,
         ns.nspname AS schema_name,
         rel.relname AS table_name,
         format('%s/%s', ns.nspname, rel.relname) AS qualified_name,
         obj_description(rel.oid, 'pg_class') AS table_comment,
         pg_total_relation_size(rel.oid) AS table_bytes,
         COALESCE(ct.citus_table_type, 'local') AS citus_table_type,
-        ct.table_name IS NULL OR citus_table_type = 'local' AS is_unmanaged_local
-      FROM pg_class rel
-      JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-      LEFT JOIN citus_tables ct ON ct.table_name = rel.oid::regclass
-      WHERE rel.relkind IN ('r', 'p')
-        AND ns.nspname NOT LIKE 'pg_%'
-        AND ns.nspname <> 'information_schema'
-        AND ns.nspname NOT IN ('tiger', 'tiger_data', 'topology', 'citus', 'citus_internal')
-    )
-    SELECT
-      fk.source_schema,
-      fk.source_table,
-      fk.target_schema,
-      fk.target_table,
-      fk.is_cross_schema,
-      src.qualified_name AS source_qualified_name,
-      src.table_comment AS source_table_comment,
-      src.table_bytes AS source_table_bytes,
-      src.citus_table_type AS source_citus_table_type,
-      src.is_unmanaged_local AS source_is_unmanaged_local,
-      tgt.qualified_name AS target_qualified_name,
-      tgt.table_comment AS target_table_comment,
-      tgt.table_bytes AS target_table_bytes,
-      tgt.citus_table_type AS target_citus_table_type,
-      tgt.is_unmanaged_local AS target_is_unmanaged_local
-    FROM foreign_keys fk
-    JOIN table_metadata src
-      ON (src.schema_name, src.table_name) = (fk.source_schema, fk.source_table)
-    JOIN table_metadata tgt
-      ON (tgt.schema_name, tgt.table_name) = (fk.target_schema, fk.target_table)
-    ORDER BY fk.source_schema, fk.source_table, fk.target_schema, fk.target_table;
+        COALESCE(ct.citus_table_type = 'local', TRUE) AS is_unmanaged_local
+    FROM pg_class rel
+    JOIN pg_namespace ns
+        ON ns.oid = rel.relnamespace
+    LEFT JOIN citus_tables ct
+        ON ct.table_name = rel.oid::regclass
+    WHERE rel.relkind IN ('r', 'p')
+      AND ns.nspname NOT LIKE 'pg_%'
+      AND ns.nspname NOT IN (
+          'information_schema',
+          'tiger',
+          'tiger_data',
+          'topology',
+          'citus',
+          'citus_internal'
+      )
+)
+SELECT DISTINCT
+    src.schema_name AS source_schema,
+    src.table_name AS source_table,
+    tgt.schema_name AS target_schema,
+    tgt.table_name AS target_table,
+    src.schema_name <> tgt.schema_name AS is_cross_schema,
+
+    src.qualified_name AS source_qualified_name,
+    src.table_comment AS source_table_comment,
+    src.table_bytes AS source_table_bytes,
+    src.citus_table_type AS source_citus_table_type,
+    src.is_unmanaged_local AS source_is_unmanaged_local,
+
+    tgt.qualified_name AS target_qualified_name,
+    tgt.table_comment AS target_table_comment,
+    tgt.table_bytes AS target_table_bytes,
+    tgt.citus_table_type AS target_citus_table_type,
+    tgt.is_unmanaged_local AS target_is_unmanaged_local
+FROM pg_constraint con
+JOIN table_metadata src
+    ON src.relation_oid = con.conrelid
+JOIN table_metadata tgt
+    ON tgt.relation_oid = con.confrelid
+WHERE con.contype = 'f'
+ORDER BY
+    source_schema,
+    source_table,
+    target_schema,
+    target_table;
 """)
 
 yaml = YAML(typ="safe")

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -1163,6 +1163,9 @@ class Config:
 
     default_distribution_strategy: DistributionStrategy | None = None
 
+    # Script configurations
+    citus_reference_script_size: int
+
     def __init__(self):
         self.commands = _CommandsConfig()
         self.components = {}

--- a/spinta/config.py
+++ b/spinta/config.py
@@ -322,7 +322,7 @@ CONFIG = {
             "backends": {
                 "default": {
                     "type": "postgresql",
-                    "dsn": "postgresql://admin:admin123@localhost:15432/spinta_tests",
+                    "dsn": "postgresql://admin:admin123@localhost:54321/spinta_tests",
                 },
                 "mongo": {
                     "type": "mongo",

--- a/spinta/config.py
+++ b/spinta/config.py
@@ -273,6 +273,8 @@ CONFIG = {
     # Default postgresql backend sharding distribution strategy (set it to `undistributed` to disable sharding)
     "default_distribution_strategy": "schema",
     "default_distribution_property": "_id",
+    # Script configuration parameters
+    "citus_reference_script_size": "10g",
     "environments": {
         "dev": {
             "keymaps.default": {
@@ -320,7 +322,7 @@ CONFIG = {
             "backends": {
                 "default": {
                     "type": "postgresql",
-                    "dsn": "postgresql://admin:admin123@localhost:54321/spinta_tests",
+                    "dsn": "postgresql://admin:admin123@localhost:15432/spinta_tests",
                 },
                 "mongo": {
                     "type": "mongo",

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -151,6 +151,7 @@ def load(context: Context, config: Config) -> Config:
         cast=lambda strategy: DistributionStrategy(
             get_enum_by_value(DistributionType, strategy),
             property=rc.get("default_distribution_property", default=None),
+            default=True,
         ),
     )
 

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -19,6 +19,7 @@ from spinta.logging_config import setup_logging
 from spinta.utils.config import asbool, get_config_path
 from spinta.utils.enums import get_enum_by_name, get_enum_by_value
 from spinta.utils.imports import importstr
+from spinta.utils.units import tobytes
 
 yaml = YAML(typ="safe")
 
@@ -154,6 +155,7 @@ def load(context: Context, config: Config) -> Config:
             default=True,
         ),
     )
+    config.citus_reference_script_size = rc.get("citus_reference_script_size", cast=tobytes, default=1000**3)
 
     return config
 

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -155,7 +155,7 @@ def load(context: Context, config: Config) -> Config:
             default=True,
         ),
     )
-    config.citus_reference_script_size = rc.get("citus_reference_script_size", cast=tobytes, default=1000**3)
+    config.citus_reference_script_size = rc.get("citus_reference_script_size", cast=tobytes, default="10g")
 
     return config
 

--- a/tests/cli/admin/test_citus_reference_config.py
+++ b/tests/cli/admin/test_citus_reference_config.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from sqlalchemy.engine import Engine
+
+from spinta import commands
+from spinta.backends.helpers import get_table_identifier
+from spinta.backends.postgresql.helpers.migrate.citus import gather_current_sharding_plan
+from spinta.cli.helpers.admin.components import Script
+from spinta.cli.helpers.script.components import ScriptStatus
+from spinta.cli.helpers.script.helpers import script_check_status_message
+from spinta.core.config import RawConfig
+from spinta.testing.citus import bootstrap_distribute_manifest
+from spinta.testing.cli import SpintaCliRunner, result_contains
+
+yaml = YAML(typ="safe")
+
+
+SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST = """
+     d                  | r | b | m    | property | type    | ref
+     distribute/example |   |   |      |          |         |
+                        |   |   | Test |          |         |
+                        |   |   |      | id       | integer |
+     distribute/data    |   |   |      |          |         |
+                        |   |   | Data |          |         |
+                        |   |   |      | id       | integer |
+                        |   |   |      | test     | ref     | distribute/example/Test
+"""
+
+
+def test_citus_reference_config_output_stdout(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+    )
+
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {test_table_identifier, data_table_identifier}.issubset(current_citus_state.local)
+
+    result = cli.invoke(context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value])
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    yml_output = yaml.load(result.stdout)
+    assert yml_output == {"models": {"distribute/example/Test": {"distribute": "copy"}}}
+
+
+def test_citus_reference_config_output_yml_file(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+    )
+
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {test_table_identifier, data_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.yml"
+    result = cli.invoke(context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path)])
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    assert not result.stdout
+    assert output_path.exists()
+    with output_path.open("r") as f:
+        yml_output = yaml.load(f)
+    assert yml_output == {"models": {"distribute/example/Test": {"distribute": "copy"}}}
+
+
+def test_citus_reference_config_output_invalid_file_type(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+    )
+
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {test_table_identifier, data_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.txt"
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path)], fail=False
+    )
+    assert result.exit_code == 1
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    assert not result.stdout
+    assert not output_path.exists()
+    assert f"Output file '{output_path}' has unsupported format. Use '.yml' or '.yaml'." in result.stderr
+
+
+def test_citus_reference_config_output_existing_file(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+    )
+
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {test_table_identifier, data_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.yml"
+    with open(output_path, "w") as f:
+        f.write("test")
+
+    assert output_path.exists()
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path)], fail=False
+    )
+    assert result.exit_code == 1
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    assert not result.stdout
+    assert f"Output file '{output_path}' already exists. Use --destructive to overwrite." in result.stderr
+
+    assert output_path.exists()
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path), "--destructive"]
+    )
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    assert not result.stdout
+    with output_path.open("r") as f:
+        yml_output = yaml.load(f)
+    assert yml_output == {"models": {"distribute/example/Test": {"distribute": "copy"}}}

--- a/tests/cli/admin/test_citus_reference_config.py
+++ b/tests/cli/admin/test_citus_reference_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from ruamel.yaml import YAML
 from sqlalchemy.engine import Engine
 
@@ -25,6 +26,22 @@ SIMPLE_CROSS_SCHEMA_REFERENCE_MANIFEST = """
                         |   |   | Data |          |         |
                         |   |   |      | id       | integer |
                         |   |   |      | test     | ref     | distribute/example/Test
+"""
+
+
+MULTI_CROSS_SCHEMA_REFERENCE_MANIFEST = """
+     d                  | r | b | m     | property | type    | ref
+     distribute/example |   |   |       |          |         |
+                        |   |   | Test  |          |         |
+                        |   |   |       | id       | integer |
+     distribute/data    |   |   |       |          |         |
+                        |   |   | Data  |          |         |
+                        |   |   |       | id       | integer |
+                        |   |   |       | test     | ref     | distribute/example/Test
+     distribute/other   |   |   |       |          |         |
+                        |   |   | Other |          |         |
+                        |   |   |       | id       | integer |
+                        |   |   |       | test     | ref     | distribute/data/Data
 """
 
 
@@ -202,3 +219,152 @@ def test_citus_reference_config_output_existing_file(
     with output_path.open("r") as f:
         yml_output = yaml.load(f)
     assert yml_output == {"models": {"distribute/example/Test": {"distribute": "copy"}}}
+
+
+def test_citus_reference_config_multiple(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=MULTI_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+    )
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+    other_model = commands.get_model(context, manifest, "distribute/other/Other")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+    other_table_identifier = get_table_identifier(other_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {data_table_identifier, other_table_identifier, test_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.yml"
+    assert not output_path.exists()
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path), "--destructive"]
+    )
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    with output_path.open("r") as f:
+        yml_output = yaml.load(f)
+    assert yml_output == {
+        "models": {
+            "distribute/data/Data": {"distribute": "copy"},
+            "distribute/example/Test": {"distribute": "copy"},
+        }
+    }
+
+
+def test_citus_reference_config_skip_existing_configs(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=MULTI_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+        model_distribution={"distribute/example/Test": {"distribute": "copy"}},
+    )
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    # Run distribution migrations
+    result = cli.invoke(context.get("rc"), ["admin", Script.CITUS_DISTRIBUTION.value])
+    assert result.exit_code == 0
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+    other_model = commands.get_model(context, manifest, "distribute/other/Other")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+    other_table_identifier = get_table_identifier(other_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert current_citus_state.references == {test_table_identifier}
+    assert not current_citus_state.distributed
+    assert {data_table_identifier, other_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.yml"
+    assert not output_path.exists()
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path), "--destructive"]
+    )
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    with output_path.open("r") as f:
+        yml_output = yaml.load(f)
+    assert yml_output == {"models": {"distribute/data/Data": {"distribute": "copy"}}}
+
+
+@pytest.mark.parametrize(
+    "undistributed_model,script_result",
+    (
+        ("distribute/example/Test", {}),
+        ("distribute/data/Data", {"distribute/example/Test": {"distribute": "copy"}}),
+    ),
+)
+def test_citus_reference_config_blocked(
+    undistributed_model: str,
+    script_result: dict,
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=MULTI_CROSS_SCHEMA_REFERENCE_MANIFEST,
+        default_distribution_strategy="schema",
+        model_distribution={undistributed_model: {"distribute": "undistributed"}},
+    )
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    test_model = commands.get_model(context, manifest, "distribute/example/Test")
+    data_model = commands.get_model(context, manifest, "distribute/data/Data")
+    other_model = commands.get_model(context, manifest, "distribute/other/Other")
+
+    test_table_identifier = get_table_identifier(test_model)
+    data_table_identifier = get_table_identifier(data_model)
+    other_table_identifier = get_table_identifier(other_model)
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+    assert {data_table_identifier, other_table_identifier, test_table_identifier}.issubset(current_citus_state.local)
+
+    output_path = tmp_path / "citus_reference_config.yml"
+    assert not output_path.exists()
+    result = cli.invoke(
+        context.get("rc"), ["admin", Script.CITUS_REFERENCE_CONFIG.value, "--output", str(output_path), "--destructive"]
+    )
+    assert result.exit_code == 0
+    assert result_contains(
+        result, script_check_status_message(Script.CITUS_REFERENCE_CONFIG.value, ScriptStatus.REQUIRED)
+    )
+    with output_path.open("r") as f:
+        yml_output = yaml.load(f)
+    assert yml_output == {"models": script_result}


### PR DESCRIPTION
Added script, that gathers remaining blocking tables (cross schema references, that block schema based distribution) and generates `config.yml` output (by defaul to `stdout`, but can specify `--output .../output.yml` path).

Still need to add CHANGES.rst, once its reviewed.