### PR TITLE
2008 citus schema distribution invalidacija neveikia

### DIFF
--- a/spinta/backends/postgresql/commands/migrate/migrate.py
+++ b/spinta/backends/postgresql/commands/migrate/migrate.py
@@ -16,7 +16,7 @@ from spinta.backends.postgresql.helpers.migrate.citus import (
     create_sharding_plan,
     distribute_all,
     gather_current_sharding_plan,
-    invalidate_default_schema_distributions,
+    invalidate_default_distribution,
     undistribute_all,
 )
 from spinta.backends.postgresql.helpers.migrate.migrate import (
@@ -103,7 +103,7 @@ def migrate(context: Context, manifest: Manifest, backend: PostgreSQL, migration
         )
     )
     sharding_plan = create_sharding_plan(context, sorted_models).get(backend.name, ShardingPlan())
-    sharding_plan = invalidate_default_schema_distributions(context, backend, sharding_plan)
+    sharding_plan = invalidate_default_distribution(context, backend, sharding_plan)
     current_sharding_plan = gather_current_sharding_plan(context, schemas=allowed_old_namespaces).get(
         backend.name, ShardingPlan()
     )

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -206,7 +206,7 @@ def valid_schema_distribution_foreign_key_inspect(plan: ShardingPlan, schema: st
     return False
 
 
-def valid_schema_distribution_foreign_key_orm(plan: ShardingPlan, schema: str, foreign_key: ForeignKey) -> bool:
+def valid_schema_distribution_foreign_key_orm(plan: ShardingPlan, schema: str | None, foreign_key: ForeignKey) -> bool:
     referred_table = foreign_key.column.table
     if referred_table.schema == schema:
         return True
@@ -237,26 +237,15 @@ def invalidate_default_schema_distributions(
     inspector = sa.inspect(backend.engine)
 
     plan_copy = deepcopy(plan)
-    store = context.get("store")
-    manifest = store.manifest
-    namespaces = commands.get_namespaces(context, manifest)
-    for name, namespace in namespaces.items():
-        if not namespace.models:
+
+    for table in backend.tables.values():
+        if not table.foreign_keys:
             continue
 
-        pg_ns_name = get_pg_name(name)
-        if pg_ns_name not in plan.schemas:
-            continue
-
-        for model in namespace.models.values():
-            table = backend.get_table(model)
-            if not table.foreign_keys:
-                continue
-
-            for key in table.foreign_keys:
-                if not valid_schema_distribution_foreign_key_orm(plan, table.schema, key):
-                    invalid_schemas.add(key.column.table.schema)
-                    invalid_schemas.add(table.schema)
+        for key in table.foreign_keys:
+            if not valid_schema_distribution_foreign_key_orm(plan, table.schema, key):
+                invalid_schemas.add(key.column.table.schema)
+                invalid_schemas.add(table.schema)
 
     for schema in plan.schemas:
         tables = inspector.get_table_names(schema=schema)

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -6,10 +6,12 @@ import sqlalchemy as sa
 from multipledispatch import dispatch
 from tqdm import tqdm
 
+from spinta import commands
 from spinta.backends import Backend
 from spinta.backends.constants import DistributionType
 from spinta.backends.helpers import TableIdentifier, get_table_identifier
 from spinta.backends.postgresql.components import PostgreSQL
+from spinta.backends.postgresql.helpers import get_pg_name
 from spinta.backends.postgresql.helpers.migrate.actions import (
     DistributeReference,
     DistributeSchema,
@@ -19,8 +21,9 @@ from spinta.backends.postgresql.helpers.migrate.actions import (
     UndistributeTable,
 )
 from spinta.cli.helpers.message import cli_message
-from spinta.components import Context, Model
+from spinta.components import Base, Context, Model
 from spinta.exceptions import NotImplementedFeature
+from spinta.types.datatype import Ref
 
 
 @dataclasses.dataclass
@@ -189,6 +192,37 @@ def invalidate_default_distribution(
             return plan
 
 
+def valid_schema_distribution_base(model: Model, base: Base) -> bool:
+    if not commands.identifiable(base):
+        return True
+
+    base_parent = base.parent
+    if base_parent.external.dataset == model.external.dataset:
+        return True
+
+    if (
+        base_parent.distribution_strategy
+        and base_parent.distribution_strategy.distribution_type is DistributionType.COPY
+    ):
+        return True
+
+    return False
+
+
+def valid_schema_distribution_reference(model: Model, ref: Ref) -> bool:
+    if not commands.identifiable(ref.prop):
+        return True
+
+    ref_model = ref.model
+    if ref_model.external.dataset == model.external.dataset:
+        return True
+
+    if ref_model.distribution_strategy and ref_model.distribution_strategy.distribution_type is DistributionType.COPY:
+        return True
+
+    return False
+
+
 def valid_schema_distribution_foreign_key(plan: ShardingPlan, schema: str, foreign_key: dict) -> bool:
     if foreign_key["referred_schema"] == schema:
         return True
@@ -222,6 +256,30 @@ def invalidate_default_schema_distributions(
     inspector = sa.inspect(backend.engine)
 
     plan_copy = deepcopy(plan)
+    store = context.get("store")
+    manifest = store.manifest
+    namespaces = commands.get_namespaces(context, manifest)
+    for name, namespace in namespaces.items():
+        if not namespace.models:
+            continue
+
+        pg_ns_name = get_pg_name(name)
+        if pg_ns_name not in plan.schemas:
+            continue
+
+        for model in namespace.models.values():
+            if model.base and not valid_schema_distribution_base(model, model.base):
+                invalid_schemas.add(pg_ns_name)
+                invalid_schemas.add(get_pg_name(model.base.parent.external.dataset.name))
+
+            for prop in model.properties.values():
+                if not isinstance(prop.dtype, Ref):
+                    continue
+
+                if not valid_schema_distribution_reference(model, prop.dtype):
+                    invalid_schemas.add(pg_ns_name)
+                    invalid_schemas.add(get_pg_name(prop.dtype.model.external.dataset.name))
+
     for schema in plan.schemas:
         tables = inspector.get_table_names(schema=schema)
 

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -272,7 +272,7 @@ def invalidate_default_schema_distributions(
                 invalid_schemas.add(pg_ns_name)
                 invalid_schemas.add(get_pg_name(model.base.parent.external.dataset.name))
 
-            for prop in model.properties.values():
+            for prop in model.flatprops.values():
                 if not isinstance(prop.dtype, Ref):
                     continue
 

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -22,9 +22,8 @@ from spinta.backends.postgresql.helpers.migrate.actions import (
     UndistributeTable,
 )
 from spinta.cli.helpers.message import cli_message
-from spinta.components import Base, Context, Model
+from spinta.components import Context, Model
 from spinta.exceptions import NotImplementedFeature
-from spinta.types.datatype import Ref
 
 
 @dataclasses.dataclass

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import sqlalchemy as sa
 from multipledispatch import dispatch
+from sqlalchemy import ForeignKey
 from tqdm import tqdm
 
 from spinta import commands
@@ -192,38 +193,7 @@ def invalidate_default_distribution(
             return plan
 
 
-def valid_schema_distribution_base(model: Model, base: Base) -> bool:
-    if not commands.identifiable(base):
-        return True
-
-    base_parent = base.parent
-    if base_parent.external.dataset == model.external.dataset:
-        return True
-
-    if (
-        base_parent.distribution_strategy
-        and base_parent.distribution_strategy.distribution_type is DistributionType.COPY
-    ):
-        return True
-
-    return False
-
-
-def valid_schema_distribution_reference(model: Model, ref: Ref) -> bool:
-    if not commands.identifiable(ref.prop):
-        return True
-
-    ref_model = ref.model
-    if ref_model.external.dataset == model.external.dataset:
-        return True
-
-    if ref_model.distribution_strategy and ref_model.distribution_strategy.distribution_type is DistributionType.COPY:
-        return True
-
-    return False
-
-
-def valid_schema_distribution_foreign_key(plan: ShardingPlan, schema: str, foreign_key: dict) -> bool:
+def valid_schema_distribution_foreign_key_inspect(plan: ShardingPlan, schema: str, foreign_key: dict) -> bool:
     if foreign_key["referred_schema"] == schema:
         return True
 
@@ -232,6 +202,18 @@ def valid_schema_distribution_foreign_key(plan: ShardingPlan, schema: str, forei
             reference.pg_schema_name == foreign_key["referred_schema"]
             and reference.pg_table_name == foreign_key["referred_table"]
         ):
+            return True
+
+    return False
+
+
+def valid_schema_distribution_foreign_key_orm(plan: ShardingPlan, schema: str, foreign_key: ForeignKey) -> bool:
+    referred_table = foreign_key.column.table
+    if referred_table.schema == schema:
+        return True
+
+    for reference in plan.references:
+        if reference.pg_schema_name == referred_table.schema and reference.pg_table_name == referred_table.name:
             return True
 
     return False
@@ -268,17 +250,14 @@ def invalidate_default_schema_distributions(
             continue
 
         for model in namespace.models.values():
-            if model.base and not valid_schema_distribution_base(model, model.base):
-                invalid_schemas.add(pg_ns_name)
-                invalid_schemas.add(get_pg_name(model.base.parent.external.dataset.name))
+            table = backend.get_table(model)
+            if not table.foreign_keys:
+                continue
 
-            for prop in model.flatprops.values():
-                if not isinstance(prop.dtype, Ref):
-                    continue
-
-                if not valid_schema_distribution_reference(model, prop.dtype):
-                    invalid_schemas.add(pg_ns_name)
-                    invalid_schemas.add(get_pg_name(prop.dtype.model.external.dataset.name))
+            for key in table.foreign_keys:
+                if not valid_schema_distribution_foreign_key_orm(plan, table.schema, key):
+                    invalid_schemas.add(key.column.table.schema)
+                    invalid_schemas.add(table.schema)
 
     for schema in plan.schemas:
         tables = inspector.get_table_names(schema=schema)
@@ -289,7 +268,7 @@ def invalidate_default_schema_distributions(
                 continue
 
             for key in foreign_keys:
-                if not valid_schema_distribution_foreign_key(plan, schema, key):
+                if not valid_schema_distribution_foreign_key_inspect(plan, schema, key):
                     invalid_schemas.add(key["referred_schema"])
                     invalid_schemas.add(schema)
 

--- a/spinta/backends/postgresql/helpers/migrate/citus.py
+++ b/spinta/backends/postgresql/helpers/migrate/citus.py
@@ -7,12 +7,10 @@ from multipledispatch import dispatch
 from sqlalchemy import ForeignKey
 from tqdm import tqdm
 
-from spinta import commands
 from spinta.backends import Backend
 from spinta.backends.constants import DistributionType
 from spinta.backends.helpers import TableIdentifier, get_table_identifier
 from spinta.backends.postgresql.components import PostgreSQL
-from spinta.backends.postgresql.helpers import get_pg_name
 from spinta.backends.postgresql.helpers.migrate.actions import (
     DistributeReference,
     DistributeSchema,

--- a/tests/backends/postgresql/commands/migrate/test_citus.py
+++ b/tests/backends/postgresql/commands/migrate/test_citus.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from sqlalchemy.engine import Engine
 
 from spinta import commands
+from spinta.backends.constants import TableType
 from spinta.backends.helpers import TableIdentifier, get_table_identifier
 from spinta.backends.postgresql.helpers.migrate.citus import gather_current_sharding_plan
 from spinta.core.config import RawConfig
@@ -496,6 +497,158 @@ def test_migrate_from_empty_default_schema_distribution_invalidation(
         f"{add_column_comment(table_identifier=test_table_identifier, column='id')}"
         f"{add_column_comment(table_identifier=test_table_identifier, column='data._id')}"
         f"{add_table_comment(table_identifier=test_table_identifier, comment='distribute/example/Test')}"
+        f"{add_changelog_table(table_identifier=test_table_identifier)}"
+        f"{add_redirect_table(table_identifier=test_table_identifier)}"
+        'CREATE TABLE "distribute/new"."New" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        '    CONSTRAINT "pk_New" PRIMARY KEY (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=new_table_identifier, index_name='ix_New__txn', columns=['_txn'])}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='id')}"
+        f"{add_table_comment(table_identifier=new_table_identifier, comment='distribute/new/New')}"
+        f"{add_changelog_table(table_identifier=new_table_identifier)}"
+        f"{add_redirect_table(table_identifier=new_table_identifier)}"
+        f"{add_schema_distribution(schema='distribute/new')}"
+        f"COMMIT;\n\n"
+    )
+    result = cli.invoke(rc, ["migrate"])
+    assert result.exit_code == 0
+
+    updated_citus_state = gather_current_sharding_plan(context, backend)
+    assert updated_citus_state.schemas == {"distribute/new"}
+    assert not updated_citus_state.references
+    assert not updated_citus_state.distributed
+    assert {data_table_identifier, test_table_identifier}.issubset(updated_citus_state.local)
+    assert not {new_table_identifier}.issubset(updated_citus_state.local)
+
+
+def test_migrate_from_empty_default_schema_distribution_invalidation_list(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    initial_manifest = """
+         d                  | r | b | m    | property | type    | ref
+    """
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=initial_manifest,
+        default_distribution_strategy="schema",
+    )
+
+    override_manifest(
+        context,
+        tmp_path,
+        """
+     d                  | r | b | m    | property | type    | ref
+     distribute/example |   |   |      |          |         |
+                        |   |   | Test |          |         |
+                        |   |   |      | id       | integer |
+                        |   |   |      | data[]   | ref     | distribute/data/Data
+     distribute/data    |   |   |      |          |         |
+                        |   |   | Data |          |         |
+                        |   |   |      | id       | integer |
+     distribute/new     |   |   |      |          |         |
+                        |   |   | New  |          |         |
+                        |   |   |      | id       | integer |
+    """,
+    )
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    data_table_identifier = TableIdentifier(schema="distribute/data", base_name="Data")
+    test_table_identifier = TableIdentifier(schema="distribute/example", base_name="Test")
+    test_list_table_identifier = test_table_identifier.change_table_type(new_type=TableType.LIST, table_arg="data")
+    new_table_identifier = TableIdentifier(schema="distribute/new", base_name="New")
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+
+    result = cli.invoke(rc, ["migrate", "-p"])
+    order = (
+        f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__id', columns=['_id'])}"
+        f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__txn', columns=['_txn'])}"
+    )
+    if order not in result.output:
+        order = (
+            f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__txn', columns=['_txn'])}"
+            f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__id', columns=['_id'])}"
+        )
+    assert result.output.endswith(
+        f"BEGIN;\n\n"
+        f"{add_schema('distribute/example')}"
+        f"{add_schema('distribute/data')}"
+        f"{add_schema('distribute/new')}"
+        'CREATE TABLE "distribute/data"."Data" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        '    CONSTRAINT "pk_Data" PRIMARY KEY (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=data_table_identifier, index_name='ix_Data__txn', columns=['_txn'])}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='id')}"
+        f"{add_table_comment(table_identifier=data_table_identifier, comment='distribute/data/Data')}"
+        f"{add_changelog_table(table_identifier=data_table_identifier)}"
+        f"{add_redirect_table(table_identifier=data_table_identifier)}"
+        'CREATE TABLE "distribute/example"."Test" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        "    data JSONB, \n"
+        '    CONSTRAINT "pk_Test" PRIMARY KEY (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test__txn', columns=['_txn'])}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='id')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='data')}"
+        f"{add_table_comment(table_identifier=test_table_identifier, comment='distribute/example/Test')}"
+        'CREATE TABLE "distribute/example"."Test/:list/data" (\n'
+        "    _txn UUID, \n"
+        "    _rid UUID, \n"
+        "    _id UUID, \n"
+        '    CONSTRAINT "fk_Test/:list/data__rid_Test" FOREIGN KEY(_rid) REFERENCES '
+        '"distribute/example"."Test" (_id) ON DELETE CASCADE, \n'
+        '    CONSTRAINT "fk_Test/:list/data__id_distribute/data.Data" FOREIGN '
+        'KEY(_id) REFERENCES "distribute/data"."Data" (_id) ON DELETE CASCADE ON '
+        "UPDATE CASCADE\n"
+        ");\n\n"
+        f"{order}"
+        f"{add_column_comment(table_identifier=test_list_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=test_list_table_identifier, column='_rid')}"
+        f"{add_column_comment(table_identifier=test_list_table_identifier, column='_id')}"
+        f"{add_table_comment(table_identifier=test_list_table_identifier, comment='distribute/example/Test/:list/data')}"
         f"{add_changelog_table(table_identifier=test_table_identifier)}"
         f"{add_redirect_table(table_identifier=test_table_identifier)}"
         'CREATE TABLE "distribute/new"."New" (\n'

--- a/tests/backends/postgresql/commands/migrate/test_citus.py
+++ b/tests/backends/postgresql/commands/migrate/test_citus.py
@@ -439,6 +439,16 @@ def test_migrate_from_empty_default_schema_distribution_invalidation(
     assert not current_citus_state.distributed
 
     result = cli.invoke(rc, ["migrate", "-p"])
+
+    order = (
+        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test_data._id', columns=['data._id'])}"
+        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test__txn', columns=['_txn'])}"
+    )
+    if order not in result.output:
+        order = (
+            f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test__txn', columns=['_txn'])}"
+            f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test_data._id', columns=['data._id'])}"
+        )
     assert result.output.endswith(
         f"BEGIN;\n\n"
         f"{add_schema('distribute/example')}"
@@ -477,8 +487,7 @@ def test_migrate_from_empty_default_schema_distribution_invalidation(
         'KEY("data._id") REFERENCES "distribute/data"."Data" (_id)\n'
         ");\n"
         "\n"
-        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test__txn', columns=['_txn'])}"
-        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test_data._id', columns=['data._id'])}"
+        f"{order}"
         f"{add_column_comment(table_identifier=test_table_identifier, column='_txn')}"
         f"{add_column_comment(table_identifier=test_table_identifier, column='_created')}"
         f"{add_column_comment(table_identifier=test_table_identifier, column='_updated')}"

--- a/tests/backends/postgresql/commands/migrate/test_citus.py
+++ b/tests/backends/postgresql/commands/migrate/test_citus.py
@@ -580,14 +580,30 @@ def test_migrate_from_empty_default_schema_distribution_invalidation_list(
     assert not current_citus_state.distributed
 
     result = cli.invoke(rc, ["migrate", "-p"])
-    order = (
+    index_order = (
         f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__id', columns=['_id'])}"
         f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__txn', columns=['_txn'])}"
     )
-    if order not in result.output:
-        order = (
+    if index_order not in result.output:
+        index_order = (
             f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__txn', columns=['_txn'])}"
             f"{add_index(table_identifier=test_list_table_identifier, index_name='ix_Test/:list/data__id', columns=['_id'])}"
+        )
+
+    constraint_order = (
+        '    CONSTRAINT "fk_Test/:list/data__rid_Test" FOREIGN KEY(_rid) REFERENCES '
+        '"distribute/example"."Test" (_id) ON DELETE CASCADE, \n'
+        '    CONSTRAINT "fk_Test/:list/data__id_distribute/data.Data" FOREIGN '
+        'KEY(_id) REFERENCES "distribute/data"."Data" (_id) ON DELETE CASCADE ON '
+        "UPDATE CASCADE\n"
+    )
+    if constraint_order not in result.output:
+        constraint_order = (
+            '    CONSTRAINT "fk_Test/:list/data__id_distribute/data.Data" FOREIGN '
+            'KEY(_id) REFERENCES "distribute/data"."Data" (_id) ON DELETE CASCADE ON '
+            "UPDATE CASCADE, \n"
+            '    CONSTRAINT "fk_Test/:list/data__rid_Test" FOREIGN KEY(_rid) REFERENCES '
+            '"distribute/example"."Test" (_id) ON DELETE CASCADE\n'
         )
     assert result.output.endswith(
         f"BEGIN;\n\n"
@@ -638,13 +654,9 @@ def test_migrate_from_empty_default_schema_distribution_invalidation_list(
         "    _txn UUID, \n"
         "    _rid UUID, \n"
         "    _id UUID, \n"
-        '    CONSTRAINT "fk_Test/:list/data__rid_Test" FOREIGN KEY(_rid) REFERENCES '
-        '"distribute/example"."Test" (_id) ON DELETE CASCADE, \n'
-        '    CONSTRAINT "fk_Test/:list/data__id_distribute/data.Data" FOREIGN '
-        'KEY(_id) REFERENCES "distribute/data"."Data" (_id) ON DELETE CASCADE ON '
-        "UPDATE CASCADE\n"
+        f"{constraint_order}"
         ");\n\n"
-        f"{order}"
+        f"{index_order}"
         f"{add_column_comment(table_identifier=test_list_table_identifier, column='_txn')}"
         f"{add_column_comment(table_identifier=test_list_table_identifier, column='_rid')}"
         f"{add_column_comment(table_identifier=test_list_table_identifier, column='_id')}"

--- a/tests/backends/postgresql/commands/migrate/test_citus.py
+++ b/tests/backends/postgresql/commands/migrate/test_citus.py
@@ -393,6 +393,136 @@ def test_migrate_mixed_distribution(
     assert not {test_table_identifier, data_table_identifier, new_table_identifier}.issubset(updated_citus_state.local)
 
 
+def test_migrate_from_empty_default_schema_distribution_invalidation(
+    migration_db: Engine,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    tmp_path: Path,
+):
+    initial_manifest = """
+         d                  | r | b | m    | property | type    | ref
+    """
+    context, rc = bootstrap_distribute_manifest(
+        rc=rc,
+        path=tmp_path,
+        manifest=initial_manifest,
+        default_distribution_strategy="schema",
+    )
+
+    override_manifest(
+        context,
+        tmp_path,
+        """
+     d                  | r | b | m    | property | type    | ref
+     distribute/example |   |   |      |          |         |
+                        |   |   | Test |          |         |
+                        |   |   |      | id       | integer |
+                        |   |   |      | data     | ref     | distribute/data/Data
+     distribute/data    |   |   |      |          |         |
+                        |   |   | Data |          |         |
+                        |   |   |      | id       | integer |
+     distribute/new     |   |   |      |          |         |
+                        |   |   | New  |          |         |
+                        |   |   |      | id       | integer |
+    """,
+    )
+    manifest = context.get("store").manifest
+    backend = manifest.backend
+
+    data_table_identifier = TableIdentifier(schema="distribute/data", base_name="Data")
+    test_table_identifier = TableIdentifier(schema="distribute/example", base_name="Test")
+    new_table_identifier = TableIdentifier(schema="distribute/new", base_name="New")
+
+    current_citus_state = gather_current_sharding_plan(context, backend)
+    assert not current_citus_state.schemas
+    assert not current_citus_state.references
+    assert not current_citus_state.distributed
+
+    result = cli.invoke(rc, ["migrate", "-p"])
+    assert result.output.endswith(
+        f"BEGIN;\n\n"
+        f"{add_schema('distribute/example')}"
+        f"{add_schema('distribute/data')}"
+        f"{add_schema('distribute/new')}"
+        'CREATE TABLE "distribute/data"."Data" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        '    CONSTRAINT "pk_Data" PRIMARY KEY (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=data_table_identifier, index_name='ix_Data__txn', columns=['_txn'])}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=data_table_identifier, column='id')}"
+        f"{add_table_comment(table_identifier=data_table_identifier, comment='distribute/data/Data')}"
+        f"{add_changelog_table(table_identifier=data_table_identifier)}"
+        f"{add_redirect_table(table_identifier=data_table_identifier)}"
+        'CREATE TABLE "distribute/example"."Test" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        '    "data._id" UUID, \n'
+        '    CONSTRAINT "pk_Test" PRIMARY KEY (_id), \n'
+        '    CONSTRAINT "fk_Test_data._id_distribute/data.Data" FOREIGN '
+        'KEY("data._id") REFERENCES "distribute/data"."Data" (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test__txn', columns=['_txn'])}"
+        f"{add_index(table_identifier=test_table_identifier, index_name='ix_Test_data._id', columns=['data._id'])}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='id')}"
+        f"{add_column_comment(table_identifier=test_table_identifier, column='data._id')}"
+        f"{add_table_comment(table_identifier=test_table_identifier, comment='distribute/example/Test')}"
+        f"{add_changelog_table(table_identifier=test_table_identifier)}"
+        f"{add_redirect_table(table_identifier=test_table_identifier)}"
+        'CREATE TABLE "distribute/new"."New" (\n'
+        "    _txn UUID, \n"
+        "    _created TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _updated TIMESTAMP WITHOUT TIME ZONE, \n"
+        "    _id UUID NOT NULL, \n"
+        "    _revision TEXT, \n"
+        "    id INTEGER, \n"
+        '    CONSTRAINT "pk_New" PRIMARY KEY (_id)\n'
+        ");\n"
+        "\n"
+        f"{add_index(table_identifier=new_table_identifier, index_name='ix_New__txn', columns=['_txn'])}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_txn')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_created')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_updated')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_id')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='_revision')}"
+        f"{add_column_comment(table_identifier=new_table_identifier, column='id')}"
+        f"{add_table_comment(table_identifier=new_table_identifier, comment='distribute/new/New')}"
+        f"{add_changelog_table(table_identifier=new_table_identifier)}"
+        f"{add_redirect_table(table_identifier=new_table_identifier)}"
+        f"{add_schema_distribution(schema='distribute/new')}"
+        f"COMMIT;\n\n"
+    )
+    result = cli.invoke(rc, ["migrate"])
+    assert result.exit_code == 0
+
+    updated_citus_state = gather_current_sharding_plan(context, backend)
+    assert updated_citus_state.schemas == {"distribute/new"}
+    assert not updated_citus_state.references
+    assert not updated_citus_state.distributed
+    assert {data_table_identifier, test_table_identifier}.issubset(updated_citus_state.local)
+    assert not {new_table_identifier}.issubset(updated_citus_state.local)
+
+
 def test_migrate_default_schema_distribution_invalidation(
     migration_db: Engine,
     rc: RawConfig,


### PR DESCRIPTION
Adds manifest data as part of invalidation step, but will also include database data from inspection. This does increase performance costs (but this action is done rarely), it is needed to make sure that there arent stray / not removed references (in case something was refererenced by hand), for the most part alot of the checks will overlap, but since we use `set`, it shouldn't matter much.

Need to add CHANGES.rst after review