### PR TITLE
2024 refactor push_state_db migration logic

### DIFF
--- a/spinta/cli/helpers/data.py
+++ b/spinta/cli/helpers/data.py
@@ -36,11 +36,11 @@ def _get_row_count(context: components.Context, model: components.Model, page_da
 def count_rows(
     context: Context,
     models: List[Model],
-    limit: int = None,
+    limit: int | None = None,
     *,
-    initial_page_data: dict = None,
+    initial_page_data: dict | None = None,
     stop_on_error: bool = False,
-    error_counter: ErrorCounter = None,
+    error_counter: ErrorCounter | None = None,
     no_progress_bar: bool = False,
 ) -> Dict[str, int]:
     counts = {}
@@ -70,11 +70,11 @@ def count_rows(
 def read_model_data(
     context: components.Context,
     model: components.Model,
-    limit: int = None,
+    limit: int | None = None,
     stop_on_error: bool = False,
-    params: QueryParams = None,
-    page: Page = None,
-    query: Expr = None,
+    params: QueryParams | None = None,
+    page: Page | None = None,
+    query: Expr | None = None,
 ) -> Iterable[Dict[str, Any]]:
     if limit is not None:
         if query is None:
@@ -103,7 +103,7 @@ def read_model_data(
         yield item
 
 
-def filter_allowed_props_for_model(model: Model) -> (list, bool):
+def filter_allowed_props_for_model(model: Model) -> tuple[list, bool]:
     allowed_props = list(model.properties.keys())
     if model.base:
         for name, prop in model.base.parent.properties.items():
@@ -126,7 +126,7 @@ def iter_model_rows(
     context: Context,
     models: List[Model],
     counts: Dict[str, int],
-    limit: int = None,
+    limit: int = None | None,
     *,
     stop_on_error: bool = False,
     no_progress_bar: bool = False,

--- a/spinta/cli/helpers/data.py
+++ b/spinta/cli/helpers/data.py
@@ -126,7 +126,7 @@ def iter_model_rows(
     context: Context,
     models: List[Model],
     counts: Dict[str, int],
-    limit: int = None | None,
+    limit: int | None = None,
     *,
     stop_on_error: bool = False,
     no_progress_bar: bool = False,

--- a/spinta/cli/helpers/push/components.py
+++ b/spinta/cli/helpers/push/components.py
@@ -32,7 +32,6 @@ class PushState(SqliteMigratableDb):
             sa.Column("model", sa.Text, primary_key=True),
             sa.Column("property", sa.Text),
             sa.Column("value", sa.Text),
-            extend_existing=True,
         )
 
     def _default_table_template(

--- a/spinta/cli/helpers/push/components.py
+++ b/spinta/cli/helpers/push/components.py
@@ -6,6 +6,7 @@ from spinta.components import Model, pagination_enabled
 from spinta.utils.sqlite import SqliteMigratableDb
 
 PUSH_STATE_DB = "push.state"
+PUSH_STATE_PATH = "push_state_path"
 PAGE_TYPE_MAPPING = {
     "string": sa.Text,
     "date": sa.Date,
@@ -31,13 +32,17 @@ class PushState(SqliteMigratableDb):
             sa.Column("model", sa.Text, primary_key=True),
             sa.Column("property", sa.Text),
             sa.Column("value", sa.Text),
+            extend_existing=True,
         )
 
     def _default_table_template(
         self, name: str, model: Model | None = None, **kwargs
     ) -> Callable[[sa.MetaData], sa.Table]:
-        if model is None:
+        def _raise_missing_model():
             raise Exception("DEFAULT TABLE TEMPLATE FOR STATE DB REQUIRES model property to be given")
+
+        if model is None:
+            return lambda _: _raise_missing_model()
 
         pagination_cols = []
         if pagination_enabled(model):
@@ -54,7 +59,6 @@ class PushState(SqliteMigratableDb):
             sa.Column("pushed", sa.DateTime),
             sa.Column("error", sa.Boolean),
             sa.Column("data", sa.Text),
-            sa.Column("session_id", sa.Text, index=True),
             *pagination_cols,
         )
 

--- a/spinta/cli/helpers/push/components.py
+++ b/spinta/cli/helpers/push/components.py
@@ -1,13 +1,62 @@
-from typing import Any, Dict, NamedTuple, Optional, TypedDict
+from typing import Any, Callable, Dict, NamedTuple, Optional, TypedDict
 
 import sqlalchemy as sa
 
-from spinta.components import Model
+from spinta.components import Model, pagination_enabled
+from spinta.utils.sqlite import SqliteMigratableDb
+
+PUSH_STATE_DB = "push.state"
+PAGE_TYPE_MAPPING = {
+    "string": sa.Text,
+    "date": sa.Date,
+    "datetime": sa.DateTime,
+    "time": sa.Time,
+    "integer": sa.Integer,
+    "number": sa.Numeric,
+}
 
 
-class State(NamedTuple):
+class PushState(SqliteMigratableDb):
     engine: sa.engine.Engine
     metadata: sa.MetaData
+
+    pagination_table_name: str = "_page"
+
+    def __init__(self, dsn: str):
+        super().__init__(dsn)
+
+        self.metatable_templates[self.pagination_table_name] = lambda metadata: sa.Table(
+            "_page",
+            metadata,
+            sa.Column("model", sa.Text, primary_key=True),
+            sa.Column("property", sa.Text),
+            sa.Column("value", sa.Text),
+        )
+
+    def _default_table_template(
+        self, name: str, model: Model | None = None, **kwargs
+    ) -> Callable[[sa.MetaData], sa.Table]:
+        if model is None:
+            raise Exception("DEFAULT TABLE TEMPLATE FOR STATE DB REQUIRES model property to be given")
+
+        pagination_cols = []
+        if pagination_enabled(model):
+            for prop in model.page.keys.values():
+                _type = PAGE_TYPE_MAPPING.get(prop.dtype.name, sa.Text)
+                pagination_cols.append(sa.Column(f"page.{prop.name}", _type, index=True))
+
+        return lambda metadata: sa.Table(
+            name,
+            metadata,
+            sa.Column("id", sa.Unicode, primary_key=True),
+            sa.Column("checksum", sa.Unicode),
+            sa.Column("revision", sa.Unicode),
+            sa.Column("pushed", sa.DateTime),
+            sa.Column("error", sa.Boolean),
+            sa.Column("data", sa.Text),
+            sa.Column("session_id", sa.Text, index=True),
+            *pagination_cols,
+        )
 
 
 class PushRow:

--- a/spinta/cli/helpers/push/delete.py
+++ b/spinta/cli/helpers/push/delete.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 import tqdm
 
 from spinta import commands
-from spinta.cli.helpers.push.components import PushRow
+from spinta.cli.helpers.push.components import PushRow, PushState
 from spinta.cli.helpers.push.utils import construct_where_condition_from_page, extract_state_page_keys
 from spinta.cli.helpers.push.write import prepare_rows_for_deletion
 from spinta.commands.read import PaginationMetaData, get_paginated_values
@@ -14,16 +14,16 @@ from spinta.components import Context, Model, get_page_size, pagination_enabled
 def get_deleted_rows(
     models: List[Model],
     context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
     no_progress_bar: bool = False,
 ):
-    counts = _get_deleted_row_counts(models, context, metadata)
+    counts = _get_deleted_row_counts(models, push_state)
     total_count = sum(counts.values())
     if total_count > 0:
         rows = _iter_deleted_rows(
             models,
             context,
-            metadata,
+            push_state,
             counts,
             no_progress_bar,
         )
@@ -35,13 +35,12 @@ def get_deleted_rows(
 
 def _get_deleted_row_counts(
     models: List[Model],
-    context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
 ) -> dict:
     counts = {}
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     for model in models:
-        table = metadata.tables[model.name]
+        table = push_state.get_table(name=model.name, model=model)
 
         row_count = conn.execute(
             sa.select(sa.func.count(table.c.id)).where(sa.and_(table.c.pushed.is_(None), table.c.error.is_(False)))
@@ -53,25 +52,20 @@ def _get_deleted_row_counts(
 def _iter_deleted_rows(
     models: List[Model],
     context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
     counts: Dict[str, int],
     no_progress_bar: bool = False,
 ) -> Iterable[PushRow]:
     models = reversed(models)
     config = context.get("config")
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     for model in models:
         size = get_page_size(config, model)
-        table = metadata.tables[model.name]
+        table = push_state.get_table(name=model.name, model=model)
         total = counts.get(model.name)
 
         if pagination_enabled(model):
-            rows = _get_deleted_rows_with_page(
-                context,
-                model,
-                table,
-                size,
-            )
+            rows = _get_deleted_rows_with_page(model, table, size, push_state)
         else:
             rows = conn.execute(sa.select([table.c.id]).where(table.c.pushed.is_(None) & table.c.error.is_(False)))
         if not no_progress_bar:
@@ -82,12 +76,12 @@ def _iter_deleted_rows(
 
 
 def _get_deleted_rows_with_page(
-    context: Context,
     model: Model,
     table: sa.Table,
     size: int,
+    push_state: PushState,
 ) -> sa.engine.LegacyCursorResult:
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
 
     order_by = []
     page = commands.create_page(model.page)

--- a/spinta/cli/helpers/push/error.py
+++ b/spinta/cli/helpers/push/error.py
@@ -7,6 +7,7 @@ import tqdm
 from spinta import commands
 from spinta.cli.helpers.data import ModelRow
 from spinta.cli.helpers.errors import ErrorCounter
+from spinta.cli.helpers.push.components import PushState
 from spinta.cli.helpers.push.utils import construct_where_condition_from_page
 from spinta.cli.helpers.push.write import prepare_rows_with_errors
 from spinta.components import Context, Model, get_page_size, pagination_enabled
@@ -18,7 +19,7 @@ def get_rows_with_errors(
     server: str,
     models: List[Model],
     context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
     counts: Dict[str, int],
     retry: int,
     timeout: tuple[float, float],
@@ -30,7 +31,7 @@ def get_rows_with_errors(
         server,
         models,
         context,
-        metadata,
+        push_state,
         counts,
         timeout,
         no_progress_bar,
@@ -44,16 +45,13 @@ def get_rows_with_errors(
 
 def get_rows_with_errors_counts(
     models: List[Model],
-    context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
 ) -> dict:
     counts = {}
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     for model in models:
-        table = metadata.tables[model.name]
-
+        table = push_state.get_table(name=model.name, model=model)
         row_count = conn.execute(sa.select(sa.func.count(table.c.id)).where(table.c.error.is_(True)))
-
         counts[model.name] = row_count.scalar()
     return counts
 
@@ -63,41 +61,43 @@ def _iter_rows_with_errors(
     server: str,
     models: List[Model],
     context: Context,
-    metadata: sa.MetaData,
+    push_state: PushState,
     counts: Dict[str, int],
     timeout: tuple[float, float],
     no_progress_bar: bool = False,
     error_counter: ErrorCounter = None,
 ) -> Iterable[ModelRow]:
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     config = context.get("config")
 
     for model in models:
         size = get_page_size(config, model)
-        table = metadata.tables[model.name]
+        table = push_state.get_table(name=model.name, model=model)
 
         if pagination_enabled(model):
             rows = _get_error_rows_with_page(
-                context,
                 model,
                 table,
                 size,
+                push_state,
             )
         else:
             rows = conn.execute(sa.select([table.c.id, table.c.checksum, table.c.data]).where(table.c.error.is_(True)))
         if not no_progress_bar:
             rows = tqdm.tqdm(rows, model.name, ascii=True, total=counts.get(model.name), leave=False)
 
-        yield from prepare_rows_with_errors(client, server, context, rows, model, table, timeout, error_counter)
+        yield from prepare_rows_with_errors(
+            client, server, context, rows, model, table, timeout, push_state, error_counter
+        )
 
 
 def _get_error_rows_with_page(
-    context: Context,
     model: Model,
     table: sa.Table,
     size: int,
+    push_state: PushState,
 ):
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     order_by = []
 
     page = commands.create_page(model.page)

--- a/spinta/cli/helpers/push/read.py
+++ b/spinta/cli/helpers/push/read.py
@@ -8,7 +8,7 @@ import tqdm
 from spinta import commands
 from spinta.cli.helpers.data import ModelRow, count_rows, read_model_data
 from spinta.cli.helpers.errors import ErrorCounter
-from spinta.cli.helpers.push.components import PUSH_NOW, PushRow, State
+from spinta.cli.helpers.push.components import PUSH_NOW, PushRow, PushState
 from spinta.cli.helpers.push.delete import get_deleted_rows
 from spinta.cli.helpers.push.error import get_rows_with_errors, get_rows_with_errors_counts
 from spinta.cli.helpers.push.utils import (
@@ -26,7 +26,7 @@ def _iter_model_rows(
     context: Context,
     models: List[Model],
     counts: Dict[str, int],
-    metadata: sa.MetaData,
+    push_state: PushState,
     limit: int = None,
     *,
     initial_page_data: dict = None,
@@ -44,11 +44,10 @@ def _iter_model_rows(
         if not no_progress_bar:
             count = counts.get(model.name)
             model_push_counter = tqdm.tqdm(desc=model.name, ascii=True, total=count, leave=False)
-
         if pagination_enabled(model):
             page = commands.create_page(model.page, initial_page_data.get(model.model_type(), None))
             rows = _read_rows_by_pages(
-                context, model, page, metadata, limit, stop_on_error, push_counter, model_push_counter, params=params
+                context, model, page, push_state, limit, stop_on_error, push_counter, model_push_counter, params=params
             )
             for row in rows:
                 yield row
@@ -68,7 +67,7 @@ def _iter_model_rows(
 def _get_model_rows(
     context: Context,
     models: List[Model],
-    metadata: sa.MetaData,
+    push_state: PushState,
     limit: int = None,
     *,
     initial_page_data: dict,
@@ -95,7 +94,7 @@ def _get_model_rows(
         context,
         models,
         counts,
-        metadata,
+        push_state,
         limit,
         initial_page_data=initial_page_data,
         stop_on_error=stop_on_error,
@@ -114,7 +113,7 @@ def read_rows(
     client: requests.Session,
     server: str,
     models: List[Model],
-    state: State,
+    push_state: PushState,
     limit: int = None,
     *,
     timeout: tuple[float, float],
@@ -130,7 +129,7 @@ def read_rows(
     yield from _get_model_rows(
         context,
         models,
-        state.metadata,
+        push_state,
         limit,
         stop_on_error=stop_on_error,
         no_progress_bar=no_progress_bar,
@@ -142,13 +141,13 @@ def read_rows(
     yield from get_deleted_rows(
         models,
         context,
-        state.metadata,
+        push_state,
         no_progress_bar=no_progress_bar,
     )
 
     for i in range(1, retry_count + 1):
         yield PUSH_NOW
-        counts = get_rows_with_errors_counts(models, context, state.metadata)
+        counts = get_rows_with_errors_counts(models, push_state)
         total_count = sum(counts.values())
 
         if total_count > 0:
@@ -157,7 +156,7 @@ def read_rows(
                 server,
                 models,
                 context,
-                state.metadata,
+                push_state,
                 counts,
                 retry=i,
                 timeout=timeout,
@@ -172,19 +171,19 @@ def _read_rows_by_pages(
     context: Context,
     model: Model,
     page: Page,
-    metadata: sa.MetaData,
-    limit: int = None,
+    push_state: PushState,
+    limit: int | None = None,
     stop_on_error: bool = False,
-    push_counter: tqdm.tqdm = None,
-    model_push_counter: tqdm.tqdm = None,
-    params: QueryParams = None,
+    push_counter: tqdm.tqdm | None = None,
+    model_push_counter: tqdm.tqdm | None = None,
+    params: QueryParams | None = None,
 ) -> Iterator[PushRow]:
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     config = context.get("config")
 
     size = get_page_size(config, model)
-    model_table = metadata.tables[model.name]
-    state_rows = _get_state_rows_with_page(context, deepcopy(page), model_table, size)
+    model_table = push_state.get_table(name=model.name, model=model)
+    state_rows = _get_state_rows_with_page(deepcopy(page), model_table, size, push_state)
     rows = read_model_data(context, model, page=deepcopy(page), limit=limit, stop_on_error=stop_on_error, params=params)
     total_count = 0
     data_push_count = 0
@@ -201,7 +200,7 @@ def _read_rows_by_pages(
         update_counter = True
 
         if data_push_count >= size or state_push_count >= size:
-            state_rows = _get_state_rows_with_page(context, deepcopy(page), model_table, size)
+            state_rows = _get_state_rows_with_page(deepcopy(page), model_table, size, push_state)
             rows = read_model_data(context, model, page=deepcopy(page), limit=limit, stop_on_error=stop_on_error)
 
             data_push_count = 0
@@ -274,9 +273,12 @@ def _read_rows_by_pages(
 
 
 def _get_state_rows_with_page(
-    context: Context, model_page: Page, table: sa.Table, size: int
+    model_page: Page,
+    table: sa.Table,
+    size: int,
+    push_state: PushState,
 ) -> sa.engine.LegacyCursorResult:
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
     model_page.size = size + 1
     order_by = []
 

--- a/spinta/cli/helpers/push/state.py
+++ b/spinta/cli/helpers/push/state.py
@@ -44,7 +44,7 @@ def init_push_state(
             # Legacy self-healing destructive migrations (fixes issues with changed pagination columns)
             inspector = sa.inspect(state.engine)
             for model in models:
-                expected_table = state._default_table_template(name=model.name, model=model)(state.metadata)
+                expected_table = state.get_table(name=model.name, model=model)
                 migrate_table(
                     state.engine,
                     state.metadata,

--- a/spinta/cli/helpers/push/state.py
+++ b/spinta/cli/helpers/push/state.py
@@ -1,96 +1,54 @@
 import datetime
 import itertools
 import json
-from typing import Iterable, Iterator, List, Tuple
+from typing import Iterable, Iterator, List
 
 import sqlalchemy as sa
 
 from spinta import spyna
 from spinta.cli.helpers.push import prepare_data_for_push_state
-from spinta.cli.helpers.push.components import PushRow, Saved
+from spinta.cli.helpers.push.components import PushRow, PushState, Saved
 from spinta.cli.helpers.push.utils import get_data_checksum
 from spinta.components import Context, Model, pagination_enabled
 from spinta.utils.json import fix_data_for_json
-from spinta.utils.sqlite import migrate_table
 
 
 def init_push_state(
     dburi: str,
     models: List[Model],
-) -> Tuple[sa.engine.Engine, sa.MetaData]:
-    engine = sa.create_engine(dburi)
-    metadata = sa.MetaData(engine)
-    inspector = sa.inspect(engine)
+) -> PushState:
+    state = PushState(dburi)
 
-    page_table = sa.Table(
-        "_page",
-        metadata,
-        sa.Column("model", sa.Text, primary_key=True),
-        sa.Column("property", sa.Text),
-        sa.Column("value", sa.Text),
-    )
-    page_table.create(checkfirst=True)
+    # Initialize metadata tables
+    state.create_all_metatables()
 
-    types = {
-        "string": sa.Text,
-        "date": sa.Date,
-        "datetime": sa.DateTime,
-        "time": sa.Time,
-        "integer": sa.Integer,
-        "number": sa.Numeric,
-    }
-
+    # Create all model tables
     for model in models:
-        pagination_cols = []
-        if pagination_enabled(model):
-            for prop in model.page.keys.values():
-                _type = types.get(prop.dtype.name, sa.Text)
-                pagination_cols.append(sa.Column(f"page.{prop.name}", _type, index=True))
-
-        table = sa.Table(
-            model.name,
-            metadata,
-            sa.Column("id", sa.Unicode, primary_key=True),
-            sa.Column("checksum", sa.Unicode),
-            sa.Column("revision", sa.Unicode),
-            sa.Column("pushed", sa.DateTime),
-            sa.Column("error", sa.Boolean),
-            sa.Column("data", sa.Text),
-            *pagination_cols,
-        )
-        migrate_table(
-            engine,
-            metadata,
-            inspector,
-            table,
-            renames={
-                "rev": "checksum",
-            },
-        )
-
-    return engine, metadata
+        state.get_table(name=model.name, model=model)
+    return state
 
 
 def reset_pushed(
     context: Context,
     models: List[Model],
-    metadata: sa.MetaData,
+    push_state: PushState,
 ):
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
+
     for model in models:
-        table = metadata.tables[model.name]
+        table = push_state.get_table(model.name)
 
         # reset pushed so we could see which objects were deleted
         conn.execute(table.update().values(pushed=None))
 
 
-def check_push_state(context: Context, rows: Iterable[PushRow], metadata: sa.MetaData):
-    conn = context.get("push.state.conn")
+def check_push_state(rows: Iterable[PushRow], push_state: PushState):
+    conn = push_state.conn
 
     for model_type, group in itertools.groupby(rows, key=_get_model_type):
         saved_rows = {}
         if model_type:
-            table = metadata.tables[model_type]
+            table = push_state.get_table(model_type)
 
             query = sa.select([table.c.id, table.c.revision, table.c.checksum])
             saved_rows = {
@@ -125,13 +83,13 @@ def check_push_state(context: Context, rows: Iterable[PushRow], metadata: sa.Met
 def save_push_state(
     context: Context,
     rows: Iterable[PushRow],
-    metadata: sa.MetaData,
+    push_state: PushState,
 ) -> Iterator[PushRow]:
-    conn = context.get("push.state.conn")
-    page_table = metadata.tables["_page"]
+    conn = push_state.conn
+    page_table = push_state.get_table(push_state.pagination_table_name)
     model_pagination_check = {}
     for row in rows:
-        table = metadata.tables[row.data["_type"]]
+        table = push_state.get_table(row.data["_type"])
         model_name = row.model.model_type()
         if model_name not in model_pagination_check:
             model_pagination_check[model_name] = pagination_enabled(row.model)

--- a/spinta/cli/helpers/push/state.py
+++ b/spinta/cli/helpers/push/state.py
@@ -5,27 +5,85 @@ from typing import Iterable, Iterator, List
 
 import sqlalchemy as sa
 
-from spinta import spyna
+from spinta import commands, spyna
 from spinta.cli.helpers.push import prepare_data_for_push_state
-from spinta.cli.helpers.push.components import PushRow, PushState, Saved
+from spinta.cli.helpers.push.components import PUSH_STATE_PATH, PushRow, PushState, Saved
 from spinta.cli.helpers.push.utils import get_data_checksum
+from spinta.cli.helpers.script.components import ScriptTag, ScriptTarget
+from spinta.cli.helpers.script.helpers import sort_scripts_by_required
+from spinta.cli.helpers.upgrade.registry import upgrade_script_registry
 from spinta.components import Context, Model, pagination_enabled
+from spinta.exceptions import PushStateMigrationRequired
 from spinta.utils.json import fix_data_for_json
 
 
 def init_push_state(
+    context: Context,
     dburi: str,
     models: List[Model],
 ) -> PushState:
     state = PushState(dburi)
+    context.set(PUSH_STATE_PATH, dburi)
+    with state:
+        is_fresh = is_fresh_database(context, state)
+        # Initialize missing metadata tables
+        state.create_all_metatables()
 
-    # Initialize metadata tables
-    state.create_all_metatables()
+        # Create all missing model tables
+        for model in models:
+            state.get_table(name=model.name, model=model)
 
-    # Create all model tables
-    for model in models:
-        state.get_table(name=model.name, model=model)
+        if is_fresh:
+            mark_migrations(push_state=state)
+        else:
+            validate_migrations(context, state)
     return state
+
+
+def is_fresh_database(context: Context, push_state: PushState) -> bool:
+    insp = sa.inspect(push_state.engine)
+    tables = insp.get_table_names()
+
+    if not len(tables):
+        return True
+
+    for metatable_name in push_state.metatable_templates.keys():
+        if metatable_name in tables:
+            return False
+
+    tables = [table for table in tables if not table.startswith("_")]
+    manifest = context.get("store").manifest
+    for table in tables:
+        if commands.has_model(context, manifest, table):
+            return False
+
+    return True
+
+
+def mark_migrations(push_state: PushState):
+    # Mark all migration scripts as already executed
+    migration_scripts = upgrade_script_registry.get_all(
+        targets={ScriptTarget.PUSH_STATE_DB.value}, tags={ScriptTag.DB_MIGRATION.value}
+    )
+    filtered = sort_scripts_by_required(migration_scripts)
+    for script in filtered.values():
+        push_state.mark_migration(script.name)
+
+
+def validate_migrations(context: Context, push_state: PushState):
+    config = context.get("config")
+    if config.upgrade_mode:
+        return
+
+    migration_scripts = upgrade_script_registry.get_all(
+        targets={ScriptTarget.PUSH_STATE_DB.value}, tags={ScriptTag.DB_MIGRATION.value}
+    )
+    filtered = sort_scripts_by_required(migration_scripts)
+    for script in filtered.values():
+        if script.check(context):
+            raise PushStateMigrationRequired(
+                dsn=push_state.dsn, migration=script.name, path=push_state.engine.url.database
+            )
 
 
 def reset_pushed(

--- a/spinta/cli/helpers/push/state.py
+++ b/spinta/cli/helpers/push/state.py
@@ -15,6 +15,7 @@ from spinta.cli.helpers.upgrade.registry import upgrade_script_registry
 from spinta.components import Context, Model, pagination_enabled
 from spinta.exceptions import PushStateMigrationRequired
 from spinta.utils.json import fix_data_for_json
+from spinta.utils.sqlite import migrate_table
 
 
 def init_push_state(
@@ -23,7 +24,9 @@ def init_push_state(
     models: List[Model],
 ) -> PushState:
     state = PushState(dburi)
-    context.set(PUSH_STATE_PATH, dburi)
+    if not context.has(PUSH_STATE_PATH):
+        context.set(PUSH_STATE_PATH, dburi)
+
     with state:
         is_fresh = is_fresh_database(context, state)
         # Initialize missing metadata tables
@@ -37,6 +40,20 @@ def init_push_state(
             mark_migrations(push_state=state)
         else:
             validate_migrations(context, state)
+
+            # Legacy self-healing destructive migrations (fixes issues with changed pagination columns)
+            inspector = sa.inspect(state.engine)
+            for model in models:
+                expected_table = state._default_table_template(name=model.name, model=model)(state.metadata)
+                migrate_table(
+                    state.engine,
+                    state.metadata,
+                    inspector,
+                    expected_table,
+                    renames={
+                        "rev": "checksum",
+                    },
+                )
     return state
 
 

--- a/spinta/cli/helpers/push/sync.py
+++ b/spinta/cli/helpers/push/sync.py
@@ -11,6 +11,7 @@ from spinta.backends.constants import BackendFeatures
 from spinta.cli.helpers.errors import ErrorCounter
 from spinta.cli.helpers.message import cli_message
 from spinta.cli.helpers.push import prepare_data_for_push_state
+from spinta.cli.helpers.push.components import PushState
 from spinta.cli.helpers.push.utils import construct_where_condition_from_page, extract_state_page_id_key
 from spinta.commands.read import PaginationMetaData, get_paginated_values
 from spinta.components import Config, Context, Model, Page, PageBy, Property, get_page_size
@@ -92,8 +93,12 @@ def _fetch_all_model_data(
             break
 
 
-def _get_state_rows_with_id(context: Context, table: sa.Table, size: int) -> sa.engine.LegacyCursorResult:
-    conn = context.get("push.state.conn")
+def _get_state_rows_with_id(
+    table: sa.Table,
+    size: int,
+    push_state: PushState,
+) -> sa.engine.LegacyCursorResult:
+    conn = push_state.conn
 
     model_page = Page()
     model_page.size = size + 1
@@ -149,7 +154,7 @@ def _update_row_from_push_state(
     if target_checksum == state_checksum:
         skip_update = True
         # Check if pushed state did not have errors while pushing already existing data
-        if getattr(state_row, "error") or getattr(state_row, "data"):
+        if getattr(state_row, "error") or getattr(state_row, "data") or not getattr(state_row, "pushed"):
             skip_update = False
 
         # Check if revisions match, they need match in order to do proper updates
@@ -226,13 +231,14 @@ def sync_push_state(
     models: List[Model],
     error_counter: ErrorCounter,
     no_progress_bar: bool,
-    metadata: sa.MetaData,
+    push_state: PushState,
     timeout: tuple[float, float],
     max_retries: int,
     delay_range: tuple[float],
 ):
     config = context.get("config")
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
+
     counters = {}
     main_bar = None
     if not no_progress_bar:
@@ -256,7 +262,7 @@ def sync_push_state(
         if skip_model:
             continue
 
-        model_table = metadata.tables[model.name]
+        model_table = push_state.get_table(name=model.name, model=model)
 
         if not no_progress_bar:
             counters[model_name] = tqdm.tqdm(desc=model_name, ascii=True)
@@ -273,7 +279,7 @@ def sync_push_state(
             progress_bar=counters.get(model_name, main_bar),
         )
 
-        state_data = _get_state_rows_with_id(context=context, table=model_table, size=size)
+        state_data = _get_state_rows_with_id(table=model_table, size=size, push_state=push_state)
         target_row = next(target_data, None)
         state_row = next(state_data, None)
         while target_row is not None or state_row is not None:

--- a/spinta/cli/helpers/push/utils.py
+++ b/spinta/cli/helpers/push/utils.py
@@ -8,7 +8,7 @@ from sqlalchemy.engine.row import Row
 
 from spinta import commands
 from spinta.auth import authorized
-from spinta.cli.helpers.push.components import PushRow
+from spinta.cli.helpers.push.components import PushRow, PushState
 from spinta.components import Context, Model, Page, pagination_enabled
 from spinta.core.enums import Action
 from spinta.types.datatype import Ref
@@ -79,14 +79,12 @@ def extract_dependant_nodes(context: Context, models: List[Model], filter_pushed
     return extracted_models
 
 
-def load_initial_page_data(
-    context: Context, metadata: sa.MetaData, models: List[Model], incremental: bool, override_page: dict
-) -> dict:
+def load_initial_page_data(push_state: PushState, models: List[Model], incremental: bool, override_page: dict) -> dict:
     if not incremental:
         return {}
 
-    conn = context.get("push.state.conn")
-    table = metadata.tables["_page"]
+    conn = push_state.conn
+    table = push_state.get_table(push_state.pagination_table_name)
     result = {}
 
     for model in models:

--- a/spinta/cli/helpers/push/write.py
+++ b/spinta/cli/helpers/push/write.py
@@ -15,7 +15,7 @@ import spinta.cli.push as cli_push
 from spinta import spyna
 from spinta.cli.helpers.data import ModelRow
 from spinta.cli.helpers.errors import ErrorCounter
-from spinta.cli.helpers.push.components import Error, PushRow, State
+from spinta.cli.helpers.push.components import Error, PushRow, PushState
 from spinta.cli.helpers.push.state import check_push_state, save_push_state
 from spinta.cli.helpers.push.utils import get_data_checksum
 from spinta.components import Context, Model
@@ -54,9 +54,11 @@ def prepare_rows_with_errors(
     model: Model,
     table: sa.Table,
     timeout: Tuple[float, float],
+    push_state: PushState,
     error_counter: ErrorCounter = None,
 ) -> Iterable[ModelRow]:
-    conn = context.get("push.state.conn")
+    conn = push_state.conn
+
     for row in rows:
         type = model.model_type()
         _id = row[table.c.id]
@@ -389,19 +391,19 @@ def push(
     rows: Iterable[PushRow],
     timeout: Tuple[float, float],
     *,
-    state: Optional[State] = None,
+    push_state: Optional[PushState] = None,
     stop_time: Optional[int] = None,  # seconds
     stop_row: Optional[int] = None,  # stop aftern given number of rows
     chunk_size: Optional[int] = None,  # split into chunks of given size in bytes
     dry_run: bool = False,  # do not send or write anything
     stop_on_error: bool = False,  # raise error immediately
-    error_counter: ErrorCounter = None,
+    error_counter: ErrorCounter | None = None,
 ) -> None:
     if stop_time:
         rows = _add_stop_time(rows, stop_time)
 
-    if state:
-        rows = check_push_state(context, rows, state.metadata)
+    if push_state:
+        rows = check_push_state(rows, push_state)
 
     rows = _prepare_rows_for_push(rows)
 
@@ -411,8 +413,8 @@ def push(
     rows = _push_to_remote_spinta(
         client, server, rows, chunk_size, dry_run=dry_run, error_counter=error_counter, timeout=timeout
     )
-    if state and not dry_run:
-        rows = save_push_state(context, rows, state.metadata)
+    if push_state and not dry_run:
+        rows = save_push_state(context, rows, push_state)
 
     _push_rows(rows, stop_on_error, error_counter)
 

--- a/spinta/cli/helpers/script/components.py
+++ b/spinta/cli/helpers/script/components.py
@@ -122,6 +122,7 @@ class ScriptStatus(enum.Enum):
 @enum.unique
 class ScriptTarget(enum.Enum):
     SQLALCHEMY_KEYMAP = "sqlalchemy_keymap"
+    PUSH_STATE_DB = "push_state_db"
     FS = "file_system"
     AUTH = "auth"
     BACKEND = "backend"

--- a/spinta/cli/helpers/script/core.py
+++ b/spinta/cli/helpers/script/core.py
@@ -15,9 +15,11 @@ def run_all_scripts(
     force: bool = False,
     check_only: bool = False,
     status_cache: ScriptStatusCache | None = None,
+    targets: set[str] | None = None,
+    tags: set[str] | None = None,
     **kwargs,
 ):
-    scripts = script_registry.get_all(script_type)
+    scripts = script_registry.get_all(script_type, targets=targets, tags=tags)
     sorted_scripts = sort_scripts_by_required(scripts)
     for script_name in sorted_scripts.keys():
         run_specific_script(

--- a/spinta/cli/helpers/upgrade/components.py
+++ b/spinta/cli/helpers/upgrade/components.py
@@ -24,3 +24,7 @@ class Script(enum.Enum):
     SQL_KEYMAP_INITIAL = "sqlalchemy_keymap_001_initial"
     SQL_KEYMAP_REDIRECT = "sqlalchemy_keymap_002_redirect_support"
     SQL_KEYMAP_MODIFIED = "sqlalchemy_keymap_003_add_modified_time"
+
+    # Push state migrations
+    PUSH_STATE_INITIAL = "push_state_db_001_initial"
+    PUSH_REV_RENAME = "push_state_db_002_rev_rename"

--- a/spinta/cli/helpers/upgrade/registry.py
+++ b/spinta/cli/helpers/upgrade/registry.py
@@ -24,6 +24,14 @@ from spinta.cli.helpers.upgrade.scripts.keymaps.sqlalchemy.redirect_support impo
     requires_sql_keymap_redirect_migration,
     sql_keymap_redirect_migration,
 )
+from spinta.cli.helpers.upgrade.scripts.push_state.initial_setup import (
+    push_state_initial_migration,
+    requires_push_state_initial_migration,
+)
+from spinta.cli.helpers.upgrade.scripts.push_state.rename_rev import (
+    push_state_rename_rev_migration,
+    requires_push_state_rename_rev_migration,
+)
 from spinta.cli.helpers.upgrade.scripts.redirect import cli_requires_redirect_migration, migrate_redirect
 
 # For convenience, easier access to upgrade scripts
@@ -97,5 +105,26 @@ script_registry.register(
         required=[Script.SQL_KEYMAP_REDIRECT.value],
         targets={ScriptTarget.SQLALCHEMY_KEYMAP.value},
         tags={ScriptTag.DB_MIGRATION.value},
+    )
+)
+
+# Push state migrations
+script_registry.register(
+    UpgradeScript(
+        name=Script.PUSH_STATE_INITIAL.value,
+        run=push_state_initial_migration,
+        check=requires_push_state_initial_migration,
+        targets={ScriptTarget.PUSH_STATE_DB.value},
+        tags={ScriptTag.DB_MIGRATION.value},
+    )
+)
+script_registry.register(
+    UpgradeScript(
+        name=Script.PUSH_REV_RENAME.value,
+        run=push_state_rename_rev_migration,
+        check=requires_push_state_rename_rev_migration,
+        targets={ScriptTarget.PUSH_STATE_DB.value},
+        tags={ScriptTag.DB_MIGRATION.value},
+        required=[Script.PUSH_STATE_INITIAL.value],
     )
 )

--- a/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/helpers.py
+++ b/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/helpers.py
@@ -23,7 +23,8 @@ def outdated_keymaps(context: Context, migration: str, additional_check: Callabl
 def apply_migration_to_outdated_keymaps(context: Context, migration: str, apply_migration: Callable, **kwargs):
     keymaps = outdated_keymaps(context, migration, None, **kwargs)
     for keymap in keymaps:
-        apply_migration_to_outdated_db(context, keymap, migration, apply_migration, keymap.name, **kwargs)
+        with keymap:
+            apply_migration_to_outdated_db(context, keymap, migration, apply_migration, keymap.name, **kwargs)
 
 
 def requires_migration(context: Context, migration: str, additional_check: Callable | None = None, **kwargs) -> bool:

--- a/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/helpers.py
+++ b/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/helpers.py
@@ -1,15 +1,14 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from typer import echo
-
 from spinta.components import Context, Store
+from spinta.utils.sqlite import apply_migration_to_outdated_db, outdated_sqlite_db
 
 if TYPE_CHECKING:
     from spinta.datasets.keymaps.sqlalchemy import SqlAlchemyKeyMap
 
 
-def outdated_keymaps(context: Context, migration: str, additional_check: Callable = None, **kwargs):
+def outdated_keymaps(context: Context, migration: str, additional_check: Callable | None = None, **kwargs):
     from spinta.datasets.keymaps.sqlalchemy import SqlAlchemyKeyMap
 
     store: Store = context.get("store")
@@ -17,26 +16,17 @@ def outdated_keymaps(context: Context, migration: str, additional_check: Callabl
         if not isinstance(keymap, SqlAlchemyKeyMap):
             continue
 
-        with keymap:
-            contains = keymap.contains_migration(migration)
-            if not contains:
-                yield keymap
-                continue
-
-            if additional_check and additional_check(context, **kwargs):
-                yield keymap
-                continue
+        if outdated_sqlite_db(context, keymap, migration, additional_check, **kwargs):
+            yield keymap
 
 
-def apply_migration_to_outdated_keymaps(context: Context, migration: str, apply_migration: callable, **kwargs):
+def apply_migration_to_outdated_keymaps(context: Context, migration: str, apply_migration: Callable, **kwargs):
     keymaps = outdated_keymaps(context, migration, None, **kwargs)
     for keymap in keymaps:
-        echo(f'\tApplying "{migration}" migration to keymap ("{keymap.name}")')
-        apply_migration(context, keymap, migration)
-        keymap.mark_migration(migration)
+        apply_migration_to_outdated_db(context, keymap, migration, apply_migration, keymap.name, **kwargs)
 
 
-def requires_migration(context: Context, migration: str, additional_check: Callable = None, **kwargs) -> bool:
+def requires_migration(context: Context, migration: str, additional_check: Callable | None = None, **kwargs) -> bool:
     keymaps = outdated_keymaps(context, migration, additional_check, **kwargs)
     for _ in keymaps:
         return True

--- a/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/redirect_support.py
+++ b/spinta/cli/helpers/upgrade/scripts/keymaps/sqlalchemy/redirect_support.py
@@ -64,7 +64,7 @@ def migrate_table(keymap: "SqlAlchemyKeyMap", table: sa.Table):
             if temp_table in keymap.metadata.tables:
                 temp_table_exists = True
 
-            new_table = keymap._create_table(temp_table)
+            new_table = keymap.get_table(temp_table, create_missing=True)
             temp_table_exists = True
 
             count_stmt = sa.select(sa.func.count()).select_from(table)

--- a/spinta/cli/helpers/upgrade/scripts/push_state/helpers.py
+++ b/spinta/cli/helpers/upgrade/scripts/push_state/helpers.py
@@ -1,0 +1,50 @@
+from typing import Callable
+
+from spinta.cli.helpers.message import cli_message
+from spinta.cli.helpers.push.components import PUSH_STATE_PATH, PushState
+from spinta.components import Context
+from spinta.utils.sqlite import apply_migration_to_outdated_db, outdated_sqlite_db
+
+
+def requires_migration(context: Context, migration: str, additional_check: Callable | None = None, **kwargs) -> bool:
+    push_state = get_push_state(context)
+
+    if push_state is None:
+        cli_message(
+            f"Skipped {migration!r} check, please provide -o push_state_path=<path> in order to run this migration"
+        )
+        return False
+
+    return outdated_sqlite_db(context, push_state, migration, additional_check, **kwargs)
+
+
+def apply_migration_to_push_state(context: Context, migration: str, apply_migration: Callable, **kwargs):
+    push_state = get_push_state(context)
+
+    if push_state is None:
+        cli_message(
+            f"Skipped {migration!r} check, please provide -o push_state_path=<path> in order to run this migration"
+        )
+        return
+
+    with push_state:
+        apply_migration_to_outdated_db(
+            context, push_state, migration, apply_migration, push_state.dsn or "push_state_db", **kwargs
+        )
+
+
+def get_push_state(context: Context) -> PushState | None:
+    rc = context.get("rc")
+    push_state_path = rc.get(PUSH_STATE_PATH)
+
+    # RawConfig given push state path is only file path
+    if push_state_path:
+        push_state_path = f"sqlite+spinta:///{push_state_path}"
+        return PushState(push_state_path)
+
+    # Context given push state path is set when calling init_push_state, which set dsn and not direct path
+    if context.has(PUSH_STATE_PATH):
+        push_state_path = context.get(PUSH_STATE_PATH)
+        return PushState(push_state_path)
+
+    return None

--- a/spinta/cli/helpers/upgrade/scripts/push_state/initial_setup.py
+++ b/spinta/cli/helpers/upgrade/scripts/push_state/initial_setup.py
@@ -1,0 +1,16 @@
+from spinta.cli.helpers.push.components import PushState
+from spinta.cli.helpers.upgrade.components import Script
+from spinta.cli.helpers.upgrade.scripts.push_state.helpers import apply_migration_to_push_state, requires_migration
+from spinta.components import Context
+
+
+def requires_push_state_initial_migration(context: Context, **kwargs) -> bool:
+    return requires_migration(context, Script.PUSH_STATE_INITIAL.value, None, **kwargs)
+
+
+def push_state_initial_migration(context: Context, **kwargs):
+    apply_migration_to_push_state(context, Script.PUSH_STATE_INITIAL.value, apply_migration, **kwargs)
+
+
+def apply_migration(context: Context, push_state: PushState, migration: str):
+    push_state.create_all_metatables()

--- a/spinta/cli/helpers/upgrade/scripts/push_state/rename_rev.py
+++ b/spinta/cli/helpers/upgrade/scripts/push_state/rename_rev.py
@@ -1,0 +1,40 @@
+import sqlalchemy as sa
+
+from spinta.cli.helpers.push.components import PushState
+from spinta.cli.helpers.upgrade.components import Script
+from spinta.cli.helpers.upgrade.scripts.push_state.helpers import apply_migration_to_push_state, requires_migration
+from spinta.components import Context
+
+
+def requires_push_state_rename_rev_migration(context: Context, **kwargs) -> bool:
+    return requires_migration(context, Script.PUSH_REV_RENAME.value, None, **kwargs)
+
+
+def push_state_rename_rev_migration(context: Context, **kwargs):
+    apply_migration_to_push_state(context, Script.PUSH_REV_RENAME.value, apply_migration, **kwargs)
+
+
+def apply_migration(context: Context, push_state: PushState, migration: str):
+    def migrate(push_state_table: sa.Table):
+        from alembic.migration import MigrationContext
+        from alembic.operations import Operations
+
+        connection = push_state.conn
+        ctx = MigrationContext.configure(
+            connection, opts={"target_metadata": push_state.metadata, "transactional_ddl:": True}
+        )
+        op = Operations(ctx)
+        table_name = push_state_table.name
+        op.alter_column(table_name=table_name, column_name="rev", new_column_name="checksum")
+
+    insp = sa.inspect(push_state.engine)
+    table_names = insp.get_table_names()
+    push_state.metadata.reflect()
+    for table in table_names:
+        if table.startswith("_"):
+            continue
+
+        columns = insp.get_columns(table)
+        column_names = [col["name"] for col in columns]
+        if "rev" in column_names and "checksum" not in column_names:
+            migrate(push_state_table=push_state.get_table(table))

--- a/spinta/cli/push.py
+++ b/spinta/cli/push.py
@@ -147,7 +147,7 @@ def push(
         models = commands.traverse_ns_models(context, ns, manifest, Action.SEARCH, dataset_=dataset, source_check=True)
         models = sort_models_by_ref_and_base(list(models))
 
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, state, models)
         push_state = context.get(PUSH_STATE_DB)
 
         # Synchronize keymaps

--- a/spinta/cli/push.py
+++ b/spinta/cli/push.py
@@ -13,7 +13,7 @@ from spinta.cli.helpers.data import ensure_data_dir
 from spinta.cli.helpers.errors import ErrorCounter
 from spinta.cli.helpers.manifest import convert_str_to_manifest_path
 from spinta.cli.helpers.message import cli_error
-from spinta.cli.helpers.push.components import State
+from spinta.cli.helpers.push.components import PUSH_STATE_DB
 from spinta.cli.helpers.push.read import read_rows
 from spinta.cli.helpers.push.state import init_push_state
 from spinta.cli.helpers.push.sync import sync_push_state
@@ -147,9 +147,8 @@ def push(
         models = commands.traverse_ns_models(context, ns, manifest, Action.SEARCH, dataset_=dataset, source_check=True)
         models = sort_models_by_ref_and_base(list(models))
 
-        if state:
-            state = State(*init_push_state(state, models))
-            context.attach("push.state.conn", state.engine.begin)
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
         # Synchronize keymaps
         with manifest.keymap as km:
@@ -182,20 +181,19 @@ def push(
                 server=creds.server,
                 error_counter=error_counter,
                 no_progress_bar=no_progress_bar,
-                metadata=state.metadata,
+                push_state=push_state,
                 timeout=(connect_timeout, read_timeout),
                 max_retries=max_retries,
                 delay_range=delay_range,
             )
 
-        initial_page_data = load_initial_page_data(context, state.metadata, models, incremental, override_page)
-
+        initial_page_data = load_initial_page_data(push_state, models, incremental, override_page)
         rows = read_rows(
             context,
             client,
             creds.server,
             models,
-            state,
+            push_state,
             limit,
             timeout=(connect_timeout, read_timeout),
             stop_on_error=stop_on_error,
@@ -211,7 +209,7 @@ def push(
             creds.server,
             models,
             rows,
-            state=state,
+            push_state=push_state,
             stop_time=stop_time,
             stop_row=stop_row,
             chunk_size=chunk_size,

--- a/spinta/cli/push.py
+++ b/spinta/cli/push.py
@@ -147,7 +147,7 @@ def push(
         models = commands.traverse_ns_models(context, ns, manifest, Action.SEARCH, dataset_=dataset, source_check=True)
         models = sort_models_by_ref_and_base(list(models))
 
-        context.attach(PUSH_STATE_DB, init_push_state, state, models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, state, models)
         push_state = context.get(PUSH_STATE_DB)
 
         # Synchronize keymaps

--- a/spinta/cli/upgrade.py
+++ b/spinta/cli/upgrade.py
@@ -28,8 +28,8 @@ def upgrade(
         """
         ),
     ),
-    ensure_config_dir: bool = Option(True, "--ensure-config", help=("Ensures that all config files are created.")),
-    force: bool = Option(False, "-f", "--force", help=("Skips all checks when running upgrades.")),
+    ensure_config_dir: bool = Option(True, "--ensure-config", help="Ensures that all config files are created."),
+    force: bool = Option(False, "-f", "--force", help="Skips all checks when running upgrades."),
     destructive: bool = Option(
         False,
         "-d",
@@ -45,12 +45,17 @@ def upgrade(
         False,
         "-c",
         "--check",
-        help=("Only runs script checks, skipping execution part (used to find out what scripts are needed to run)."),
+        help="Only runs script checks, skipping execution part (used to find out what scripts are needed to run).",
     ),
+    targets: list[str] | None = Option(None, "--target", help="Target specific script type"),
+    tags: list[str] | None = Option(None, "--tag", help="Target specific script tag"),
 ):
     rc = ctx.obj.get("rc")
     rc.add("upgrade", {"upgrade_mode": True})
     context = configure_context(ctx.obj)
+
+    targets = set(targets) if targets else None
+    tags = set(tags) if tags else None
 
     if force and check_only:
         echo("Cannot run force mode with check only mode", err=True)
@@ -71,6 +76,8 @@ def upgrade(
             force=force,
             check_only=check_only,
             status_cache=status_cache,
+            targets=targets,
+            tags=tags,
         )
         return
 

--- a/spinta/datasets/keymaps/sqlalchemy.py
+++ b/spinta/datasets/keymaps/sqlalchemy.py
@@ -46,7 +46,6 @@ class SqlAlchemyKeyMap(SqliteMigratableDb, KeyMap):
             sa.Column("model", sa.Text, primary_key=True),
             sa.Column("cid", sa.BIGINT),
             sa.Column("updated", sa.DateTime),
-            extend_existing=True,
         )
 
     def copy(self) -> "SqlAlchemyKeyMap":

--- a/spinta/datasets/keymaps/sqlalchemy.py
+++ b/spinta/datasets/keymaps/sqlalchemy.py
@@ -46,6 +46,7 @@ class SqlAlchemyKeyMap(SqliteMigratableDb, KeyMap):
             sa.Column("model", sa.Text, primary_key=True),
             sa.Column("cid", sa.BIGINT),
             sa.Column("updated", sa.DateTime),
+            extend_existing=True,
         )
 
     def copy(self) -> "SqlAlchemyKeyMap":
@@ -401,14 +402,13 @@ def initialize_meta_tables(keymap: SqlAlchemyKeyMap):
 def is_fresh_database(context: Context, keymap: SqlAlchemyKeyMap) -> bool:
     insp = sa.inspect(keymap.engine)
     tables = insp.get_table_names()
-    if keymap.sync_table_name in tables:
-        return False
-
-    if keymap.migration_table_name in tables:
-        return False
 
     if not len(tables):
         return True
+
+    for metatable_name in keymap.metatable_templates.keys():
+        if metatable_name in tables:
+            return False
 
     tables = [table for table in tables if not table.startswith("_")]
     manifest = context.get("store").manifest

--- a/spinta/datasets/keymaps/sqlalchemy.py
+++ b/spinta/datasets/keymaps/sqlalchemy.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from collections.abc import Generator
 from copy import copy
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from uuid import UUID
 
 import msgpack
@@ -25,45 +25,34 @@ from spinta.datasets.keymaps.components import KeyMap, KeymapSyncData
 from spinta.datasets.keymaps.helpers import prepare_keymap_values
 from spinta.exceptions import KeymapDuplicateMapping, KeyMapGivenKeyMissmatch, KeymapMigrationRequired
 from spinta.utils.json import fix_data_for_json
+from spinta.utils.sqlite import SqliteMigratableDb
 
 
-class SqlAlchemyKeyMap(KeyMap):
+class SqlAlchemyKeyMap(SqliteMigratableDb, KeyMap):
     dsn: str = None
 
-    migration_table_name: str = "_migrations"
     sync_table_name: str = "_synchronize"
     sync_transaction_size: int = None
 
     # On duplicate validation warn only, instead of raise error
     duplicate_warn_only: bool = False
 
-    def __init__(self, dsn: str = None):
-        self.dsn = dsn
-        self.engine = None
-        self.metadata = None
-        self.conn = None
+    def __init__(self, dsn: str | None = None):
+        super().__init__(dsn)
 
-    def __enter__(self):
-        assert self.dsn is not None
-        assert self.conn is None
-        self.conn = self.engine.connect()
-        return self
-
-    def __exit__(self, *exc):
-        self.conn.close()
-        self.conn = None
+        self.metatable_templates[self.sync_table_name] = lambda metadata: sa.Table(
+            self.sync_table_name,
+            metadata,
+            sa.Column("model", sa.Text, primary_key=True),
+            sa.Column("cid", sa.BIGINT),
+            sa.Column("updated", sa.DateTime),
+        )
 
     def copy(self) -> "SqlAlchemyKeyMap":
         copied = copy(self)
         # Reset any context manager variables
         copied.conn = None
         return copied
-
-    def get_table(self, name) -> sa.Table:
-        table = self.metadata.tables.get(name)
-        if table is None:
-            table = self._create_table(name)
-        return table
 
     def encode(self, name: str, value: object, primary_key=None) -> Optional[str]:
         valid_value = _valid_keymap_value(value)
@@ -267,49 +256,15 @@ class SqlAlchemyKeyMap(KeyMap):
                     self, key=name, key_count=affected_key_count, affected_count=affected_row_count
                 )
 
-    def contains_migration(self, name: str):
-        migrations = self.get_table(self.migration_table_name)
-
-        query = sa.select([sa.func.count()]).where(migrations.c.migration == name)
-        count = self.conn.execute(query).scalar()
-        return count != 0
-
-    def mark_migration(self, name: str):
-        if self.contains_migration(name):
-            return
-
-        migrations = self.get_table(self.migration_table_name)
-        stmt = migrations.insert().values(migration=name)
-        self.conn.execute(stmt)
-
-    def _create_table(self, name: str) -> sa.Table:
-        if name == self.sync_table_name:
-            table = sa.Table(
-                name,
-                self.metadata,
-                sa.Column("model", sa.Text, primary_key=True),
-                sa.Column("cid", sa.BIGINT),
-                sa.Column("updated", sa.DateTime),
-            )
-        elif name == self.migration_table_name:
-            table = sa.Table(
-                name,
-                self.metadata,
-                sa.Column("migration", sa.Text, primary_key=True),
-                sa.Column("applied_at", sa.DateTime, server_default=sa.func.now()),
-            )
-        else:
-            table = sa.Table(
-                name,
-                self.metadata,
-                sa.Column("key", sa.Text, primary_key=True),
-                sa.Column("value", sa.Text, index=True),
-                sa.Column("redirect", sa.Text, index=True),
-                sa.Column("modified_at", sa.DateTime, index=True),
-            )
-
-        table.create(checkfirst=True)
-        return table
+    def _default_table_template(self, name: str, **kwargs) -> Callable[[sa.MetaData], sa.Table]:
+        return lambda metadata: sa.Table(
+            name,
+            metadata,
+            sa.Column("key", sa.Text, primary_key=True),
+            sa.Column("value", sa.Text, index=True),
+            sa.Column("redirect", sa.Text, index=True),
+            sa.Column("modified_at", sa.DateTime, index=True),
+        )
 
 
 def _valid_keymap_value(value: object) -> bool:
@@ -379,15 +334,12 @@ def configure(context: Context, keymap: SqlAlchemyKeyMap):
     if dsn.startswith("sqlite:///"):
         dsn = dsn.replace("sqlite:///", "sqlite+spinta:///")
     keymap.sync_transaction_size = sync_transaction_size
-    keymap.dsn = dsn
     keymap.duplicate_warn_only = rc.get("keymaps", keymap.name, "duplicate_warn_only", cast=bool, default=False)
+    keymap.configure_engine(dsn)
 
 
 @commands.prepare.register(Context, SqlAlchemyKeyMap)
 def prepare(context: Context, keymap: SqlAlchemyKeyMap, **kwargs):
-    keymap.engine = sa.create_engine(keymap.dsn)
-    keymap.metadata = sa.MetaData(keymap.engine)
-
     fresh = is_fresh_database(context, keymap)
     if fresh:
         initialize_meta_tables(keymap)

--- a/spinta/datasets/keymaps/sqlalchemy.py
+++ b/spinta/datasets/keymaps/sqlalchemy.py
@@ -51,7 +51,7 @@ class SqlAlchemyKeyMap(SqliteMigratableDb, KeyMap):
     def copy(self) -> "SqlAlchemyKeyMap":
         copied = copy(self)
         # Reset any context manager variables
-        copied.conn = None
+        copied._conn = None
         return copied
 
     def encode(self, name: str, value: object, primary_key=None) -> Optional[str]:

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -1267,6 +1267,24 @@ class ValuesForIdCantHaveSpecialSymbols(BaseError):
     template = "The value used for _id can not have special symbols. Found {value} value on {property} property. Change _id type to Base32 or remove the special symbol."
 
 
+class SqliteDatabaseNotConfigured(BaseError):
+    template = (
+        "SQLite database is not configured. Call `configure_engine(dsn)` before accessing its engine or metadata."
+    )
+
+
+class SqliteConnectionNotOpen(BaseError):
+    template = "SQLite database connection is not open. Use the database as a context manager before accessing it."
+
+
+class SqliteConnectionAlreadyOpen(BaseError):
+    template = "SQLite database connection is already open. Close it before opening it again."
+
+
+class SqliteTableNotFound(BaseError):
+    template = "SQLite table {table!r} is not registered and automatic creation is disabled."
+
+
 class PushStateMigrationRequired(UpgradeError):
     template = """
     Push state database ({dsn!r}) is missing {migration!r} migration.

--- a/spinta/exceptions.py
+++ b/spinta/exceptions.py
@@ -1265,3 +1265,11 @@ class Base32TypeOnlyAllowedOnIdOrRevision(BaseError):
 
 class ValuesForIdCantHaveSpecialSymbols(BaseError):
     template = "The value used for _id can not have special symbols. Found {value} value on {property} property. Change _id type to Base32 or remove the special symbol."
+
+
+class PushStateMigrationRequired(UpgradeError):
+    template = """
+    Push state database ({dsn!r}) is missing {migration!r} migration.
+    Run this command to execute migrations:
+    `spinta -o push_state_path={path} upgrade --target push_state_db`.
+    """

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -96,7 +96,6 @@ class SqliteMigratableDb:
         if not create_missing:
             raise Exception("table not found")
 
-
         table_template = self.metatable_templates.get(name)
         if table_template is None:
             table_template = self._default_table_template(name, **kwargs)

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -7,6 +7,12 @@ from sqlalchemy.engine.reflection import Inspector
 
 from spinta.cli.helpers.message import cli_message
 from spinta.components import Context
+from spinta.exceptions import (
+    SqliteConnectionAlreadyOpen,
+    SqliteConnectionNotOpen,
+    SqliteDatabaseNotConfigured,
+    SqliteTableNotFound,
+)
 
 if TYPE_CHECKING:
     from alembic.operations import Operations
@@ -38,14 +44,16 @@ class SqliteMigratableDb:
         }
 
     def __enter__(self):
-        assert self.dsn is not None
-        assert self._conn is None
-        assert self._engine is not None
-        self._conn = self._engine.connect()
+        if self._conn is not None:
+            raise SqliteConnectionAlreadyOpen()
+
+        self._conn = self.engine.connect()
         return self
 
     def __exit__(self, *exc):
-        assert self._conn is not None
+        if self._conn is None:
+            raise SqliteConnectionNotOpen()
+
         self._conn.close()
         self._conn = None
 
@@ -56,21 +64,21 @@ class SqliteMigratableDb:
     @property
     def conn(self) -> sa.engine.Connection:
         if self._conn is None:
-            raise RuntimeError("Database connection is not open.")
+            raise SqliteConnectionNotOpen()
 
         return self._conn
 
     @property
     def engine(self) -> sa.engine.Engine:
         if self._engine is None:
-            raise RuntimeError("Database engine is not configured")
+            raise SqliteDatabaseNotConfigured()
 
         return self._engine
 
     @property
     def metadata(self) -> sa.MetaData:
         if self._metadata is None:
-            raise RuntimeError("Database metadata is not configured.")
+            raise SqliteDatabaseNotConfigured()
 
         return self._metadata
 
@@ -94,7 +102,7 @@ class SqliteMigratableDb:
             return table
 
         if not create_missing:
-            raise Exception("table not found")
+            raise SqliteTableNotFound(table=name)
 
         table_template = self.metatable_templates.get(name)
         if table_template is None:
@@ -124,7 +132,7 @@ class SqliteMigratableDb:
             self.get_table(name)
 
     def _default_table_template(self, name: str, **kwargs) -> Callable[[sa.MetaData], sa.Table]:
-        raise Exception("Not implemented")
+        raise NotImplementedError("SqliteMigratableDb subclasses must implement `_default_table_template`.")
 
 
 def outdated_sqlite_db(

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -93,7 +93,9 @@ class SqliteMigratableDb:
         table = self.metadata.tables.get(name)
         if table is None:
             if create_missing:
-                table_template = self.metatable_templates.get(name, self._default_table_template(name, **kwargs))
+                table_template = self.metatable_templates.get(name)
+                if table_template is None:
+                    table_template = self._default_table_template(name, **kwargs)
                 table = table_template(self.metadata)
                 self.create_table(table)
             else:

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Callable, Dict, Optional
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
@@ -7,6 +7,113 @@ from sqlalchemy.engine.reflection import Inspector
 
 if TYPE_CHECKING:
     from alembic.operations import Operations
+
+
+class SqliteMigratableDb:
+    dsn: str | None
+
+    # Private sqlalchemy fields should not be accessed directly.
+    _engine: Engine | None
+    _metadata: sa.MetaData | None
+    _conn: sa.engine.Connection | None
+
+    migration_table_name: str = "_migrations"
+    metatable_templates: dict[str, Callable[[sa.MetaData], sa.Table]]
+
+    def __init__(self, dsn: str | None = None, migration_table_name: str = migration_table_name):
+        self.configure_engine(dsn)
+        self._conn = None
+        self.migration_table_name = migration_table_name
+
+        self.metatable_templates = {
+            self.migration_table_name: lambda metadata: sa.Table(
+                self.migration_table_name,
+                metadata,
+                sa.Column("migration", sa.Text, primary_key=True),
+                sa.Column("applied_at", sa.DateTime, server_default=sa.func.now()),
+            )
+        }
+
+    def __enter__(self):
+        assert self.dsn is not None
+        assert self._conn is None
+        assert self._engine is not None
+        self._conn = self._engine.connect()
+        return self
+
+    def __exit__(self, *exc):
+        assert self._conn is not None
+        self._conn.close()
+        self._conn = None
+
+    @property
+    def conn(self) -> sa.engine.Connection:
+        if self._conn is None:
+            raise RuntimeError("Database connection is not open.")
+
+        return self._conn
+
+    @property
+    def engine(self) -> sa.engine.Engine:
+        if self._engine is None:
+            raise RuntimeError("Database engine is not configured")
+
+        return self._engine
+
+    @property
+    def metadata(self) -> sa.MetaData:
+        if self._metadata is None:
+            raise RuntimeError("Database metadata is not configured.")
+
+        return self._metadata
+
+    def configure_engine(self, dsn: str | None):
+        if dsn is None:
+            self.dsn = None
+            self._engine = None
+            self._metadata = None
+            return
+
+        self.dsn = dsn
+        self._engine = sa.create_engine(dsn)
+        self._metadata = sa.MetaData(self._engine)
+
+    def create_table(self, table: sa.Table):
+        table.create(self.engine, checkfirst=True)
+
+    def get_table(self, name: str, create_missing: bool = True, **kwargs) -> sa.Table:
+        table = self.metadata.tables.get(name)
+        if table is None:
+            if create_missing:
+                table_template = self.metatable_templates.get(name, self._default_table_template(name, **kwargs))
+                table = table_template(self.metadata)
+                self.create_table(table)
+            else:
+                raise Exception("table not found")
+        return table
+
+    def contains_migration(self, name: str):
+        migrations = self.get_table(self.migration_table_name)
+
+        query = sa.select([sa.func.count()]).where(migrations.c.migration == name)
+        count = self.conn.execute(query).scalar()
+        return count != 0
+
+    def mark_migration(self, name: str):
+        if self.contains_migration(name):
+            return
+
+        migrations = self.get_table(self.migration_table_name)
+        stmt = migrations.insert().values(migration=name)
+        self.conn.execute(stmt)
+
+    def create_all_metatables(self):
+        for table_template in self.metatable_templates.values():
+            table = table_template(self.metadata)
+            self.create_table(table)
+
+    def _default_table_template(self, name: str, **kwargs) -> Callable[[sa.MetaData], sa.Table]:
+        raise Exception("Not implemented")
 
 
 def migrate_table(

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -34,7 +34,6 @@ class SqliteMigratableDb:
                 metadata,
                 sa.Column("migration", sa.Text, primary_key=True),
                 sa.Column("applied_at", sa.DateTime, server_default=sa.func.now()),
-                extend_existing=True,
             )
         }
 
@@ -91,15 +90,19 @@ class SqliteMigratableDb:
 
     def get_table(self, name: str, create_missing: bool = True, **kwargs) -> sa.Table:
         table = self.metadata.tables.get(name)
-        if table is None:
-            if create_missing:
-                table_template = self.metatable_templates.get(name)
-                if table_template is None:
-                    table_template = self._default_table_template(name, **kwargs)
-                table = table_template(self.metadata)
-                self.create_table(table)
-            else:
-                raise Exception("table not found")
+        if table is not None:
+            return table
+
+        if not create_missing:
+            raise Exception("table not found")
+
+
+        table_template = self.metatable_templates.get(name)
+        if table_template is None:
+            table_template = self._default_table_template(name, **kwargs)
+
+        table = table_template(self.metadata)
+        self.create_table(table)
         return table
 
     def contains_migration(self, name: str):
@@ -118,9 +121,8 @@ class SqliteMigratableDb:
         self.conn.execute(stmt)
 
     def create_all_metatables(self):
-        for table_template in self.metatable_templates.values():
-            table = table_template(self.metadata)
-            self.create_table(table)
+        for name in self.metatable_templates.keys():
+            self.get_table(name)
 
     def _default_table_template(self, name: str, **kwargs) -> Callable[[sa.MetaData], sa.Table]:
         raise Exception("Not implemented")

--- a/spinta/utils/sqlite.py
+++ b/spinta/utils/sqlite.py
@@ -5,6 +5,9 @@ from sqlalchemy.dialects.sqlite.base import SQLiteDialect
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.reflection import Inspector
 
+from spinta.cli.helpers.message import cli_message
+from spinta.components import Context
+
 if TYPE_CHECKING:
     from alembic.operations import Operations
 
@@ -31,6 +34,7 @@ class SqliteMigratableDb:
                 metadata,
                 sa.Column("migration", sa.Text, primary_key=True),
                 sa.Column("applied_at", sa.DateTime, server_default=sa.func.now()),
+                extend_existing=True,
             )
         }
 
@@ -45,6 +49,10 @@ class SqliteMigratableDb:
         assert self._conn is not None
         self._conn.close()
         self._conn = None
+
+    @property
+    def is_entered(self) -> bool:
+        return self._conn is not None
 
     @property
     def conn(self) -> sa.engine.Connection:
@@ -114,6 +122,43 @@ class SqliteMigratableDb:
 
     def _default_table_template(self, name: str, **kwargs) -> Callable[[sa.MetaData], sa.Table]:
         raise Exception("Not implemented")
+
+
+def outdated_sqlite_db(
+    context: Context, sqlite_db: SqliteMigratableDb, migration: str, additional_check: Callable | None = None, **kwargs
+) -> bool:
+    def _check_missing_migrations() -> bool:
+        if not sqlite_db.contains_migration(migration):
+            return True
+
+        if additional_check and additional_check(context, **kwargs):
+            return True
+        return False
+
+    if not isinstance(sqlite_db, SqliteMigratableDb):
+        return False
+
+    if sqlite_db.is_entered:
+        return _check_missing_migrations()
+
+    with sqlite_db:
+        return _check_missing_migrations()
+
+
+def apply_migration_to_outdated_db(
+    context: Context,
+    sqlite_db: SqliteMigratableDb,
+    migration: str,
+    apply_migration: Callable,
+    database_name: str,
+    **kwargs,
+):
+    if not outdated_sqlite_db(context, sqlite_db, migration, None, **kwargs):
+        return
+
+    cli_message(f'\tApplying "{migration}" migration to sqlite database ("{database_name}")')
+    apply_migration(context, sqlite_db, migration)
+    sqlite_db.mark_migration(migration)
 
 
 def migrate_table(

--- a/tests/cli/upgrade/test_push_state_migration.py
+++ b/tests/cli/upgrade/test_push_state_migration.py
@@ -33,9 +33,7 @@ def test_upgrade_push_state_without_path_does_not_apply_migrations(
     assert migrations == []
 
 
-def test_upgrade_missing_initial_migration(
-    context, rc: RawConfig, cli: SpintaCliRunner, responses, tmp_path
-):
+def test_upgrade_missing_initial_migration(context, rc: RawConfig, cli: SpintaCliRunner, responses, tmp_path):
     push_state_path = str(tmp_path / "tmp_push_state.db")
     push_state_dsn = f"sqlite+spinta:///{push_state_path}"
 
@@ -58,7 +56,11 @@ def test_upgrade_missing_initial_migration(
 
 
 def test_upgrade_missing_rev_rename_migration(
-    context, rc: RawConfig, cli: SpintaCliRunner, responses, tmp_path,
+    context,
+    rc: RawConfig,
+    cli: SpintaCliRunner,
+    responses,
+    tmp_path,
 ):
     context, manifest = load_manifest_and_context(
         rc,

--- a/tests/cli/upgrade/test_push_state_migration.py
+++ b/tests/cli/upgrade/test_push_state_migration.py
@@ -1,0 +1,100 @@
+import pytest
+import sqlalchemy as sa
+
+from spinta import commands
+from spinta.cli.helpers.push.components import PUSH_STATE_PATH, PushState
+from spinta.cli.helpers.push.state import init_push_state
+from spinta.cli.helpers.script.components import ScriptStatus, ScriptTarget
+from spinta.cli.helpers.script.helpers import script_check_status_message
+from spinta.cli.helpers.upgrade.components import Script
+from spinta.core.config import RawConfig
+from spinta.exceptions import PushStateMigrationRequired
+from spinta.testing.cli import SpintaCliRunner, result_contains
+from spinta.testing.manifest import load_manifest_and_context
+
+
+def test_upgrade_push_state_without_path_does_not_apply_migrations(
+    context, rc: RawConfig, cli: SpintaCliRunner, tmp_path
+):
+    push_state_path = str(tmp_path / "tmp_push_state.db")
+    push_state_dsn = f"sqlite+spinta:///{push_state_path}"
+
+    push_state: PushState = init_push_state(context, push_state_dsn, [])
+    with push_state:
+        migration_table = push_state.get_table(push_state.migration_table_name)
+        push_state.conn.execute(migration_table.delete())
+
+    result = cli.invoke(rc, ["upgrade", "--target", ScriptTarget.PUSH_STATE_DB.value])
+
+    assert result.exit_code == 0
+    with push_state:
+        migration_table = push_state.get_table(push_state.migration_table_name)
+        migrations = push_state.conn.execute(sa.select([migration_table.c.migration])).fetchall()
+    assert migrations == []
+
+
+def test_upgrade_missing_initial_migration(
+    context, rc: RawConfig, cli: SpintaCliRunner, responses, tmp_path
+):
+    push_state_path = str(tmp_path / "tmp_push_state.db")
+    push_state_dsn = f"sqlite+spinta:///{push_state_path}"
+
+    push_state: PushState = init_push_state(context, push_state_dsn, [])
+    with push_state:
+        migration_table = push_state.get_table(push_state.migration_table_name)
+        push_state.conn.execute(migration_table.delete())
+
+    with pytest.raises(PushStateMigrationRequired):
+        init_push_state(context, push_state_dsn, [])
+
+    result = cli.invoke(
+        rc.fork({PUSH_STATE_PATH: push_state_path}),
+        ["upgrade", "--target", ScriptTarget.PUSH_STATE_DB.value],
+    )
+    assert result.exit_code == 0
+    assert result_contains(result, script_check_status_message(Script.PUSH_STATE_INITIAL.value, ScriptStatus.REQUIRED))
+
+    assert isinstance(init_push_state(context, push_state_dsn, []), PushState)
+
+
+def test_upgrade_missing_rev_rename_migration(
+    context, rc: RawConfig, cli: SpintaCliRunner, responses, tmp_path,
+):
+    context, manifest = load_manifest_and_context(
+        rc,
+        """
+    d | r | b | m | property   | type    | ref       | level | access
+    example                    |         |           |       |
+      |   |   | Continent      |         |           | 4     |
+      |   |   |   | id         | integer |           | 3     | open
+      |   |   |   | name       | string  |           | 3     | open
+    """,
+    )
+    model = commands.get_model(context, manifest, "example/Continent")
+
+    push_state_path = str(tmp_path / "tmp_push_state.db")
+    push_state_dsn = f"sqlite+spinta:///{push_state_path}"
+
+    push_state: PushState = init_push_state(context, push_state_dsn, [])
+    with push_state:
+        migration_table = push_state.get_table(push_state.migration_table_name)
+        push_state.conn.execute(migration_table.delete(migration_table.c.migration == Script.PUSH_REV_RENAME.value))
+        push_state.get_table(model.name, model=model)
+        push_state.conn.execute(sa.text('ALTER TABLE "example/Continent" RENAME COLUMN checksum TO rev'))
+
+    with pytest.raises(PushStateMigrationRequired):
+        init_push_state(context, push_state_dsn, [])
+
+    result = cli.invoke(
+        rc.fork({PUSH_STATE_PATH: push_state_path}),
+        ["upgrade", "--target", ScriptTarget.PUSH_STATE_DB.value],
+    )
+    assert result.exit_code == 0
+    assert result_contains(result, script_check_status_message(Script.PUSH_REV_RENAME.value, ScriptStatus.REQUIRED))
+
+    assert isinstance(init_push_state(context, push_state_dsn, []), PushState)
+
+    push_state.metadata.reflect()
+    columns = [column.name for column in push_state.get_table(model.name, model=model).columns]
+    assert "rev" not in columns
+    assert "checksum" in columns

--- a/tests/cli/upgrade/test_upgrade.py
+++ b/tests/cli/upgrade/test_upgrade.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 import pytest
 
-from spinta.cli.helpers.script.components import ScriptStatus
+from spinta.cli.helpers.script.components import ScriptStatus, ScriptTag, ScriptTarget
 from spinta.cli.helpers.script.helpers import script_check_status_message
 from spinta.cli.helpers.upgrade.components import Script
 from spinta.cli.helpers.upgrade.registry import upgrade_script_registry
@@ -59,6 +59,22 @@ def test_upgrade_all(context, rc, cli: SpintaCliRunner, tmp_path: pathlib.Path):
 
     for script in upgrade_script_registry.get_all_names():
         assert result_contains(result, script_check_status_message(script, ScriptStatus.PASSED))
+
+
+def test_upgrade_target(context, rc, cli: SpintaCliRunner):
+    result = cli.invoke(rc, ["upgrade", "--target", ScriptTarget.AUTH.value, "-c"])
+
+    assert result.exit_code == 0
+    assert result_contains(result, script_check_status_message(Script.CLIENTS.value, ScriptStatus.PASSED))
+    assert f"Script {Script.SQL_KEYMAP_INITIAL.value!r} check." not in result.stderr
+
+
+def test_upgrade_tag(context, rc, cli: SpintaCliRunner):
+    result = cli.invoke(rc, ["upgrade", "--tag", ScriptTag.DB_MIGRATION.value, "-c"])
+
+    assert result.exit_code == 0
+    assert result_contains(result, script_check_status_message(Script.SQL_KEYMAP_INITIAL.value, ScriptStatus.PASSED))
+    assert f"Script {Script.CLIENTS.value!r} check." not in result.stderr
 
 
 def test_upgrade_multiple(context, rc, cli: SpintaCliRunner, tmp_path: pathlib.Path):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1118,7 +1118,7 @@ def test_push_state__max_errors(rc: RawConfig, responses: RequestsMock):
         assert list(push_state.conn.execute(query)) == [(_id1, rev, True), (_id2, None, True)]
 
 
-@pytest.skip("Push init state can no longer self heal")
+@pytest.mark.skip("Push init state can no longer self heal")
 def test_push_init_state(rc: RawConfig, sqlite: Sqlite):
     context, manifest = load_manifest_and_context(
         rc,

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -263,7 +263,7 @@ def test_push_state__create(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rows = [
@@ -339,7 +339,7 @@ def test_push_state__create_error(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rows = [
@@ -389,7 +389,7 @@ def test_push_state__update(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
@@ -482,7 +482,7 @@ def test_push_state__update_without_sync(rc: RawConfig, responses: RequestsMock)
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         synchronize_time = datetime.datetime.now()
@@ -565,7 +565,7 @@ def test_push_state__update_sync_first_time(rc: RawConfig, responses: RequestsMo
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         table = push_state.get_table(model.name)
@@ -646,7 +646,7 @@ def test_push_state__update_sync(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
         time_before_sync_push = datetime.datetime.now()
         table = push_state.get_table(model.name)
@@ -718,7 +718,7 @@ def test_push_state__update_error(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
@@ -863,7 +863,7 @@ def test_push_state__delete(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
@@ -953,7 +953,7 @@ def test_push_state__retry(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
@@ -1039,7 +1039,7 @@ def test_push_state__max_errors(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
@@ -1151,7 +1151,7 @@ def test_push_init_state(rc: RawConfig, sqlite: Sqlite):
     conn.execute(table.insert().values(id=_id, rev=rev, pushed=pushed))
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         table = push_state.get_table(model.name)
@@ -1185,7 +1185,7 @@ def test_push_state__paginate(rc: RawConfig, responses: RequestsMock):
     models = [model]
 
     with context:
-        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        context.attach(PUSH_STATE_DB, init_push_state, context, "sqlite://", models)
         push_state = context.get(PUSH_STATE_DB)
 
         rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -13,7 +13,7 @@ from responses import POST, RequestsMock
 
 from spinta import commands
 from spinta.cli.helpers.errors import ErrorCounter
-from spinta.cli.helpers.push.components import PushRow, State
+from spinta.cli.helpers.push.components import PUSH_STATE_DB, PushRow
 from spinta.cli.helpers.push.state import init_push_state, reset_pushed
 from spinta.cli.helpers.push.write import _map_sent_and_recv, get_row_for_error, push, send_request
 from spinta.core.config import RawConfig
@@ -262,67 +262,67 @@ def test_push_state__create(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-            op="insert",
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
+        rows = [
+            PushRow(
+                model,
                 {
                     "_type": model.name,
                     "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                    "_revision": "f91adeea-3bb8-41b0-8049-ce47c7530bdc",
                     "name": "Vilnius",
-                }
+                },
+                op="insert",
+            ),
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "_revision": "f91adeea-3bb8-41b0-8049-ce47c7530bdc",
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "insert",
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                    }
+                )
             ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "insert",
-                    "_type": model.name,
-                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                }
-            )
-        ],
-    )
-
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
-
-    table = state.metadata.tables[model.name]
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [
-        (
-            "4d741843-4e94-4890-81d9-5af7c5b5989a",
-            "f91adeea-3bb8-41b0-8049-ce47c7530bdc",
-            False,
         )
-    ]
+
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
+
+        table = push_state.get_table(name=model.name)
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [
+            (
+                "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                "f91adeea-3bb8-41b0-8049-ce47c7530bdc",
+                False,
+            )
+        ]
 
 
 def test_push_state__create_error(rc: RawConfig, responses: RequestsMock):
@@ -338,41 +338,41 @@ def test_push_state__create_error(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-            op="insert",
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                    "name": "Vilnius",
+                },
+                op="insert",
+            )
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(POST, server, status=500, body="ERROR!")
+
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
         )
-    ]
 
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(POST, server, status=500, body="ERROR!")
-
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
-
-    table = state.metadata.tables[model.name]
-    query = sa.select([table.c.id, table.c.error])
-    assert list(conn.execute(query)) == [
-        ("4d741843-4e94-4890-81d9-5af7c5b5989a", True),
-    ]
+        table = push_state.get_table(model.name)
+        query = sa.select([table.c.id, table.c.error])
+        assert list(push_state.conn.execute(query)) == [
+            ("4d741843-4e94-4890-81d9-5af7c5b5989a", True),
+        ]
 
 
 def test_push_state__update(rc: RawConfig, responses: RequestsMock):
@@ -388,83 +388,83 @@ def test_push_state__update(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    rev_after = "45e8d4d6-bb6c-42cd-8ad8-09049bbed6bd"
+        rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        rev_after = "45e8d4d6-bb6c-42cd-8ad8-09049bbed6bd"
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a",
-            revision=rev_before,
-            checksum="CHANGED",
-            pushed=datetime.datetime.now(),
-            error=False,
-        )
-    )
-
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_revision": rev_before,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-            op="patch",
-            saved=True,
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
-                {
-                    "_type": model.name,
-                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                    "_revision": rev_after,
-                    "name": "Vilnius",
-                }
-            ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "patch",
-                    "_type": model.name,
-                    "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
-                    "_revision": rev_before,
-                }
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                revision=rev_before,
+                checksum="CHANGED",
+                pushed=datetime.datetime.now(),
+                error=False,
             )
-        ],
-    )
-
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
-
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [
-        (
-            "4d741843-4e94-4890-81d9-5af7c5b5989a",
-            rev_after,
-            False,
         )
-    ]
+
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_revision": rev_before,
+                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                    "name": "Vilnius",
+                },
+                op="patch",
+                saved=True,
+            ),
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "_revision": rev_after,
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "patch",
+                        "_type": model.name,
+                        "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+                        "_revision": rev_before,
+                    }
+                )
+            ],
+        )
+
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
+
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [
+            (
+                "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                rev_after,
+                False,
+            )
+        ]
 
 
 @pytest.mark.skip(reason="not implemented yet")
@@ -481,65 +481,73 @@ def test_push_state__update_without_sync(rc: RawConfig, responses: RequestsMock)
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    syncronize_time = datetime.datetime.now()
+        synchronize_time = datetime.datetime.now()
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a",
-            checksum="CHANGED",
-            pushed=datetime.datetime.now(),
-            error=False,
-            synchronize=syncronize_time,
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                checksum="CHANGED",
+                pushed=datetime.datetime.now(),
+                error=False,
+                synchronize=synchronize_time,
+            )
         )
-    )
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
+        rows = [
+            PushRow(
+                model,
                 {
                     "_type": model.name,
                     "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
                     "name": "Vilnius",
-                }
+                },
+            ),
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "patch",
+                        "_type": model.name,
+                        "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+                    }
+                )
             ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "patch",
-                    "_type": model.name,
-                    "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
-                }
-            )
-        ],
-    )
+        )
 
-    push(context, client, server, models, rows, timeout=(5, 300), state=state, syncronize=False)
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
 
-    query = sa.select([table.c.id, table.c.synchronize])
-    res = list(conn.execute(query))
+        query = sa.select([table.c.id, table.c.synchronize])
+        res = list(push_state.conn.execute(query))
 
-    assert res[0][1] == syncronize_time
+        assert res[0][1] == synchronize_time
 
 
 @pytest.mark.skip(reason="not implemented yet")
@@ -556,60 +564,71 @@ def test_push_state__update_sync_first_time(rc: RawConfig, responses: RequestsMo
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a", checksum="CHANGED", pushed=datetime.datetime.now(), error=False
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                checksum="CHANGED",
+                pushed=datetime.datetime.now(),
+                error=False,
+            )
         )
-    )
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
+        rows = [
+            PushRow(
+                model,
                 {
                     "_type": model.name,
                     "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
                     "name": "Vilnius",
-                }
+                },
+            ),
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "patch",
+                        "_type": model.name,
+                        "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+                    }
+                )
             ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "patch",
-                    "_type": model.name,
-                    "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
-                }
-            )
-        ],
-    )
+        )
 
-    push(context, client, server, models, rows, state=state, timeout=(5, 300), syncronize=False)
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            push_state=push_state,
+            timeout=(5, 300),
+        )
 
-    query = sa.select([table.c.id, table.c.checksum, table.c.synchronize])
-    res = list(conn.execute(query))
+        query = sa.select([table.c.id, table.c.checksum, table.c.synchronize])
+        res = list(push_state.conn.execute(query))
 
-    assert res[0][1] != "CHANGED"
-    assert res[0][2] is not None
+        assert res[0][1] != "CHANGED"
+        assert res[0][2] is not None
 
 
 @pytest.mark.skip(reason="not implemented yet")
@@ -626,63 +645,63 @@ def test_push_state__update_sync(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
-    time_before_sync_push = datetime.datetime.now()
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a",
-            checksum="CHANGED",
-            pushed=datetime.datetime.now(),
-            error=False,
-            synchronize=time_before_sync_push,
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
+        time_before_sync_push = datetime.datetime.now()
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                checksum="CHANGED",
+                pushed=datetime.datetime.now(),
+                error=False,
+                synchronize=time_before_sync_push,
+            )
         )
-    )
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
+        rows = [
+            PushRow(
+                model,
                 {
                     "_type": model.name,
                     "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
                     "name": "Vilnius",
-                }
+                },
+            ),
+        ]
+
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "patch",
+                        "_type": model.name,
+                        "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+                    }
+                )
             ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "patch",
-                    "_type": model.name,
-                    "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
-                }
-            )
-        ],
-    )
+        )
 
-    push(context, client, server, models, rows, state=state, timeout=(5, 300), syncronize=True)
+        push(context, client, server, models, rows, push_state=push_state, timeout=(5, 300))
 
-    query = sa.select([table.c.id, table.c.checksum, table.c.synchronize])
-    res = list(conn.execute(query))
+        query = sa.select([table.c.id, table.c.checksum, table.c.synchronize])
+        res = list(push_state.conn.execute(query))
 
-    assert res[0][1] != "CHANGED"
+        assert res[0][1] != "CHANGED"
 
 
 def test_push_state__update_error(rc: RawConfig, responses: RequestsMock):
@@ -698,59 +717,59 @@ def test_push_state__update_error(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a",
-            revision=rev_before,
-            checksum="CHANGED",
-            pushed=datetime.datetime.now(),
-            error=False,
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                revision=rev_before,
+                checksum="CHANGED",
+                pushed=datetime.datetime.now(),
+                error=False,
+            )
         )
-    )
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_revision": rev_before,
-                "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                "name": "Vilnius",
-            },
-            op="patch",
-            saved=True,
-        ),
-    ]
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_revision": rev_before,
+                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                    "name": "Vilnius",
+                },
+                op="patch",
+                saved=True,
+            ),
+        ]
 
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(POST, server, status=500, body="ERROR!")
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(POST, server, status=500, body="ERROR!")
 
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
-
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [
-        (
-            "4d741843-4e94-4890-81d9-5af7c5b5989a",
-            rev_before,
-            True,
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
         )
-    ]
+
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [
+            (
+                "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                rev_before,
+                True,
+            )
+        ]
 
 
 def test_push_delete_with_dependent_objects(
@@ -843,81 +862,81 @@ def test_push_state__delete(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    rev_after = "45e8d4d6-bb6c-42cd-8ad8-09049bbed6bd"
+        rev_before = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        rev_after = "45e8d4d6-bb6c-42cd-8ad8-09049bbed6bd"
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id="4d741843-4e94-4890-81d9-5af7c5b5989a",
-            revision=rev_before,
-            checksum="DELETED",
-            pushed=datetime.datetime.now(),
-            error=False,
-        )
-    )
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
-                {
-                    "_type": model.name,
-                    "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
-                    "_revision": rev_after,
-                }
-            ],
-        },
-        match=[
-            _matcher(
-                {"_op": "delete", "_type": model.name, "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')"}
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id="4d741843-4e94-4890-81d9-5af7c5b5989a",
+                revision=rev_before,
+                checksum="DELETED",
+                pushed=datetime.datetime.now(),
+                error=False,
             )
-        ],
-    )
-
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [
-        (
-            "4d741843-4e94-4890-81d9-5af7c5b5989a",
-            rev_before,
-            False,
         )
-    ]
 
-    reset_pushed(context, models, state.metadata)
-
-    rows = [
-        PushRow(
-            model,
-            {
-                "_op": "delete",
-                "_type": "City",
-                "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                        "_revision": rev_after,
+                    }
+                ],
             },
-            op="delete",
-            saved=True,
-        ),
-    ]
+            match=[
+                _matcher(
+                    {"_op": "delete", "_type": model.name, "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')"}
+                )
+            ],
+        )
 
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [
+            (
+                "4d741843-4e94-4890-81d9-5af7c5b5989a",
+                rev_before,
+                False,
+            )
+        ]
 
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == []
+        reset_pushed(context, models, push_state)
+
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_op": "delete",
+                    "_type": "City",
+                    "_where": "eq(_id, '4d741843-4e94-4890-81d9-5af7c5b5989a')",
+                },
+                op="delete",
+                saved=True,
+            ),
+        ]
+
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
+
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == []
 
 
 def test_push_state__retry(rc: RawConfig, responses: RequestsMock):
@@ -933,77 +952,77 @@ def test_push_state__retry(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    _id = "4d741843-4e94-4890-81d9-5af7c5b5989a"
+        rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        _id = "4d741843-4e94-4890-81d9-5af7c5b5989a"
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id=_id,
-            revision=None,
-            checksum="CREATED",
-            pushed=datetime.datetime.now(),
-            error=True,
-        )
-    )
-
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": _id,
-                "name": "Vilnius",
-            },
-            op="insert",
-            error=True,
-            saved=True,
-        ),
-    ]
-
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
-                {
-                    "_type": model.name,
-                    "_id": _id,
-                    "_revision": rev,
-                    "name": "Vilnius",
-                }
-            ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "insert",
-                    "_type": model.name,
-                    "_id": _id,
-                    "name": "Vilnius",
-                }
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id=_id,
+                revision=None,
+                checksum="CREATED",
+                pushed=datetime.datetime.now(),
+                error=True,
             )
-        ],
-    )
+        )
 
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_id": _id,
+                    "name": "Vilnius",
+                },
+                op="insert",
+                error=True,
+                saved=True,
+            ),
+        ]
 
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [(_id, rev, False)]
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": _id,
+                        "_revision": rev,
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "insert",
+                        "_type": model.name,
+                        "_id": _id,
+                        "name": "Vilnius",
+                    }
+                )
+            ],
+        )
+
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
+
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [(_id, rev, False)]
 
 
 def test_push_state__max_errors(rc: RawConfig, responses: RequestsMock):
@@ -1019,68 +1038,84 @@ def test_push_state__max_errors(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    conflicting_rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    _id1 = "4d741843-4e94-4890-81d9-5af7c5b5989a"
-    _id2 = "21ef6792-0315-4e86-9c39-b1b8f04b1f53"
+        rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        conflicting_rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        _id1 = "4d741843-4e94-4890-81d9-5af7c5b5989a"
+        _id2 = "21ef6792-0315-4e86-9c39-b1b8f04b1f53"
 
-    table = state.metadata.tables[model.name]
-    conn.execute(
-        table.insert().values(
-            id=_id1,
-            revision=rev,
-            checksum="CREATED",
-            pushed=datetime.datetime.now(),
-            error=False,
+        table = push_state.get_table(model.name)
+        push_state.conn.execute(
+            table.insert().values(
+                id=_id1,
+                revision=rev,
+                checksum="CREATED",
+                pushed=datetime.datetime.now(),
+                error=False,
+            )
         )
-    )
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": _id1,
-                "_revision": conflicting_rev,
-                "name": "Vilnius",
-            },
-            op="patch",
-            saved=True,
-        ),
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_id": _id2,
-                "name": "Vilnius",
-            },
-            op="insert",
-        ),
-    ]
+        rows = [
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_id": _id1,
+                    "_revision": conflicting_rev,
+                    "name": "Vilnius",
+                },
+                op="patch",
+                saved=True,
+            ),
+            PushRow(
+                model,
+                {
+                    "_type": model.name,
+                    "_id": _id2,
+                    "name": "Vilnius",
+                },
+                op="insert",
+            ),
+        ]
 
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(POST, server, status=409, body="Conflicting value")
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(POST, server, status=409, body="Conflicting value")
 
-    error_counter = ErrorCounter(1)
-    push(
-        context, client, server, models, rows, timeout=(5, 300), state=state, chunk_size=1, error_counter=error_counter
-    )
+        error_counter = ErrorCounter(1)
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+            chunk_size=1,
+            error_counter=error_counter,
+        )
 
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [(_id1, rev, True)]
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [(_id1, rev, True)]
 
-    error_counter = ErrorCounter(2)
-    push(
-        context, client, server, models, rows, timeout=(5, 300), state=state, chunk_size=1, error_counter=error_counter
-    )
+        error_counter = ErrorCounter(2)
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+            chunk_size=1,
+            error_counter=error_counter,
+        )
 
-    query = sa.select([table.c.id, table.c.revision, table.c.error])
-    assert list(conn.execute(query)) == [(_id1, rev, True), (_id2, None, True)]
+        query = sa.select([table.c.id, table.c.revision, table.c.error])
+        assert list(push_state.conn.execute(query)) == [(_id1, rev, True), (_id2, None, True)]
 
 
 def test_push_init_state(rc: RawConfig, sqlite: Sqlite):
@@ -1114,23 +1149,25 @@ def test_push_init_state(rc: RawConfig, sqlite: Sqlite):
     pushed = datetime.datetime.now()
     conn.execute(table.insert().values(id=_id, rev=rev, pushed=pushed))
 
-    state = State(*init_push_state(sqlite.dsn, models))
-    conn = state.engine.connect()
-    table = state.metadata.tables[model.name]
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    query = sa.select(
-        [
-            table.c.id,
-            table.c.checksum,
-            table.c.pushed,
-            table.c.revision,
-            table.c.error,
-            table.c.data,
+        table = push_state.get_table(model.name)
+
+        query = sa.select(
+            [
+                table.c.id,
+                table.c.checksum,
+                table.c.pushed,
+                table.c.revision,
+                table.c.error,
+                table.c.data,
+            ]
+        )
+        assert list(conn.execute(query)) == [
+            (_id, rev, pushed, None, None, None),
         ]
-    )
-    assert list(conn.execute(query)) == [
-        (_id, rev, pushed, None, None, None),
-    ]
 
 
 def test_push_state__paginate(rc: RawConfig, responses: RequestsMock):
@@ -1146,67 +1183,67 @@ def test_push_state__paginate(rc: RawConfig, responses: RequestsMock):
     model = commands.get_model(context, manifest, "City")
     models = [model]
 
-    state = State(*init_push_state("sqlite://", models))
-    conn = state.engine.connect()
-    context.set("push.state.conn", conn)
+    with context:
+        context.attach(PUSH_STATE_DB, init_push_state, "sqlite://", models)
+        push_state = context.get(PUSH_STATE_DB)
 
-    rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
-    _id = "4d741843-4e94-4890-81d9-5af7c5b5989a"
+        rev = "f91adeea-3bb8-41b0-8049-ce47c7530bdc"
+        _id = "4d741843-4e94-4890-81d9-5af7c5b5989a"
 
-    table = state.metadata.tables[model.name]
-    page_table = state.metadata.tables["_page"]
+        table = push_state.get_table(model.name)
+        page_table = push_state.get_table(push_state.pagination_table_name)
 
-    rows = [
-        PushRow(
-            model,
-            {
-                "_type": model.name,
-                "_page": [_id],
-                "_id": _id,
-                "name": "Vilnius",
-            },
-            op="insert",
-        ),
-    ]
-    client = requests.Session()
-    server = "https://example.com/"
-    responses.add(
-        POST,
-        server,
-        json={
-            "_data": [
+        rows = [
+            PushRow(
+                model,
                 {
                     "_type": model.name,
-                    "_id": _id,
-                    "_revision": rev,
-                    "name": "Vilnius",
-                }
-            ],
-        },
-        match=[
-            _matcher(
-                {
-                    "_op": "insert",
-                    "_type": model.name,
+                    "_page": [_id],
                     "_id": _id,
                     "name": "Vilnius",
                 },
-            )
-        ],
-    )
+                op="insert",
+            ),
+        ]
+        client = requests.Session()
+        server = "https://example.com/"
+        responses.add(
+            POST,
+            server,
+            json={
+                "_data": [
+                    {
+                        "_type": model.name,
+                        "_id": _id,
+                        "_revision": rev,
+                        "name": "Vilnius",
+                    }
+                ],
+            },
+            match=[
+                _matcher(
+                    {
+                        "_op": "insert",
+                        "_type": model.name,
+                        "_id": _id,
+                        "name": "Vilnius",
+                    },
+                )
+            ],
+        )
 
-    push(
-        context,
-        client,
-        server,
-        models,
-        rows,
-        timeout=(5, 300),
-        state=state,
-    )
+        push(
+            context,
+            client,
+            server,
+            models,
+            rows,
+            timeout=(5, 300),
+            push_state=push_state,
+        )
 
-    query = sa.select([table.c.id, table.c.revision, table.c.error, table.c["page._id"]])
-    assert list(conn.execute(query)) == [(_id, rev, False, _id)]
+        query = sa.select([table.c.id, table.c.revision, table.c.error, table.c["page._id"]])
+        assert list(push_state.conn.execute(query)) == [(_id, rev, False, _id)]
 
-    query = sa.select([page_table.c.model, page_table.c.property, page_table.c.value])
-    assert list(conn.execute(query)) == [(model.name, "_id", '{"_id": "' + _id + '"}')]
+        query = sa.select([page_table.c.model, page_table.c.property, page_table.c.value])
+        assert list(push_state.conn.execute(query)) == [(model.name, "_id", '{"_id": "' + _id + '"}')]

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1118,6 +1118,7 @@ def test_push_state__max_errors(rc: RawConfig, responses: RequestsMock):
         assert list(push_state.conn.execute(query)) == [(_id1, rev, True), (_id2, None, True)]
 
 
+@pytest.skip("Push init state can no longer self heal")
 def test_push_init_state(rc: RawConfig, sqlite: Sqlite):
     context, manifest = load_manifest_and_context(
         rc,

--- a/tests/utils/test_sqlite.py
+++ b/tests/utils/test_sqlite.py
@@ -4,6 +4,12 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
 
+from spinta.exceptions import (
+    SqliteConnectionAlreadyOpen,
+    SqliteConnectionNotOpen,
+    SqliteDatabaseNotConfigured,
+    SqliteTableNotFound,
+)
 from spinta.utils.sqlite import SqliteMigratableDb, migrate_table
 
 
@@ -11,16 +17,44 @@ def test_sqlite_migratable_db_connection_context():
     database = SqliteMigratableDb("sqlite://")
 
     assert not database.is_entered
-    with pytest.raises(RuntimeError, match="Database connection is not open"):
+    with pytest.raises(SqliteConnectionNotOpen):
         database.conn
 
     with database:
         assert database.is_entered
         assert not database.conn.closed
 
+        with pytest.raises(SqliteConnectionAlreadyOpen):
+            with database:
+                pass
+
     assert not database.is_entered
-    with pytest.raises(RuntimeError, match="Database connection is not open"):
+    with pytest.raises(SqliteConnectionNotOpen):
         database.conn
+
+
+def test_sqlite_migratable_db_requires_configuration():
+    database = SqliteMigratableDb()
+
+    with pytest.raises(SqliteDatabaseNotConfigured):
+        database.engine
+
+    with pytest.raises(SqliteDatabaseNotConfigured):
+        database.metadata
+
+
+def test_sqlite_migratable_db_missing_table():
+    database = SqliteMigratableDb("sqlite://")
+
+    with pytest.raises(SqliteTableNotFound):
+        database.get_table("missing", create_missing=False)
+
+
+def test_sqlite_migratable_db_requires_default_table_template():
+    database = SqliteMigratableDb("sqlite://")
+
+    with pytest.raises(NotImplementedError):
+        database.get_table("model")
 
 
 def test_sqlite_migratable_db_tracks_migrations():

--- a/tests/utils/test_sqlite.py
+++ b/tests/utils/test_sqlite.py
@@ -4,7 +4,47 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
 
-from spinta.utils.sqlite import migrate_table
+from spinta.utils.sqlite import SqliteMigratableDb, migrate_table
+
+
+def test_sqlite_migratable_db_connection_context():
+    database = SqliteMigratableDb("sqlite://")
+
+    assert not database.is_entered
+    with pytest.raises(RuntimeError, match="Database connection is not open"):
+        database.conn
+
+    with database:
+        assert database.is_entered
+        assert not database.conn.closed
+
+    assert not database.is_entered
+    with pytest.raises(RuntimeError, match="Database connection is not open"):
+        database.conn
+
+
+def test_sqlite_migratable_db_tracks_migrations():
+    database = SqliteMigratableDb("sqlite://")
+
+    with database:
+        assert not database.contains_migration("initial")
+
+        database.mark_migration("initial")
+        database.mark_migration("initial")
+
+        migration_table = database.get_table(database.migration_table_name)
+        migrations = database.conn.execute(sa.select([migration_table.c.migration])).fetchall()
+
+    assert migrations == [("initial",)]
+
+
+def test_sqlite_migratable_db_uses_custom_migration_table_name():
+    database = SqliteMigratableDb("sqlite://", migration_table_name="schema_versions")
+
+    with database:
+        database.mark_migration("initial")
+
+    assert sa.inspect(database.engine).get_table_names() == ["schema_versions"]
 
 
 @pytest.mark.parametrize("copy", [True, False])


### PR DESCRIPTION
## Summary

- Added `SqliteMigratableDb` to centralize SQLite engine, connection, metadata, table creation, and migration tracking.
- Refactored push state and SQLAlchemy keymap implementations to use the shared migratable database abstraction.
- Added push state upgrade scripts for:
  - initializing migration metadata;
  - renaming the legacy `rev` column to `checksum`.
- Added detection of outdated push state databases and the `PushStateMigrationRequired` error.
- Push state migrations are skipped unless `push_state_path` is explicitly provided.
- Added `--target` and `--tag` options to the `upgrade` command, allowing upgrade scripts to be filtered by their target or category.
- Preserved legacy push state schema migration support for outdated model and pagination tables.
- Reworked table-template handling so existing SQLAlchemy `Table` definitions are reused instead of relying on `extend_existing=True`.

Still need to add CHANGES.rst