### PR TITLE
health check endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,8 +52,28 @@ Improvements:
   ``ALLOWED_JWT_ALGORITHMS`` allow-list (RSA and EC families, including the
   ``RS512`` used for access tokens) is now passed to token encode/decode.
 - Added support to citus distribution management using `spinta migrate` cli command (`#1915`_).
+- Added a ``/health`` probe endpoint, following the UAPI ``health`` schema: a
+  ``healthy`` flag for the whole service and a ``dependencies`` list, where each
+  item has a ``name`` and its own ``healthy`` flag. The reported dependencies
+  are ``spinta`` itself, ``disk`` (enough free disk space on ``data_path``) and
+  ``memory`` (enough available RAM). Only these flags are reported: since the
+  probe is not authenticated, paths, free space and errors are written to the
+  log instead of to the response. Available memory is measured against the
+  limit of the control group the process belongs to, falling back to the memory
+  of the host when it is not limited, so that a container is not reported as
+  healthy right before being killed for using up the memory it was given. Note
+  that an unhealthy service is reported in the body, not in the status code: the
+  endpoint answers ``200`` with ``healthy: false``, because UAPI declares
+  ``503`` to be the ``ServiceNotAvailable`` error object. Consumers, including
+  container and load balancer probes, must therefore inspect ``healthy`` rather
+  than the status code. Thresholds are configurable via
+  ``health.min_free_disk_space`` (MB, defaults to ``2048``) and
+  ``health.min_free_memory`` (MB, defaults to ``256``). Like the other utility
+  routes, ``/health`` is matched before the catch-all route, so it shadows a
+  root level namespace or model named ``health``, if there is one (`#1873`_).
 
 .. _#513: https://github.com/atviriduomenys/dvms/issues/513
+.. _#1873: https://github.com/atviriduomenys/spinta/issues/1873
 .. _#1996: https://github.com/atviriduomenys/spinta/issues/1996
 .. _#1556: https://github.com/atviriduomenys/spinta/issues/1556
 .. _#1915: https://github.com/atviriduomenys/spinta/issues/1915

--- a/docs/en/manual/configuration/health.md
+++ b/docs/en/manual/configuration/health.md
@@ -1,0 +1,110 @@
+# Health probe configuration
+
+Spinta serves a `/health` endpoint that reports whether the service is
+operational. It is meant for container, load balancer and monitoring probes,
+and it requires no authentication.
+
+The response follows the UAPI
+[`health`](https://ivpk.github.io/uapi/#tag/utility/operation/apiHealth)
+schema: a `healthy` flag for the whole service and a `dependencies` list, where
+each item is a named dependency with its own `healthy` flag.
+
+```json
+{
+  "healthy": true,
+  "dependencies": [
+    {"name": "spinta", "healthy": true},
+    {"name": "disk", "healthy": true},
+    {"name": "memory", "healthy": true}
+  ]
+}
+```
+
+The service is `healthy` only when every dependency is:
+
+| Dependency | Healthy when                                                  |
+| ---------- | ------------------------------------------------------------- |
+| `spinta`   | Spinta answered the request at all                             |
+| `disk`     | free disk space on `data_path` is at or above the threshold    |
+| `memory`   | available memory is at or above the threshold                  |
+
+## Reading the result
+
+```{important}
+An unhealthy service is reported in the body, not in the status code. The
+endpoint always answers `200`, with `healthy: false` when something is wrong,
+because UAPI declares `503` to be the `ServiceNotAvailable` error object.
+Probes must therefore inspect the `healthy` field rather than the status code.
+```
+
+Only the flags are reported. Since the endpoint is not authenticated, it must
+not disclose how the service is deployed, so paths, free space, thresholds and
+errors are written to the log instead of to the response. When a check fails,
+Spinta logs the details at `ERROR` level, for example:
+
+```
+Not enough free disk space on /var/lib/spinta: 1024 MB free, 2048 MB required.
+```
+
+## Configuration options
+
+Both thresholds are absolute values in megabytes. The values are read from your
+`config.yml`; if they are not set there, Spinta falls back to the defaults
+defined in `spinta/config.py`.
+
+| Option                         | Default | Meaning                                            |
+| ------------------------------ | ------- | -------------------------------------------------- |
+| `health.min_free_disk_space`   | `2048`  | MB of free disk space below which `disk` is unhealthy   |
+| `health.min_free_memory`       | `256`   | MB of available memory below which `memory` is unhealthy |
+
+```yaml
+health:
+  min_free_disk_space: 2048
+  min_free_memory: 256
+```
+
+Or as environment variables:
+
+```sh
+SPINTA_HEALTH__MIN_FREE_DISK_SPACE=2048
+SPINTA_HEALTH__MIN_FREE_MEMORY=256
+```
+
+### Choosing the thresholds
+
+A threshold must be lower than the resources the machine is actually given,
+otherwise the probe reports the service as unhealthy from the moment it starts.
+The defaults are chosen against the minimum requirements for running an agent —
+1 GB of RAM and 5 GB of free disk space — so that a machine provisioned to those
+minimums is healthy, and the probe warns while there is still room to react.
+
+Raise the thresholds together with the resources. On a host with a large data
+volume 2 GB of free space is reached far too late to be a useful warning, and on
+a container given more than 1 GB of memory the memory threshold can be raised in
+proportion.
+
+## What is measured
+
+`disk` is the free space of the file system holding `data_path`, not of the
+whole machine. If `data_path` has not been created yet, the closest existing
+parent directory is measured, so a fresh installation is not reported as
+unhealthy merely because the directory is missing.
+
+`memory` is measured against the memory limit of the control group this process
+belongs to — the limit given to a container, or a `MemoryMax=` set on a systemd
+service. Parent groups constrain it as well, so what is reported is the smallest
+amount left across the process' own group and all of its parents; memory a
+parent has already given to its other children is not available to this process
+either. Finally, the memory of the host bounds it too, because a control group
+limit is a ceiling and not a reservation: a container with room to spare is
+still killed when the machine itself runs out of memory, so the smaller of the
+two is what gets reported. Reclaimable page cache is not counted as used, the same way
+the kernel decides whether to kill the process. When no control group limits
+this process, only the available memory of the host is left to go by.
+
+```{note}
+This distinction matters in containers. `/proc/meminfo`, which reports host
+memory, is not namespaced, so a container reading it sees the memory of the whole
+machine. A container limited to 1 GB and about to be killed for using it all
+would otherwise look perfectly healthy.
+```

--- a/docs/en/manual/configuration/index.rst
+++ b/docs/en/manual/configuration/index.rst
@@ -32,6 +32,7 @@ directory where additional configuration files are looked for.
    manifest
    soap-custom-adapters
    front-page
+   health
 
 .. _config-file:
 

--- a/docs/lt/agentas/agento-paruošimas.md
+++ b/docs/lt/agentas/agento-paruošimas.md
@@ -28,6 +28,14 @@ Pats savaime Agentas su visomis Python priklausomybėmis diske užima apie 2 GB 
 
 Agento veikimas turėtu būti nuolat stebimas ir reikiami resursai didinami, pagal poreikį.
 
+Disko vietos ir atminties likutį Agentas stebi ir pats — `/health` adresu jis pateikia savo būsenos suvestinę, kurią galima naudoti stebėsenos sistemoje ar konteinerio būsenos tikrinime. Pagal nutylėjimą būsena tampa nesveika, kai lieka mažiau nei 2 GB laisvos vietos diske arba mažiau nei 256 MB prieinamos atminties. Šios ribos parinktos taip, kad aukščiau nurodytus minimalius reikalavimus atitinkanti sistema būtų sveika, o įspėjimas ateitų dar likus laiko sureaguoti.
+
+:::{note}
+Nesveika būsena nurodoma atsakymo `healthy` lauke, o ne HTTP statuso kode — endpoint'as visada grąžina `200`. Stebėsenos sistemą reikia konfigūruoti tikrinti būtent šį lauką.
+:::
+
+Ribas galima keisti `health.min_free_disk_space` ir `health.min_free_memory` parametrais; jas verta didinti kartu su Agentui skiriamais resursais. Plačiau apie šiuos parametrus rašoma angliškos dokumentacijos skyriuje „Configuration → Health probe configuration“.
+
 ## Operacinės sistemos paruošimas
 
 ### Papildomų OS paketų diegimas

--- a/spinta/api/__init__.py
+++ b/spinta/api/__init__.py
@@ -17,6 +17,10 @@ from starlette.staticfiles import StaticFiles
 
 from spinta import commands, components
 from spinta.accesslog import create_accesslog
+
+# Imported under a different name, so that `spinta.api.health` keeps meaning
+# the module and not this function.
+from spinta.api.health import health as health_probe
 from spinta.api.validators import ClientAddData, ClientBackendsData, ClientPatchData, ClientSecretPatchData
 from spinta.auth import (
     AuthorizationServer,
@@ -448,6 +452,7 @@ def init(context: Context):
         Route("/robots.txt", robots, methods=["GET"]),
         Route("/favicon.ico", favicon, methods=["GET"]),
         Route("/version", version, methods=["GET"]),
+        Route("/health", health_probe, methods=["GET"]),
         Route("/auth/token", auth_token, methods=["POST"]),
         Route("/.well-known/jwks.json", get_verification_keys, methods=["GET"]),
         Route("/_srid/{srid:int}/{x:spinta_float}/{y:spinta_float}", srid_check, methods=["GET"]),

--- a/spinta/api/health.py
+++ b/spinta/api/health.py
@@ -1,0 +1,116 @@
+"""`/health` probe.
+
+Reports whether Spinta is operational: whether there is enough free disk space
+and enough available memory. The response format, the configuration options and
+how the thresholds are chosen are documented in
+`docs/en/manual/configuration/health.md`.
+
+The checks are a handful of file system reads, so this is a plain synchronous
+handler, which Starlette runs in a worker thread. That keeps a check that does
+block, `statvfs` on an unresponsive network mount for one, off the event loop.
+
+Details of a failed check go to the log and never to the response: the probe is
+not authenticated, so it must not disclose how the service is deployed.
+"""
+
+import logging
+import pathlib
+import threading
+
+import psutil
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from spinta.components import Config, Context
+from spinta.utils.memory import available_memory
+
+log = logging.getLogger(__name__)
+
+MB = 1024 * 1024
+
+# Only one disk check runs at a time, because `statvfs` blocks on an
+# unresponsive mount and every probe would otherwise start another worker thread
+# that never returns. Waiting a moment for a check that is merely in progress
+# keeps two overlapping probes from reporting a healthy disk as unhealthy.
+DISK_CHECK_WAIT = 1
+_disk_check = threading.Lock()
+
+
+def _existing_path(path: pathlib.Path) -> pathlib.Path:
+    """Return the closest existing directory of a possibly not yet created path."""
+    for candidate in (path, *path.parents):
+        if candidate.exists():
+            return candidate
+    return pathlib.Path(path.anchor or ".")
+
+
+def check_disk(config: Config) -> bool:
+    """Check that enough disk space is left where Spinta keeps its data."""
+    if not _disk_check.acquire(timeout=DISK_CHECK_WAIT):
+        log.error("Skipping the disk check, the previous one has not finished yet.")
+        return False
+    try:
+        return _free_disk_space_is_enough(config)
+    finally:
+        _disk_check.release()
+
+
+def _free_disk_space_is_enough(config: Config) -> bool:
+    path = config.data_path
+    try:
+        # `Path.exists()` raises, for example when a parent directory may not be
+        # searched, so resolving the path has to be guarded as well.
+        path = _existing_path(path)
+        free = psutil.disk_usage(str(path)).free // MB
+    except Exception:
+        log.exception("Error while checking free disk space of %s.", path)
+        return False
+
+    if free < config.health_min_free_disk_space:
+        log.error(
+            "Not enough free disk space on %s: %s MB free, %s MB required.",
+            path,
+            free,
+            config.health_min_free_disk_space,
+        )
+        return False
+    return True
+
+
+def check_memory(config: Config) -> bool:
+    """Check that enough memory is left for Spinta to keep working."""
+    try:
+        available = available_memory() // MB
+    except Exception:
+        log.exception("Error while checking available memory.")
+        return False
+
+    if available < config.health_min_free_memory:
+        log.error(
+            "Not enough available memory: %s MB available, %s MB required.",
+            available,
+            config.health_min_free_memory,
+        )
+        return False
+    return True
+
+
+def health(request: Request) -> JSONResponse:
+    context: Context = request.state.context
+    config: Config = context.get("config")
+
+    dependencies = [
+        # Spinta itself answered, everything else it needs is checked separately.
+        {"name": "spinta", "healthy": True},
+        {"name": "disk", "healthy": check_disk(config)},
+        {"name": "memory", "healthy": check_memory(config)},
+    ]
+
+    return JSONResponse(
+        {
+            "healthy": all(dependency["healthy"] for dependency in dependencies),
+            "dependencies": dependencies,
+        },
+        # Probes must always get the current state, never a cached one.
+        headers={"Cache-Control": "no-store"},
+    )

--- a/spinta/components.py
+++ b/spinta/components.py
@@ -1157,6 +1157,10 @@ class Config:
     # HTTP Strict Transport Security (HSTS) header
     http_strict_transport_security: str = ""
 
+    # `/health` probe thresholds, in MB
+    health_min_free_disk_space: int
+    health_min_free_memory: int
+
     log_level: str
     file_log_level: str
     file_log_path: pathlib.Path

--- a/spinta/config.py
+++ b/spinta/config.py
@@ -267,6 +267,13 @@ CONFIG = {
     # Response HTTP Strict Transport Security (HSTS) header. `max-age` must be at
     # least 31536000 seconds (1 year) and `includeSubDomains` must be specified.
     "http_strict_transport_security": "max-age=31536000; includeSubDomains",
+    # `/health` probe thresholds.
+    "health": {
+        # Minimum amount of free disk space (MB) on `data_path`.
+        "min_free_disk_space": 2048,
+        # Minimum amount of available RAM (MB).
+        "min_free_memory": 256,
+    },
     # Default postgresql backend sharding distribution strategy (set it to `undistributed` to disable sharding)
     "default_distribution_strategy": "schema",
     "default_distribution_property": "_id",

--- a/spinta/config.yml
+++ b/spinta/config.yml
@@ -215,6 +215,14 @@ check:
     names:
       type: boolean
 
+health:
+  type: object
+  items:
+    min_free_disk_space:
+      type: integer
+    min_free_memory:
+      type: integer
+
 root:
   type: string
 

--- a/spinta/types/config.py
+++ b/spinta/types/config.py
@@ -133,6 +133,9 @@ def load(context: Context, config: Config) -> Config:
 
     config.http_strict_transport_security = rc.get("http_strict_transport_security", default="")
 
+    config.health_min_free_disk_space = rc.get("health", "min_free_disk_space", default=2048, cast=int)
+    config.health_min_free_memory = rc.get("health", "min_free_memory", default=256, cast=int)
+
     if config.token_validation_keys_download_url and config.token_validation_key:
         raise ValueError(
             "token_validation_keys_download_url and token_validation_keys_download_url are mutually exclusive and can't be used together. Use one."

--- a/spinta/utils/memory.py
+++ b/spinta/utils/memory.py
@@ -1,0 +1,153 @@
+"""How much memory this process is still allowed to use.
+
+`psutil` reads `/proc/meminfo`, which is not namespaced: inside a container it
+reports the memory of the host, not the limit the container was given. A
+container about to be killed for using up its memory would therefore look
+perfectly healthy. So the limit of the control group this process belongs to is
+taken into account when it has one.
+
+Neither number replaces the other. A cgroup limit is a ceiling, not a
+reservation, so a container with room to spare is still killed when the machine
+itself runs out of memory. What this process can really use is whichever of the
+two is tighter.
+"""
+
+import pathlib
+from typing import NamedTuple
+
+import psutil
+
+
+class CgroupLayout(NamedTuple):
+    """Where one cgroup version keeps its memory accounting."""
+
+    root: pathlib.Path
+    # Name this version goes by in `/proc/self/cgroup`, empty for cgroup v2.
+    controller: str
+    limit: str
+    usage: str
+    stat: str
+
+
+CGROUP_LAYOUTS = (
+    CgroupLayout(pathlib.Path("/sys/fs/cgroup"), "", "memory.max", "memory.current", "memory.stat"),
+    CgroupLayout(
+        pathlib.Path("/sys/fs/cgroup/memory"),
+        "memory",
+        "memory.limit_in_bytes",
+        "memory.usage_in_bytes",
+        "memory.stat",
+    ),
+)
+
+# Tells which cgroup this process belongs to. A container sees its own limit at
+# the mount root, but a systemd service does not: it runs in a nested cgroup,
+# such as `/system.slice/spinta.service`, while the root stays unlimited.
+PROC_CGROUP = pathlib.Path("/proc/self/cgroup")
+
+# cgroup v1 reports a limit near the maximum of a 64 bit integer when there is
+# none, and cgroup v2 reports `max`.
+NO_CGROUP_LIMIT = 2**62
+
+
+def _read_int(path: pathlib.Path) -> int | None:
+    """Read a cgroup number, or None when there is no limit to read.
+
+    Only a missing file and the `max` marker mean that. Anything else that goes
+    wrong is left to raise, so that a cgroup which cannot be read is reported as
+    unhealthy rather than mistaken for an unlimited one.
+    """
+    try:
+        value = path.read_text().strip()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+    return None if value == "max" else int(value)
+
+
+def _read_inactive_file(path: pathlib.Path) -> int:
+    """Page cache that can be reclaimed, so it does not count as used memory."""
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return 0
+
+    fields = {}
+    for line in lines:
+        name, _, value = line.partition(" ")
+        if name in ("inactive_file", "total_inactive_file"):
+            fields[name] = value
+
+    # cgroup v1 reports both: `inactive_file` for this group alone and
+    # `total_inactive_file` including its descendants, which is what its
+    # `memory.usage_in_bytes` counts, so the totals are the matching pair.
+    # cgroup v2 reports only `inactive_file`, and its `memory.current` already
+    # includes descendants.
+    try:
+        return int(fields.get("total_inactive_file", fields.get("inactive_file")))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _cgroup_of_this_process(controller: str) -> str:
+    """Path of this process within the cgroup hierarchy of `controller`.
+
+    A missing file means the system has no cgroups at all. Any other failure is
+    left to raise, so that an unreadable file is reported as unhealthy rather
+    than mistaken for the root cgroup, which is usually unlimited.
+    """
+    try:
+        lines = PROC_CGROUP.read_text().splitlines()
+    except FileNotFoundError:
+        return ""
+
+    for line in lines:
+        # Each line is `hierarchy:controllers:path`, with no controllers listed
+        # for cgroup v2.
+        _, _, rest = line.partition(":")
+        controllers, _, path = rest.partition(":")
+        if controller in controllers.split(","):
+            return path
+    return ""
+
+
+def _cgroup_dirs(layout: CgroupLayout) -> list[pathlib.Path]:
+    """This process' cgroup and its ancestors, closest one first."""
+    parts = [part for part in _cgroup_of_this_process(layout.controller).split("/") if part]
+    return [layout.root.joinpath(*parts[:depth]) for depth in range(len(parts), -1, -1)]
+
+
+def _available_within(layout: CgroupLayout, directory: pathlib.Path) -> int | None:
+    """Memory left within one cgroup's limit, or None if it has no limit."""
+    limit = _read_int(directory / layout.limit)
+    usage = _read_int(directory / layout.usage)
+    if limit is None or usage is None or limit >= NO_CGROUP_LIMIT:
+        return None
+
+    # What the kernel considers used when deciding to kill the container.
+    working_set = max(usage - _read_inactive_file(directory / layout.stat), 0)
+    return max(limit - working_set, 0)
+
+
+def _cgroup_available_memory() -> int | None:
+    """Memory left within this process' cgroup limits, or None if not limited."""
+    for layout in CGROUP_LAYOUTS:
+        # A process is bound by its own cgroup and by every ancestor of it, so
+        # the tightest of them is what it really has left. An ancestor's usage
+        # counts its other children as well, and their memory is not available
+        # to this process either.
+        headroom = [
+            available
+            for directory in _cgroup_dirs(layout)
+            if (available := _available_within(layout, directory)) is not None
+        ]
+        if headroom:
+            return min(headroom)
+    return None
+
+
+def available_memory() -> int:
+    """Memory, in bytes, this process can still use before it is killed."""
+    host = psutil.virtual_memory().available
+    cgroup = _cgroup_available_memory()
+    return host if cgroup is None else min(cgroup, host)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,139 @@
+import inspect
+import pathlib
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from spinta.api.health import check_disk, check_memory, health
+from spinta.testing.client import TestClient
+
+DEPENDENCIES = ["spinta", "disk", "memory"]
+
+MB = 1024 * 1024
+
+
+def _healthy(data: dict, name: str) -> bool:
+    (dependency,) = [dep for dep in data["dependencies"] if dep["name"] == name]
+    return dependency["healthy"]
+
+
+def _disk_config(**kwargs) -> SimpleNamespace:
+    return SimpleNamespace(data_path=pathlib.Path("/"), health_min_free_disk_space=1, **kwargs)
+
+
+def test_health(app: TestClient, mocker):
+    # Thresholds are put out of the way, so that the result does not depend on
+    # how much disk and memory the machine running the tests happens to have.
+    config = app.context.get("config")
+    mocker.patch.object(config, "health_min_free_disk_space", 0)
+    mocker.patch.object(config, "health_min_free_memory", 0)
+
+    resp = app.get("/health")
+    assert resp.status_code == 200
+    assert resp.headers["Cache-Control"] == "no-store"
+
+    assert resp.json() == {
+        "healthy": True,
+        "dependencies": [{"name": name, "healthy": True} for name in DEPENDENCIES],
+    }
+
+
+def test_health_is_not_a_coroutine():
+    # Starlette runs a synchronous endpoint in a worker thread, which is what
+    # keeps a blocking check, `statvfs` on an unresponsive network mount for
+    # one, off the event loop. Making this a coroutine would put it back on it.
+    assert not inspect.iscoroutinefunction(health)
+
+
+@pytest.mark.parametrize(
+    "name, target",
+    [
+        ("disk", "psutil.disk_usage"),
+        ("memory", "spinta.api.health.available_memory"),
+    ],
+)
+def test_health_resource_check_error(app: TestClient, name: str, target: str, mocker):
+    # A failing check must still produce a well formed response, otherwise the
+    # probe answers with a 500 error envelope exactly when something is wrong.
+    mocker.patch(target, side_effect=OSError("cannot read"))
+
+    resp = app.get("/health")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["healthy"] is False
+    assert _healthy(data, name) is False
+    assert "cannot read" not in resp.text
+
+
+@pytest.mark.parametrize("name", ["disk", "memory"])
+def test_health_not_enough_resources(app: TestClient, name: str, mocker):
+    config = app.context.get("config")
+    # Require more resources than any machine running the tests can have.
+    required = 1024**3
+    mocker.patch.object(config, "health_min_free_disk_space", required)
+    mocker.patch.object(config, "health_min_free_memory", required)
+
+    resp = app.get("/health")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["healthy"] is False
+    assert _healthy(data, name) is False
+
+
+def test_check_memory_reports_the_measured_amount(mocker):
+    mocker.patch("spinta.api.health.available_memory", return_value=300 * MB)
+
+    assert check_memory(SimpleNamespace(health_min_free_memory=256)) is True
+    assert check_memory(SimpleNamespace(health_min_free_memory=512)) is False
+
+
+def test_disk_check_waits_for_a_check_that_is_only_slow(mocker):
+    # Probes overlapping is normal, so a check that is merely in progress must
+    # be waited for rather than reported as a disk that is not there.
+    def slow_disk_usage(path):
+        time.sleep(0.1)
+        return SimpleNamespace(free=100 * MB)
+
+    mocker.patch("psutil.disk_usage", side_effect=slow_disk_usage)
+    config = _disk_config()
+
+    results = []
+    probes = [threading.Thread(target=lambda: results.append(check_disk(config))) for _ in range(2)]
+    for probe in probes:
+        probe.start()
+    for probe in probes:
+        probe.join(10)
+
+    assert results == [True, True]
+
+
+def test_disk_check_does_not_pile_up(mocker):
+    # `statvfs` blocks on an unresponsive mount, so without a guard every probe
+    # would start another worker thread that never returns.
+    mocker.patch("spinta.api.health.DISK_CHECK_WAIT", 0.05)
+    blocked = threading.Event()
+    release = threading.Event()
+
+    def blocking_disk_usage(path):
+        blocked.set()
+        release.wait(10)
+        raise OSError("mount is gone")
+
+    mocker.patch("psutil.disk_usage", side_effect=blocking_disk_usage)
+    config = _disk_config()
+
+    stuck = threading.Thread(target=check_disk, args=(config,))
+    stuck.start()
+    try:
+        assert blocked.wait(10)
+
+        started = time.monotonic()
+        assert check_disk(config) is False
+        assert time.monotonic() - started < 1
+    finally:
+        release.set()
+        stuck.join(10)

--- a/tests/utils/test_memory.py
+++ b/tests/utils/test_memory.py
@@ -1,0 +1,152 @@
+import pathlib
+
+import pytest
+
+from spinta.utils.memory import CgroupLayout, available_memory
+
+MB = 1024 * 1024
+
+V2 = CgroupLayout(pathlib.Path(), "", "memory.max", "memory.current", "memory.stat")
+V1 = CgroupLayout(pathlib.Path(), "memory", "memory.limit_in_bytes", "memory.usage_in_bytes", "memory.stat")
+
+
+def _write_cgroup(path: pathlib.Path, limit: str, usage: str, layout: CgroupLayout = V2, **stat: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / layout.limit).write_text(limit)
+    (path / layout.usage).write_text(usage)
+    fields = "".join(f"{name} {value}\n" for name, value in stat.items())
+    (path / layout.stat).write_text(f"anon 1000\n{fields}slab 20\n")
+
+
+def _fake_cgroup(
+    mocker,
+    tmp_path: pathlib.Path,
+    cgroup: str = "/",
+    layout: CgroupLayout = V2,
+) -> pathlib.Path:
+    """Point the memory check at a fake cgroup tree, entered from `cgroup`."""
+    root = tmp_path / "cgroup"
+    root.mkdir(exist_ok=True)
+
+    proc = tmp_path / "proc-self-cgroup"
+    proc.write_text(f"9:{layout.controller}:{cgroup}\n" if layout.controller else f"0::{cgroup}\n")
+    mocker.patch("spinta.utils.memory.PROC_CGROUP", proc)
+    mocker.patch("spinta.utils.memory.CGROUP_LAYOUTS", (layout._replace(root=root),))
+    return root
+
+
+def _host_memory(mocker, available: int) -> None:
+    mocker.patch("psutil.virtual_memory").return_value.available = available
+
+
+def test_available_memory_of_a_container(tmp_path: pathlib.Path, mocker):
+    # A container limited to 512 MB has to be measured against that limit, not
+    # against the memory of the host, which is all `/proc/meminfo` knows about.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit=str(512 * MB), usage=str(200 * MB))
+
+    assert available_memory() == 312 * MB
+
+
+def test_available_memory_of_a_nested_cgroup(tmp_path: pathlib.Path, mocker):
+    # A systemd service runs in a nested cgroup while the mount root stays
+    # unlimited, so looking only at the root would miss its `MemoryMax`.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path, cgroup="/system.slice/spinta.service")
+    _write_cgroup(root, limit="max", usage=str(8000 * MB))
+    _write_cgroup(root / "system.slice" / "spinta.service", limit=str(512 * MB), usage=str(200 * MB))
+
+    assert available_memory() == 312 * MB
+
+
+def test_available_memory_inherits_an_ancestor_limit(tmp_path: pathlib.Path, mocker):
+    # The limit can sit on a parent slice rather than on the process' own cgroup.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path, cgroup="/system.slice/spinta.service")
+    _write_cgroup(root / "system.slice", limit=str(512 * MB), usage=str(200 * MB))
+
+    assert available_memory() == 312 * MB
+
+
+def test_available_memory_uses_the_tightest_limit(tmp_path: pathlib.Path, mocker):
+    # Every ancestor constrains the process, not only the closest cgroup, and an
+    # ancestor's usage counts its other children too. Here the parent has less
+    # left than the child's own limit allows.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path, cgroup="/system.slice/spinta.service")
+    _write_cgroup(root / "system.slice", limit=str(512 * MB), usage=str(400 * MB))
+    _write_cgroup(root / "system.slice" / "spinta.service", limit=str(1024 * MB), usage=str(100 * MB))
+
+    assert available_memory() == 112 * MB
+
+
+def test_available_memory_ignores_reclaimable_cache(tmp_path: pathlib.Path, mocker):
+    # Page cache is charged to the group but reclaimed instead of being killed
+    # for, so counting it as used would report a busy container as unhealthy.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit=str(512 * MB), usage=str(500 * MB), inactive_file=str(400 * MB))
+
+    assert available_memory() == 412 * MB
+
+
+def test_available_memory_of_a_cgroup_v1_container(tmp_path: pathlib.Path, mocker):
+    # cgroup v1 counts descendants in `memory.usage_in_bytes`, so the matching
+    # reclaimable cache is `total_inactive_file`. Taking `inactive_file`, which
+    # covers this group alone, would report 112 MB here instead of 412 MB.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path, cgroup="/system.slice/spinta.service", layout=V1)
+    _write_cgroup(
+        root / "system.slice" / "spinta.service",
+        limit=str(512 * MB),
+        usage=str(500 * MB),
+        layout=V1,
+        inactive_file=str(100 * MB),
+        total_inactive_file=str(400 * MB),
+    )
+
+    assert available_memory() == 412 * MB
+
+
+def test_available_memory_is_bound_by_the_host(tmp_path: pathlib.Path, mocker):
+    # A cgroup limit is a ceiling, not a reservation: a container with gigabytes
+    # of headroom is still killed when the machine itself runs out of memory.
+    _host_memory(mocker, 100 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit=str(8000 * MB), usage=str(200 * MB))
+
+    assert available_memory() == 100 * MB
+
+
+def test_available_memory_with_a_zero_limit(tmp_path: pathlib.Path, mocker):
+    # A cgroup allowed no memory at all is unusable, not unlimited, so it must
+    # not fall back to the memory of the host.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit="0", usage=str(100 * MB))
+
+    assert available_memory() == 0
+
+
+@pytest.mark.parametrize("limit", ["max", str(2**63 - 1)])
+def test_available_memory_falls_back_to_the_host(tmp_path: pathlib.Path, limit: str, mocker):
+    _host_memory(mocker, 700 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit=limit, usage=str(200 * MB))
+
+    assert available_memory() == 700 * MB
+
+
+def test_available_memory_raises_when_a_cgroup_cannot_be_read(tmp_path: pathlib.Path, mocker):
+    # A cgroup that cannot be read is not an unlimited one. Falling back to the
+    # memory of the host would hide that the real headroom is unknown.
+    _host_memory(mocker, 8000 * MB)
+    root = _fake_cgroup(mocker, tmp_path)
+    _write_cgroup(root, limit=str(512 * MB), usage=str(200 * MB))
+    mocker.patch("pathlib.Path.read_text", side_effect=PermissionError("denied"))
+
+    with pytest.raises(PermissionError):
+        available_memory()
+
+    assert root.exists()


### PR DESCRIPTION
Šiame PR įgyvendinti šie health checkpointo dalykai:

    pačios spintos reportinimas-
    disko vietos reportinimas
    atminties reportinimas

Nėra pranešama, kiek disko vietos ar atminties likę, kad nebūtų atskleista per daug informacijos, tik ar jos užtenka, ar ne.

Disko vietos ir atmintie ribos, ties kuriomis pranešama, yra konfigūruojamos, bet turi savo defaultus.